### PR TITLE
Add support for aarch64 with simde

### DIFF
--- a/2.0/Makefile
+++ b/2.0/Makefile
@@ -6,9 +6,12 @@
 
 # Does not currently support -DCPU_CHECK_...
 
-BASEFLAGS=-g -DZSTD_MULTITHREAD 
+# Specific setting for X86 cpu 
 # BASEFLAGS=-g -mavx2 -mbmi -mbmi2 -mlzcnt -DZSTD_MULTITHREAD
 # BASEFLAGS=-g -msse4.2 -DZSTD_MULTITHREAD
+
+# General setting for both ARM and x86 cpu
+BASEFLAGS=-g -DZSTD_MULTITHREAD
 
 include Makefile.src
 

--- a/2.0/Makefile
+++ b/2.0/Makefile
@@ -6,9 +6,9 @@
 
 # Does not currently support -DCPU_CHECK_...
 
-BASEFLAGS=-g -mavx2 -mbmi -mbmi2 -mlzcnt -DZSTD_MULTITHREAD
+BASEFLAGS=-g -DZSTD_MULTITHREAD 
+# BASEFLAGS=-g -mavx2 -mbmi -mbmi2 -mlzcnt -DZSTD_MULTITHREAD
 # BASEFLAGS=-g -msse4.2 -DZSTD_MULTITHREAD
-# BASEFLAGS=-g -DZSTD_MULTITHREAD
 
 include Makefile.src
 
@@ -18,14 +18,19 @@ CC		?= gcc
 CXX		?= g++
 CFLAGS		?= -O3
 CXXFLAGS	?= -O2
-ZLIB		?= ../zlib-1.2.11/libz-64.a
+ZLIB		?= -lz
+# ZLIB		?= -L. ../zlib-1.2.11/libz-64.a
+
+# dynamic zstd: remove -DSTATIC_ZSTD above, change this to -lzstd, replace
+# OBJ with OBJ_NO_ZSTD below
+ZSTD		?= -lzstd
 BLASFLAGS64	?= -llapack -lf77blas -latlas
 ARCH32		?=
 
 # Mandatory flags added to defaults or env settings
 CFLAGS		+= -std=gnu99 $(BASEFLAGS) $(CWARN) $(CINCLUDE)
-CXXFLAGS	+= -std=c++14 $(BASEFLAGS) $(CXXWARN)
-LDFLAGS		+= -lm -lpthread -L. $(ZLIB) -lzstd
+CXXFLAGS	+= -std=c++14 $(BASEFLAGS) $(CXXWARN) $(CXXINCLUDE)
+LDFLAGS		+= -lm -lpthread $(ZLIB) ${ZSTD}
 
 # Installation defaults
 MKDIR		?= mkdir
@@ -36,9 +41,12 @@ DESTDIR		?= .
 
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
+  # argh
+  CFLAGS += -I/usr/local/include
+  CXXFLAGS += -I/usr/local/include
   BLASFLAGS=-framework Accelerate
   BLASFLAGS64=-framework Accelerate
-  LDFLAGS=-ldl -lpthread -lz -lzstd
+  LDFLAGS=-ldl -lpthread -lz -lzstd -L/usr/local/lib
 endif
 
 %.o: %.c
@@ -59,7 +67,7 @@ plink2: $(OBJ_NO_ZSTD)
 # basic pgenlib usage example; also needed for tests
 pgen_compress: $(PGCOBJ)
 	$(MKDIR) -p bin
-	$(CXX) $(PGCOBJ) \
+	$(CXX) ${CXXINCLUDE} $(PGCOBJ) \
 		-o bin/pgen_compress
 
 .PHONY: install-strip install clean

--- a/2.0/Makefile.src
+++ b/2.0/Makefile.src
@@ -5,7 +5,7 @@ CXXWARN = ${CWARN} -Wold-style-cast
 CWARN2 = -Wall -Wextra -Wshadow -Wformat-security
 CXXWARN2 = ${CWARN2} -Wold-style-cast
 
-CSRC = SFMT.c libdeflate/lib/adler32.c libdeflate/lib/aligned_malloc.c libdeflate/lib/crc32.c libdeflate/lib/deflate_compress.c libdeflate/lib/deflate_decompress.c libdeflate/lib/gzip_compress.c libdeflate/lib/gzip_decompress.c libdeflate/lib/zlib_compress.c libdeflate/lib/zlib_decompress.c libdeflate/lib/x86/cpu_features.c
+CSRC = SFMT.c libdeflate/lib/adler32.c libdeflate/lib/aligned_malloc.c libdeflate/lib/crc32.c libdeflate/lib/deflate_compress.c libdeflate/lib/deflate_decompress.c libdeflate/lib/gzip_compress.c libdeflate/lib/gzip_decompress.c libdeflate/lib/zlib_compress.c libdeflate/lib/zlib_decompress.c libdeflate/lib/arm/arm_cpu_features.c  libdeflate/lib/x86/x86_cpu_features.c
 
 ZCSRC = zstd/lib/common/debug.c zstd/lib/common/entropy_common.c zstd/lib/common/zstd_common.c zstd/lib/common/error_private.c zstd/lib/common/xxhash.c zstd/lib/common/fse_decompress.c zstd/lib/common/pool.c zstd/lib/common/threading.c zstd/lib/compress/fse_compress.c zstd/lib/compress/hist.c zstd/lib/compress/huf_compress.c zstd/lib/compress/zstd_double_fast.c zstd/lib/compress/zstd_fast.c zstd/lib/compress/zstd_lazy.c zstd/lib/compress/zstd_ldm.c zstd/lib/compress/zstd_opt.c zstd/lib/compress/zstd_compress.c zstd/lib/compress/zstd_compress_literals.c zstd/lib/compress/zstd_compress_sequences.c zstd/lib/compress/zstdmt_compress.c zstd/lib/decompress/huf_decompress.c zstd/lib/decompress/zstd_decompress.c zstd/lib/decompress/zstd_ddict.c zstd/lib/decompress/zstd_decompress_block.c
 
@@ -21,8 +21,10 @@ OBJ2 = $(notdir $(OBJ))
 
 OBJ3 = $(CSRC2:.c=.o) $(ZCSRC2:.c=.o) $(CCSRC2:.cc=.o)
 
-CINCLUDE = -Ilibdeflate -Ilibdeflate/common
-CINCLUDE2 = -I../libdeflate -I../libdeflate/common
+CINCLUDE = -Ilibdeflate -Ilibdeflate/common -Isimde
+CINCLUDE2 = -I../libdeflate -I../libdeflate/common -I../simde
+CXXINCLUDE = -Isimde
+CXXINCLUDE2 = -I../simde
 ZSTD_INCLUDE = -Izstd/lib -Izstd/lib/common
 ZSTD_INCLUDE2 = -I../zstd/lib -I../zstd/lib/common
 
@@ -30,5 +32,5 @@ PGCSRC = plink2_base.cc pgenlib_misc.cc pgenlib_read.cc pgenlib_write.cc pgen_co
 PGCOBJ = $(PGCSRC:.c=.o)
 PGCSRC2 = $(foreach fname,$(PGCSRC),../$(fname))
 
-CLEAN = *.o libdeflate/lib/*.o libdeflate/lib/x86/*.o zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o bin/plink2 bin/pgen_compress
+CLEAN = *.o libdeflate/lib/*.o libdeflate/lib/arm/*.o libdeflate/lib/x86/*.o zstd/lib/common/*.o zstd/lib/compress/*.o zstd/lib/decompress/*.o bin/plink2 bin/pgen_compress
 CLEAN3 = $(foreach expr,$(CLEAN),../$(expr))

--- a/2.0/SFMT.h
+++ b/2.0/SFMT.h
@@ -129,7 +129,12 @@ extern "C" {
   128-bit SIMD like data type for standard C
   ------------------------------------------*/
 #ifdef __LP64__
-  #include <emmintrin.h>
+ #ifdef __x86_64__
+    #include <emmintrin.h>
+  #else
+    #define SIMDE_ENABLE_NATIVE_ALIASES
+    #include "x86/sse2.h"
+  #endif
 
 /** 128-bit data structure */
 union W128_T {

--- a/2.0/libdeflate/lib/arm/adler32_impl.h
+++ b/2.0/libdeflate/lib/arm/adler32_impl.h
@@ -1,0 +1,120 @@
+/*
+ * arm/adler32_impl.h - ARM implementations of Adler-32 checksum algorithm
+ *
+ * Copyright 2016 Eric Biggers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "cpu_features.h"
+
+/* NEON implementation */
+#undef DISPATCH_NEON
+#if !defined(DEFAULT_IMPL) &&	\
+	(defined(__ARM_NEON) || (ARM_CPU_FEATURES_ENABLED &&	\
+				 COMPILER_SUPPORTS_NEON_TARGET_INTRINSICS))
+#  define FUNCNAME		adler32_neon
+#  define FUNCNAME_CHUNK	adler32_neon_chunk
+#  define IMPL_ALIGNMENT	16
+#  define IMPL_SEGMENT_SIZE	32
+/* Prevent unsigned overflow of the 16-bit precision byte counters */
+#  define IMPL_MAX_CHUNK_SIZE	(32 * (0xFFFF / 0xFF))
+#  ifdef __ARM_NEON
+#    define ATTRIBUTES
+#    define DEFAULT_IMPL	adler32_neon
+#  else
+#    ifdef __arm__
+#      define ATTRIBUTES	__attribute__((target("fpu=neon")))
+#    else
+#      define ATTRIBUTES	__attribute__((target("+simd")))
+#    endif
+#    define DISPATCH		1
+#    define DISPATCH_NEON	1
+#  endif
+#  include <arm_neon.h>
+static forceinline ATTRIBUTES void
+adler32_neon_chunk(const uint8x16_t *p, const uint8x16_t * const end,
+		   u32 *s1, u32 *s2)
+{
+	uint32x4_t v_s1 = (uint32x4_t) { 0, 0, 0, 0 };
+	uint32x4_t v_s2 = (uint32x4_t) { 0, 0, 0, 0 };
+	uint16x8_t v_byte_sums_a = (uint16x8_t) { 0, 0, 0, 0, 0, 0, 0, 0 };
+	uint16x8_t v_byte_sums_b = (uint16x8_t) { 0, 0, 0, 0, 0, 0, 0, 0 };
+	uint16x8_t v_byte_sums_c = (uint16x8_t) { 0, 0, 0, 0, 0, 0, 0, 0 };
+	uint16x8_t v_byte_sums_d = (uint16x8_t) { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+	do {
+		const uint8x16_t bytes1 = *p++;
+		const uint8x16_t bytes2 = *p++;
+		uint16x8_t tmp;
+
+		v_s2 += v_s1;
+
+		/* Vector Pairwise Add Long (u8 => u16) */
+		tmp = vpaddlq_u8(bytes1);
+
+		/* Vector Pairwise Add and Accumulate Long (u8 => u16) */
+		tmp = vpadalq_u8(tmp, bytes2);
+
+		/* Vector Pairwise Add and Accumulate Long (u16 => u32) */
+		v_s1 = vpadalq_u16(v_s1, tmp);
+
+		/* Vector Add Wide (u8 => u16) */
+		v_byte_sums_a = vaddw_u8(v_byte_sums_a, vget_low_u8(bytes1));
+		v_byte_sums_b = vaddw_u8(v_byte_sums_b, vget_high_u8(bytes1));
+		v_byte_sums_c = vaddw_u8(v_byte_sums_c, vget_low_u8(bytes2));
+		v_byte_sums_d = vaddw_u8(v_byte_sums_d, vget_high_u8(bytes2));
+
+	} while (p != end);
+
+	/* Vector Shift Left (u32) */
+	v_s2 = vqshlq_n_u32(v_s2, 5);
+
+	/* Vector Multiply Accumulate Long (u16 => u32) */
+	v_s2 = vmlal_u16(v_s2, vget_low_u16(v_byte_sums_a),  (uint16x4_t) { 32, 31, 30, 29 });
+	v_s2 = vmlal_u16(v_s2, vget_high_u16(v_byte_sums_a), (uint16x4_t) { 28, 27, 26, 25 });
+	v_s2 = vmlal_u16(v_s2, vget_low_u16(v_byte_sums_b),  (uint16x4_t) { 24, 23, 22, 21 });
+	v_s2 = vmlal_u16(v_s2, vget_high_u16(v_byte_sums_b), (uint16x4_t) { 20, 19, 18, 17 });
+	v_s2 = vmlal_u16(v_s2, vget_low_u16(v_byte_sums_c),  (uint16x4_t) { 16, 15, 14, 13 });
+	v_s2 = vmlal_u16(v_s2, vget_high_u16(v_byte_sums_c), (uint16x4_t) { 12, 11, 10,  9 });
+	v_s2 = vmlal_u16(v_s2, vget_low_u16 (v_byte_sums_d), (uint16x4_t) {  8,  7,  6,  5 });
+	v_s2 = vmlal_u16(v_s2, vget_high_u16(v_byte_sums_d), (uint16x4_t) {  4,  3,  2,  1 });
+
+	*s1 += v_s1[0] + v_s1[1] + v_s1[2] + v_s1[3];
+	*s2 += v_s2[0] + v_s2[1] + v_s2[2] + v_s2[3];
+}
+#  include "../adler32_vec_template.h"
+#endif /* NEON implementation */
+
+#ifdef DISPATCH
+static inline adler32_func_t
+arch_select_adler32_func(void)
+{
+	u32 features = get_cpu_features();
+
+#ifdef DISPATCH_NEON
+	if (features & ARM_CPU_FEATURE_NEON)
+		return adler32_neon;
+#endif
+	return NULL;
+}
+#endif /* DISPATCH */

--- a/2.0/libdeflate/lib/arm/arm_cpu_features.c
+++ b/2.0/libdeflate/lib/arm/arm_cpu_features.c
@@ -1,0 +1,119 @@
+/*
+ * arm/cpu_features.c - feature detection for ARM processors
+ *
+ * Copyright 2018 Eric Biggers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * ARM processors don't have a standard way for unprivileged programs to detect
+ * processor features.  But, on Linux we can read the AT_HWCAP and AT_HWCAP2
+ * values from /proc/self/auxv.
+ *
+ * Ideally we'd use the C library function getauxval(), but it's not guaranteed
+ * to be available: it was only added to glibc in 2.16, and in Android it was
+ * added to API level 18 for ARM and level 21 for AArch64.
+ */
+
+#include "cpu_features.h"
+
+#if ARM_CPU_FEATURES_ENABLED
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#define AT_HWCAP	16
+#define AT_HWCAP2	26
+
+volatile u32 _cpu_features = 0;
+
+static void scan_auxv(unsigned long *hwcap, unsigned long *hwcap2)
+{
+	int fd;
+	unsigned long auxbuf[32];
+	int filled = 0;
+	int i;
+
+	fd = open("/proc/self/auxv", O_RDONLY);
+	if (fd < 0)
+		return;
+
+	for (;;) {
+		do {
+			int ret = read(fd, &((char *)auxbuf)[filled],
+				       sizeof(auxbuf) - filled);
+			if (ret <= 0) {
+				if (ret < 0 && errno == EINTR)
+					continue;
+				goto out;
+			}
+			filled += ret;
+		} while ((unsigned int)filled < 2 * sizeof(long));
+
+		i = 0;
+		do {
+			unsigned long type = auxbuf[i];
+			unsigned long value = auxbuf[i + 1];
+
+			if (type == AT_HWCAP)
+				*hwcap = value;
+			else if (type == AT_HWCAP2)
+				*hwcap2 = value;
+			i += 2;
+			filled -= 2 * sizeof(long);
+		} while ((unsigned int)filled >= 2 * sizeof(long));
+
+		memmove(auxbuf, &auxbuf[i], filled);
+	}
+out:
+	close(fd);
+}
+
+void setup_cpu_features(void)
+{
+	u32 features = 0;
+	unsigned long hwcap = 0;
+	unsigned long hwcap2 = 0;
+
+	scan_auxv(&hwcap, &hwcap2);
+
+#ifdef __arm__
+	STATIC_ASSERT(sizeof(long) == 4);
+	if (hwcap & (1 << 12))	/* HWCAP_NEON */
+		features |= ARM_CPU_FEATURE_NEON;
+	if (hwcap2 & (1 << 1))	/* HWCAP2_PMULL */
+		features |= ARM_CPU_FEATURE_PMULL;
+#else
+	STATIC_ASSERT(sizeof(long) == 8);
+	if (hwcap & (1 << 1))	/* HWCAP_ASIMD */
+		features |= ARM_CPU_FEATURE_NEON;
+	if (hwcap & (1 << 4))	/* HWCAP_PMULL */
+		features |= ARM_CPU_FEATURE_PMULL;
+#endif
+
+	_cpu_features = features | ARM_CPU_FEATURES_KNOWN;
+}
+
+#endif /* ARM_CPU_FEATURES_ENABLED */

--- a/2.0/libdeflate/lib/arm/cpu_features.h
+++ b/2.0/libdeflate/lib/arm/cpu_features.h
@@ -1,0 +1,39 @@
+/*
+ * arm/cpu_features.h - feature detection for ARM processors
+ */
+
+#ifndef LIB_ARM_CPU_FEATURES_H
+#define LIB_ARM_CPU_FEATURES_H
+
+#include "../lib_common.h"
+
+#if (defined(__arm__) || defined(__aarch64__)) && \
+	defined(__linux__) && \
+	COMPILER_SUPPORTS_TARGET_FUNCTION_ATTRIBUTE && \
+	!defined(FREESTANDING)
+#  define ARM_CPU_FEATURES_ENABLED 1
+#else
+#  define ARM_CPU_FEATURES_ENABLED 0
+#endif
+
+#if ARM_CPU_FEATURES_ENABLED
+
+#define ARM_CPU_FEATURE_NEON		0x00000001
+#define ARM_CPU_FEATURE_PMULL		0x00000002
+
+#define ARM_CPU_FEATURES_KNOWN		0x80000000
+
+extern volatile u32 _cpu_features;
+
+void setup_cpu_features(void);
+
+static inline u32 get_cpu_features(void)
+{
+	if (_cpu_features == 0)
+		setup_cpu_features();
+	return _cpu_features;
+}
+
+#endif /* ARM_CPU_FEATURES_ENABLED */
+
+#endif /* LIB_ARM_CPU_FEATURES_H */

--- a/2.0/libdeflate/lib/arm/crc32_impl.h
+++ b/2.0/libdeflate/lib/arm/crc32_impl.h
@@ -1,0 +1,166 @@
+/*
+ * arm/crc32_impl.h
+ *
+ * Copyright 2017 Jun He <jun.he@linaro.org>
+ * Copyright 2018 Eric Biggers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "cpu_features.h"
+
+/*
+ * CRC-32 folding with ARM Crypto extension-PMULL
+ *
+ * This works the same way as the x86 PCLMUL version.
+ * See x86/crc32_pclmul_template.h for an explanation.
+ */
+#undef DISPATCH_PMULL
+#if (defined(__ARM_FEATURE_CRYPTO) ||	\
+     (ARM_CPU_FEATURES_ENABLED &&	\
+      COMPILER_SUPPORTS_PMULL_TARGET_INTRINSICS)) && \
+      /* not yet tested on big endian, probably needs changes to work there */ \
+    (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && \
+      /* clang as of v5.0.1 doesn't allow pmull intrinsics in 32-bit mode, even
+       * when compiling with -mfpu=crypto-neon-fp-armv8 */ \
+    !(defined(__clang__) && defined(__arm__))
+#  define FUNCNAME		crc32_pmull
+#  define FUNCNAME_ALIGNED	crc32_pmull_aligned
+#  ifdef __ARM_FEATURE_CRYPTO
+#    define ATTRIBUTES
+#    define DEFAULT_IMPL	crc32_pmull
+#  else
+#    ifdef __arm__
+#      define ATTRIBUTES	__attribute__((target("fpu=crypto-neon-fp-armv8")))
+#    else
+#      ifdef __clang__
+#        define ATTRIBUTES	__attribute__((target("crypto")))
+#      else
+#        define ATTRIBUTES	__attribute__((target("+crypto")))
+#      endif
+#    endif
+#    define DISPATCH		1
+#    define DISPATCH_PMULL	1
+#  endif
+
+#include <arm_neon.h>
+
+static forceinline ATTRIBUTES uint8x16_t
+clmul_00(uint8x16_t a, uint8x16_t b)
+{
+	return (uint8x16_t)vmull_p64((poly64_t)vget_low_u8(a),
+				     (poly64_t)vget_low_u8(b));
+}
+
+static forceinline ATTRIBUTES uint8x16_t
+clmul_10(uint8x16_t a, uint8x16_t b)
+{
+	return (uint8x16_t)vmull_p64((poly64_t)vget_low_u8(a),
+				     (poly64_t)vget_high_u8(b));
+}
+
+static forceinline ATTRIBUTES uint8x16_t
+clmul_11(uint8x16_t a, uint8x16_t b)
+{
+	return (uint8x16_t)vmull_high_p64((poly64x2_t)a, (poly64x2_t)b);
+}
+
+static forceinline ATTRIBUTES uint8x16_t
+fold_128b(uint8x16_t dst, uint8x16_t src, uint8x16_t multipliers)
+{
+	return dst ^ clmul_00(src, multipliers) ^ clmul_11(src, multipliers);
+}
+
+static forceinline ATTRIBUTES u32
+crc32_pmull_aligned(u32 remainder, const uint8x16_t *p, size_t nr_segs)
+{
+	/* Constants precomputed by gen_crc32_multipliers.c.  Do not edit! */
+	const uint8x16_t multipliers_4 =
+		(uint8x16_t)(uint64x2_t){ 0x8F352D95, 0x1D9513D7 };
+	const uint8x16_t multipliers_1 =
+		(uint8x16_t)(uint64x2_t){ 0xAE689191, 0xCCAA009E };
+	const uint8x16_t final_multiplier =
+		(uint8x16_t)(uint64x2_t){ 0xB8BC6765 };
+	const uint8x16_t mask32 = (uint8x16_t)(uint32x4_t){ 0xFFFFFFFF };
+	const uint8x16_t barrett_reduction_constants =
+			(uint8x16_t)(uint64x2_t){ 0x00000001F7011641,
+						  0x00000001DB710641 };
+	const uint8x16_t zeroes = (uint8x16_t){ 0 };
+
+	const uint8x16_t * const end = p + nr_segs;
+	const uint8x16_t * const end512 = p + (nr_segs & ~3);
+	uint8x16_t x0, x1, x2, x3;
+
+	x0 = *p++ ^ (uint8x16_t)(uint32x4_t){ remainder };
+	if (nr_segs >= 4) {
+		x1 = *p++;
+		x2 = *p++;
+		x3 = *p++;
+
+		/* Fold 512 bits at a time */
+		while (p != end512) {
+			x0 = fold_128b(*p++, x0, multipliers_4);
+			x1 = fold_128b(*p++, x1, multipliers_4);
+			x2 = fold_128b(*p++, x2, multipliers_4);
+			x3 = fold_128b(*p++, x3, multipliers_4);
+		}
+
+		/* Fold 512 bits => 128 bits */
+		x1 = fold_128b(x1, x0, multipliers_1);
+		x2 = fold_128b(x2, x1, multipliers_1);
+		x0 = fold_128b(x3, x2, multipliers_1);
+	}
+
+	/* Fold 128 bits at a time */
+	while (p != end)
+		x0 = fold_128b(*p++, x0, multipliers_1);
+
+	/* Fold 128 => 96 bits, implicitly appending 32 zeroes */
+	x0 = vextq_u8(x0, zeroes, 8) ^ clmul_10(x0, multipliers_1);
+
+	/* Fold 96 => 64 bits */
+	x0 = vextq_u8(x0, zeroes, 4) ^ clmul_00(x0 & mask32, final_multiplier);
+
+	/* Reduce 64 => 32 bits using Barrett reduction */
+	x1 = x0;
+	x0 = clmul_00(x0 & mask32, barrett_reduction_constants);
+	x0 = clmul_10(x0 & mask32, barrett_reduction_constants);
+	return vgetq_lane_u32((uint32x4_t)(x0 ^ x1), 1);
+}
+#define IMPL_ALIGNMENT		16
+#define IMPL_SEGMENT_SIZE	16
+#include "../crc32_vec_template.h"
+#endif /* PMULL implementation */
+
+#ifdef DISPATCH
+static inline crc32_func_t
+arch_select_crc32_func(void)
+{
+	u32 features = get_cpu_features();
+
+#ifdef DISPATCH_PMULL
+	if (features & ARM_CPU_FEATURE_PMULL)
+		return crc32_pmull;
+#endif
+	return NULL;
+}
+#endif /* DISPATCH */

--- a/2.0/libdeflate/lib/arm/matchfinder_impl.h
+++ b/2.0/libdeflate/lib/arm/matchfinder_impl.h
@@ -1,0 +1,93 @@
+/*
+ * arm/matchfinder_impl.h - ARM implementations of matchfinder functions
+ *
+ * Copyright 2016 Eric Biggers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifdef __ARM_NEON
+#  if MATCHFINDER_ALIGNMENT < 16
+#    undef MATCHFINDER_ALIGNMENT
+#    define MATCHFINDER_ALIGNMENT 16
+#  endif
+#  include <arm_neon.h>
+static forceinline bool
+matchfinder_init_neon(mf_pos_t *data, size_t size)
+{
+	int16x8_t v, *p;
+	size_t n;
+
+	if (size % (sizeof(int16x8_t) * 4) != 0)
+		return false;
+
+	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
+	v = (int16x8_t) {
+		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
+		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
+		MATCHFINDER_INITVAL, MATCHFINDER_INITVAL,
+	};
+	p = (int16x8_t *)data;
+	n = size / (sizeof(int16x8_t) * 4);
+	do {
+		p[0] = v;
+		p[1] = v;
+		p[2] = v;
+		p[3] = v;
+		p += 4;
+	} while (--n);
+	return true;
+}
+#undef arch_matchfinder_init
+#define arch_matchfinder_init matchfinder_init_neon
+
+static forceinline bool
+matchfinder_rebase_neon(mf_pos_t *data, size_t size)
+{
+	int16x8_t v, *p;
+	size_t n;
+
+	if (size % (sizeof(int16x8_t) * 4) != 0)
+		return false;
+
+	STATIC_ASSERT(sizeof(mf_pos_t) == 2);
+	v = (int16x8_t) {
+		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
+		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
+		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
+		(u16)-MATCHFINDER_WINDOW_SIZE, (u16)-MATCHFINDER_WINDOW_SIZE,
+	};
+	p = (int16x8_t *)data;
+	n = size / (sizeof(int16x8_t) * 4);
+	do {
+		p[0] = vqaddq_s16(p[0], v);
+		p[1] = vqaddq_s16(p[1], v);
+		p[2] = vqaddq_s16(p[2], v);
+		p[3] = vqaddq_s16(p[3], v);
+		p += 4;
+	} while (--n);
+	return true;
+}
+#undef arch_matchfinder_rebase
+#define arch_matchfinder_rebase matchfinder_rebase_neon
+
+#endif /* __ARM_NEON */

--- a/2.0/libdeflate/lib/x86/x86_cpu_features.c
+++ b/2.0/libdeflate/lib/x86/x86_cpu_features.c
@@ -1,0 +1,139 @@
+/*
+ * x86/cpu_features.c - feature detection for x86 processors
+ *
+ * Copyright 2016 Eric Biggers
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "cpu_features.h"
+
+#if X86_CPU_FEATURES_ENABLED
+
+volatile u32 _cpu_features = 0;
+
+/* With old GCC versions we have to manually save and restore the x86_32 PIC
+ * register (ebx).  See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47602  */
+#if defined(__i386__) && defined(__PIC__)
+#  define EBX_CONSTRAINT "=r"
+#else
+#  define EBX_CONSTRAINT "=b"
+#endif
+
+/* Execute the CPUID instruction.  */
+static inline void
+cpuid(u32 leaf, u32 subleaf, u32 *a, u32 *b, u32 *c, u32 *d)
+{
+	__asm__(".ifnc %%ebx, %1; mov  %%ebx, %1; .endif\n"
+		"cpuid                                  \n"
+		".ifnc %%ebx, %1; xchg %%ebx, %1; .endif\n"
+		: "=a" (*a), EBX_CONSTRAINT (*b), "=c" (*c), "=d" (*d)
+		: "a" (leaf), "c" (subleaf));
+}
+
+/* Read an extended control register.  */
+static inline u64
+read_xcr(u32 index)
+{
+	u32 edx, eax;
+
+	/* Execute the "xgetbv" instruction.  Old versions of binutils do not
+	 * recognize this instruction, so list the raw bytes instead.  */
+	__asm__ (".byte 0x0f, 0x01, 0xd0" : "=d" (edx), "=a" (eax) : "c" (index));
+
+	return ((u64)edx << 32) | eax;
+}
+
+#undef BIT
+#define BIT(nr)			(1UL << (nr))
+
+#define XCR0_BIT_SSE		BIT(1)
+#define XCR0_BIT_AVX		BIT(2)
+#define XCR0_BIT_OPMASK		BIT(5)
+#define XCR0_BIT_ZMM_HI256	BIT(6)
+#define XCR0_BIT_HI16_ZMM	BIT(7)
+
+#define IS_SET(reg, nr)		((reg) & BIT(nr))
+#define IS_ALL_SET(reg, mask)	(((reg) & (mask)) == (mask))
+
+/* Initialize _cpu_features with bits for interesting processor features. */
+void setup_cpu_features(void)
+{
+	u32 features = 0;
+	u32 dummy1, dummy2, dummy3, dummy4;
+	u32 max_function;
+	u32 features_1, features_2, features_3, features_4;
+	bool os_avx_support = false;
+	bool os_avx512_support = false;
+
+	/* Get maximum supported function  */
+	cpuid(0, 0, &max_function, &dummy2, &dummy3, &dummy4);
+	if (max_function < 1)
+		goto out;
+
+	/* Standard feature flags  */
+	cpuid(1, 0, &dummy1, &dummy2, &features_2, &features_1);
+
+	if (IS_SET(features_1, 26))
+		features |= X86_CPU_FEATURE_SSE2;
+
+	if (IS_SET(features_2, 1))
+		features |= X86_CPU_FEATURE_PCLMULQDQ;
+
+	if (IS_SET(features_2, 27)) { /* OSXSAVE set? */
+		u64 xcr0 = read_xcr(0);
+
+		os_avx_support = IS_ALL_SET(xcr0,
+					    XCR0_BIT_SSE |
+					    XCR0_BIT_AVX);
+
+		os_avx512_support = IS_ALL_SET(xcr0,
+					       XCR0_BIT_SSE |
+					       XCR0_BIT_AVX |
+					       XCR0_BIT_OPMASK |
+					       XCR0_BIT_ZMM_HI256 |
+					       XCR0_BIT_HI16_ZMM);
+	}
+
+	if (os_avx_support && IS_SET(features_2, 28))
+		features |= X86_CPU_FEATURE_AVX;
+
+	if (max_function < 7)
+		goto out;
+
+	/* Extended feature flags  */
+	cpuid(7, 0, &dummy1, &features_3, &features_4, &dummy4);
+
+	if (os_avx_support && IS_SET(features_3, 5))
+		features |= X86_CPU_FEATURE_AVX2;
+
+	if (IS_SET(features_3, 8))
+		features |= X86_CPU_FEATURE_BMI2;
+
+	if (os_avx512_support && IS_SET(features_3, 30))
+		features |= X86_CPU_FEATURE_AVX512BW;
+
+out:
+	_cpu_features = features | X86_CPU_FEATURES_KNOWN;
+}
+
+#endif /* X86_CPU_FEATURES_ENABLED */

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3031,7 +3031,7 @@ int main(int argc, char** argv) {
 #ifdef __APPLE__
   fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
 #else
-#  ifdef __LP64__
+#  if defined __LP64__ && defined __x86_64__
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 #  endif
 #endif

--- a/2.0/plink2_base.h
+++ b/2.0/plink2_base.h
@@ -128,12 +128,12 @@
 #endif
 
 #ifdef __LP64__
-#  ifndef __SSE2__
-    // todo: remove this requirement, the 32-bit VecW-using code does most of
-    // what we need
-#    error "64-bit builds currently require SSE2.  Try producing a 32-bit build instead."
+#  ifdef __x86_64__
+#    include <emmintrin.h>
+#  else
+#    define SIMDE_ENABLE_NATIVE_ALIASES
+#    include "x86/sse2.h"
 #  endif
-#  include <emmintrin.h>
 #  ifdef __SSE4_2__
 #    define USE_SSE42
 #    include <smmintrin.h>

--- a/2.0/simde/arm/neon.h
+++ b/2.0/simde/arm/neon.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_H)
+#define SIMDE_ARM_NEON_H
+
+#include "neon/types.h"
+
+#include "neon/abd.h"
+#include "neon/abs.h"
+#include "neon/add.h"
+#include "neon/addl.h"
+#include "neon/addl_high.h"
+#include "neon/addw.h"
+#include "neon/and.h"
+#include "neon/bsl.h"
+#include "neon/cagt.h"
+#include "neon/ceq.h"
+#include "neon/ceqz.h"
+#include "neon/cge.h"
+#include "neon/cgez.h"
+#include "neon/cgt.h"
+#include "neon/cgtz.h"
+#include "neon/cle.h"
+#include "neon/clez.h"
+#include "neon/clt.h"
+#include "neon/cltz.h"
+#include "neon/cvt.h"
+#include "neon/combine.h"
+#include "neon/create.h"
+#include "neon/dot.h"
+#include "neon/dot_lane.h"
+#include "neon/dup_n.h"
+#include "neon/eor.h"
+#include "neon/ext.h"
+#include "neon/get_high.h"
+#include "neon/get_lane.h"
+#include "neon/get_low.h"
+#include "neon/ld1.h"
+#include "neon/ld3.h"
+#include "neon/ld4.h"
+#include "neon/max.h"
+#include "neon/min.h"
+#include "neon/mla.h"
+#include "neon/mla_n.h"
+#include "neon/mlal.h"
+#include "neon/mlal_high.h"
+#include "neon/movl.h"
+#include "neon/movl_high.h"
+#include "neon/movn.h"
+#include "neon/mul.h"
+#include "neon/mul_n.h"
+#include "neon/mull.h"
+#include "neon/mull_n.h"
+#include "neon/mvn.h"
+#include "neon/neg.h"
+#include "neon/orr.h"
+#include "neon/padal.h"
+#include "neon/padd.h"
+#include "neon/paddl.h"
+#include "neon/pmax.h"
+#include "neon/pmin.h"
+#include "neon/qadd.h"
+#include "neon/qdmulh.h"
+#include "neon/qdmull.h"
+#include "neon/qrdmulh.h"
+#include "neon/qrdmulh_n.h"
+#include "neon/qmovn.h"
+#include "neon/qmovun.h"
+#include "neon/qmovn_high.h"
+#include "neon/qtbl.h"
+#include "neon/qtbx.h"
+#include "neon/rbit.h"
+#include "neon/reinterpret.h"
+#include "neon/rev16.h"
+#include "neon/rev32.h"
+#include "neon/rev64.h"
+#include "neon/rhadd.h"
+#include "neon/rshl.h"
+#include "neon/rshr_n.h"
+#include "neon/rsra_n.h"
+#include "neon/set_lane.h"
+#include "neon/shl.h"
+#include "neon/shl_n.h"
+#include "neon/shr_n.h"
+#include "neon/sra_n.h"
+#include "neon/st1.h"
+#include "neon/st1_lane.h"
+#include "neon/st3.h"
+#include "neon/st4.h"
+#include "neon/sub.h"
+#include "neon/subl.h"
+#include "neon/tbl.h"
+#include "neon/tbx.h"
+#include "neon/trn.h"
+#include "neon/trn1.h"
+#include "neon/trn2.h"
+#include "neon/tst.h"
+#include "neon/uzp.h"
+#include "neon/uzp1.h"
+#include "neon/uzp2.h"
+#include "neon/zip.h"
+#include "neon/zip1.h"
+#include "neon/zip2.h"
+
+#endif /* SIMDE_ARM_NEON_H */

--- a/2.0/simde/arm/neon/abd.h
+++ b/2.0/simde/arm/neon/abd.h
@@ -1,0 +1,354 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ABD_H)
+#define SIMDE_ARM_NEON_ABD_H
+
+#include "abs.h"
+#include "subl.h"
+#include "movn.h"
+#include "movl.h"
+#include "reinterpret.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vabd_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_f32(a, b);
+  #else
+    return simde_vabs_f32(simde_vsub_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_f32
+  #define vabd_f32(a, b) simde_vabd_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vabd_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabd_f64(a, b);
+  #else
+    return simde_vabs_f64(simde_vsub_f64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vabd_f64
+  #define vabd_f64(a, b) simde_vabd_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vabd_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_s8(a, b);
+  #else
+    return simde_vmovn_s16(simde_vabsq_s16(simde_vsubl_s8(a, b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_s8
+  #define vabd_s8(a, b) simde_vabd_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vabd_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_s16(a, b);
+  #else
+    return simde_vmovn_s32(simde_vabsq_s32(simde_vsubl_s16(a, b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_s16
+  #define vabd_s16(a, b) simde_vabd_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vabd_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_s32(a, b);
+  #else
+    return simde_vmovn_s64(simde_vabsq_s64(simde_vsubl_s32(a, b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_s32
+  #define vabd_s32(a, b) simde_vabd_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vabd_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_u8(a, b);
+  #else
+    return simde_vmovn_u16(
+      simde_vreinterpretq_u16_s16(
+        simde_vabsq_s16(
+          simde_vsubq_s16(
+            simde_vreinterpretq_s16_u16(simde_vmovl_u8(a)),
+            simde_vreinterpretq_s16_u16(simde_vmovl_u8(b))))));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_u8
+  #define vabd_u8(a, b) simde_vabd_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vabd_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_u16(a, b);
+  #else
+    return simde_vmovn_u32(
+      simde_vreinterpretq_u32_s32(
+        simde_vabsq_s32(
+          simde_vsubq_s32(
+            simde_vreinterpretq_s32_u32(simde_vmovl_u16(a)),
+            simde_vreinterpretq_s32_u32(simde_vmovl_u16(b))))));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_u16
+  #define vabd_u16(a, b) simde_vabd_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vabd_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabd_u32(a, b);
+  #else
+    return simde_vmovn_u64(
+      simde_vreinterpretq_u64_s64(
+        simde_vabsq_s64(
+          simde_vsubq_s64(
+            simde_vreinterpretq_s64_u64(simde_vmovl_u32(a)),
+            simde_vreinterpretq_s64_u64(simde_vmovl_u32(b))))));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabd_u32
+  #define vabd_u32(a, b) simde_vabd_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vabdq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_f32(a, b);
+  #else
+    return simde_vabsq_f32(simde_vsubq_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_f32
+  #define vabdq_f32(a, b) simde_vabdq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vabdq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabdq_f64(a, b);
+  #else
+    return simde_vabsq_f64(simde_vsubq_f64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_f64
+  #define vabdq_f64(a, b) simde_vabdq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vabdq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int16_t tmp = HEDLEY_STATIC_CAST(int16_t, a_.values[i]) - HEDLEY_STATIC_CAST(int16_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_s8
+  #define vabdq_s8(a, b) simde_vabdq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vabdq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int32_t tmp = HEDLEY_STATIC_CAST(int32_t, a_.values[i]) - HEDLEY_STATIC_CAST(int32_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_s16
+  #define vabdq_s16(a, b) simde_vabdq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vabdq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int64_t tmp = HEDLEY_STATIC_CAST(int64_t, a_.values[i]) - HEDLEY_STATIC_CAST(int64_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int32_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_s32
+  #define vabdq_s32(a, b) simde_vabdq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vabdq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_u8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+    return vec_absd(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int16_t tmp = HEDLEY_STATIC_CAST(int16_t, a_.values[i]) - HEDLEY_STATIC_CAST(int16_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_u8
+  #define vabdq_u8(a, b) simde_vabdq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vabdq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_u16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+    return vec_absd(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int32_t tmp = HEDLEY_STATIC_CAST(int32_t, a_.values[i]) - HEDLEY_STATIC_CAST(int32_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_u16
+  #define vabdq_u16(a, b) simde_vabdq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vabdq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabdq_u32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+    return vec_absd(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      int64_t tmp = HEDLEY_STATIC_CAST(int64_t, a_.values[i]) - HEDLEY_STATIC_CAST(int64_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, tmp < 0 ? -tmp : tmp);
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabdq_u32
+  #define vabdq_u32(a, b) simde_vabdq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ABD_H) */

--- a/2.0/simde/arm/neon/abs.h
+++ b/2.0/simde/arm/neon/abs.h
@@ -1,0 +1,392 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ABS_H)
+#define SIMDE_ARM_NEON_ABS_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vabs_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabs_f32(a);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabs_f32
+  #define vabs_f32(a) simde_vabs_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vabs_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabs_f64(a);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vabs_f64
+  #define vabs_f64(a) simde_vabs_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vabs_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabs_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi8(a);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT8_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabs_s8
+  #define vabs_s8(a) simde_vabs_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vabs_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabs_s16(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi16(a);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT16_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabs_s16
+  #define vabs_s16(a) simde_vabs_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vabs_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabs_s32(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi32(a);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT32_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabs_s32
+  #define vabs_s32(a) simde_vabs_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vabs_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabs_s64(a);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT64_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabs_s64
+  #define vabs_s64(a) simde_vabs_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vabsq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabsq_f32(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_abs(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_abs(a);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_castps512_ps128(_mm512_abs_ps(_mm512_castps128_ps512(a)));
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_math_fabsf(a_.values[i]);
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_f32
+  #define vabsq_f32(a) simde_vabsq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vabsq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabsq_f64(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_abs(a);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_castpd512_pd128(_mm512_abs_pd(_mm512_castpd128_pd512(a)));
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_math_fabs(a_.values[i]);
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_f64
+  #define vabsq_f64(a) simde_vabsq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vabsq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabsq_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi8(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_abs(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_abs(a);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT8_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_s8
+  #define vabsq_s8(a) simde_vabsq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vabsq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabsq_s16(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi16(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_abs(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_abs(a);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT16_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_s16
+  #define vabsq_s16(a) simde_vabsq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vabsq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vabsq_s32(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi32(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_abs(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_abs(a);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT32_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_s32
+  #define vabsq_s32(a) simde_vabsq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vabsq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vabsq_s64(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION)
+    return vec_abs(a);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < INT64_C(0));
+      r_.values = (-a_.values & m) | (a_.values & ~m);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] < 0 ? -a_.values[i] : a_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vabsq_s64
+  #define vabsq_s64(a) simde_vabsq_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ABS_H) */

--- a/2.0/simde/arm/neon/add.h
+++ b/2.0/simde/arm/neon/add.h
@@ -1,0 +1,653 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ADD_H)
+#define SIMDE_ARM_NEON_ADD_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vadd_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_f32
+  #define vadd_f32(a, b) simde_vadd_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vadd_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vadd_f64(a, b);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vadd_f64
+  #define vadd_f64(a, b) simde_vadd_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vadd_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_s8
+  #define vadd_s8(a, b) simde_vadd_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vadd_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_s16
+  #define vadd_s16(a, b) simde_vadd_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vadd_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_s32
+  #define vadd_s32(a, b) simde_vadd_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vadd_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_s64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_s64
+  #define vadd_s64(a, b) simde_vadd_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vadd_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_u8
+  #define vadd_u8(a, b) simde_vadd_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vadd_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_u16
+  #define vadd_u16(a, b) simde_vadd_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vadd_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_u32
+  #define vadd_u32(a, b) simde_vadd_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vadd_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vadd_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vadd_u64
+  #define vadd_u64(a, b) simde_vadd_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vaddq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_add_ps(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(float) a_ , b_, r_;
+    a_ = a;
+    b_ = b;
+    r_ = vec_add(a_, b_);
+    return r_;
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_add(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_f32
+  #define vaddq_f32(a, b) simde_vaddq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vaddq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_pd(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_add(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_add(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_f64
+  #define vaddq_f64(a, b) simde_vaddq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vaddq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_add(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_s8
+  #define vaddq_s8(a, b) simde_vaddq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vaddq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_add(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_s16
+  #define vaddq_s16(a, b) simde_vaddq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_add(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_s32
+  #define vaddq_s32(a, b) simde_vaddq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vaddq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_add(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_add(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_s64
+  #define vaddq_s64(a, b) simde_vaddq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vaddq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_u8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_u8
+  #define vaddq_u8(a, b) simde_vaddq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vaddq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_u16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_u16
+  #define vaddq_u16(a, b) simde_vaddq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vaddq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_u32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_add(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_u32
+  #define vaddq_u32(a, b) simde_vaddq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vaddq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddq_u64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_add(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values + b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddq_u64
+  #define vaddq_u64(a, b) simde_vaddq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ADD_H) */

--- a/2.0/simde/arm/neon/addl.h
+++ b/2.0/simde/arm/neon/addl.h
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ADDL_H)
+#define SIMDE_ARM_NEON_ADDL_H
+
+#include "add.h"
+#include "movl.h"
+#include "movl_high.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vaddl_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_s8(a, b);
+  #else
+    return simde_vaddq_s16(simde_vmovl_s8(a), simde_vmovl_s8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_s8
+  #define vaddl_s8(a, b) simde_vaddl_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vaddl_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_s16(a, b);
+  #else
+    return simde_vaddq_s32(simde_vmovl_s16(a), simde_vmovl_s16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_s16
+  #define vaddl_s16(a, b) simde_vaddl_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vaddl_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_s32(a, b);
+  #else
+    return simde_vaddq_s64(simde_vmovl_s32(a), simde_vmovl_s32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_s32
+  #define vaddl_s32(a, b) simde_vaddl_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vaddl_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_u8(a, b);
+  #else
+    return simde_vaddq_u16(simde_vmovl_u8(a), simde_vmovl_u8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_u8
+  #define vaddl_u8(a, b) simde_vaddl_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vaddl_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_u16(a, b);
+  #else
+    return simde_vaddq_u32(simde_vmovl_u16(a), simde_vmovl_u16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_u16
+  #define vaddl_u16(a, b) simde_vaddl_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vaddl_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddl_u32(a, b);
+  #else
+    return simde_vaddq_u64(simde_vmovl_u32(a), simde_vmovl_u32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_u32
+  #define vaddl_u32(a, b) simde_vaddl_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ADDL_H) */

--- a/2.0/simde/arm/neon/addl_high.h
+++ b/2.0/simde/arm/neon/addl_high.h
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ADDL_HIGH_H)
+#define SIMDE_ARM_NEON_ADDL_HIGH_H
+
+#include "add.h"
+#include "movl.h"
+#include "movl_high.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vaddl_high_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_s8(a, b);
+  #else
+    return simde_vaddq_s16(simde_vmovl_high_s8(a), simde_vmovl_high_s8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_s8
+  #define vaddl_high_s8(a, b) simde_vaddl_high_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vaddl_high_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_s16(a, b);
+  #else
+    return simde_vaddq_s32(simde_vmovl_high_s16(a), simde_vmovl_high_s16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_s16
+  #define vaddl_high_s16(a, b) simde_vaddl_high_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vaddl_high_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_s32(a, b);
+  #else
+    return simde_vaddq_s64(simde_vmovl_high_s32(a), simde_vmovl_high_s32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_s32
+  #define vaddl_high_s32(a, b) simde_vaddl_high_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vaddl_high_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_u8(a, b);
+  #else
+    return simde_vaddq_u16(simde_vmovl_high_u8(a), simde_vmovl_high_u8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_u8
+  #define vaddl_high_u8(a, b) simde_vaddl_high_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vaddl_high_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_u16(a, b);
+  #else
+    return simde_vaddq_u32(simde_vmovl_high_u16(a), simde_vmovl_high_u16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_u16
+  #define vaddl_high_u16(a, b) simde_vaddl_high_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vaddl_high_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vaddl_high_u32(a, b);
+  #else
+    return simde_vaddq_u64(simde_vmovl_high_u32(a), simde_vmovl_high_u32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vaddl_high_u32
+  #define vaddl_high_u32(a, b) simde_vaddl_high_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ADDL_HIGH_H) */

--- a/2.0/simde/arm/neon/addw.h
+++ b/2.0/simde/arm/neon/addw.h
@@ -1,0 +1,222 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ADDW_H)
+#define SIMDE_ARM_NEON_ADDW_H
+
+#include "types.h"
+#include "add.h"
+#include "movl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vaddw_s8(simde_int16x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_s8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_s16(a, simde_vmovl_s8(b));
+  #else
+    simde_int16x8_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_int8x8_private b_ = simde_int8x8_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_s8
+  #define vaddw_s8(a, b) simde_vaddw_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vaddw_s16(simde_int32x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_s32(a, simde_vmovl_s16(b));
+  #else
+    simde_int32x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_int16x4_private b_ = simde_int16x4_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_s16
+  #define vaddw_s16(a, b) simde_vaddw_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vaddw_s32(simde_int64x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_s32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_s64(a, simde_vmovl_s32(b));
+  #else
+    simde_int64x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_int32x2_private b_ = simde_int32x2_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_s32
+  #define vaddw_s32(a, b) simde_vaddw_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vaddw_u8(simde_uint16x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_u8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_u16(a, simde_vmovl_u8(b));
+  #else
+    simde_uint16x8_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_uint8x8_private b_ = simde_uint8x8_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_u8
+  #define vaddw_u8(a, b) simde_vaddw_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vaddw_u16(simde_uint32x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_u32(a, simde_vmovl_u16(b));
+  #else
+    simde_uint32x4_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_uint16x4_private b_ = simde_uint16x4_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_u16
+  #define vaddw_u16(a, b) simde_vaddw_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vaddw_u32(simde_uint64x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vaddw_u32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vaddq_u64(a, simde_vmovl_u32(b));
+  #else
+    simde_uint64x2_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_uint32x2_private b_ = simde_uint32x2_to_private(b);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, b_.values);
+      r_.values += a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vaddw_u32
+  #define vaddw_u32(a, b) simde_vaddw_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ADDW_H) */

--- a/2.0/simde/arm/neon/and.h
+++ b/2.0/simde/arm/neon/and.h
@@ -1,0 +1,552 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_AND_H)
+#define SIMDE_ARM_NEON_AND_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vand_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_s8
+  #define vand_s8(a, b) simde_vand_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vand_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_s16
+  #define vand_s16(a, b) simde_vand_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vand_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_s32
+  #define vand_s32(a, b) simde_vand_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vand_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_s64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_s64
+  #define vand_s64(a, b) simde_vand_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vand_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_u8
+  #define vand_u8(a, b) simde_vand_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vand_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_u16
+  #define vand_u16(a, b) simde_vand_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vand_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_u32
+  #define vand_u32(a, b) simde_vand_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vand_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vand_u64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vand_u64
+  #define vand_u64(a, b) simde_vand_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vandq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_s8
+  #define vandq_s8(a, b) simde_vandq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vandq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_s16
+  #define vandq_s16(a, b) simde_vandq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vandq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_s32
+  #define vandq_s32(a, b) simde_vandq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vandq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_s64
+  #define vandq_s64(a, b) simde_vandq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vandq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_u8
+  #define vandq_u8(a, b) simde_vandq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vandq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_u16
+  #define vandq_u16(a, b) simde_vandq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vandq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_u32
+  #define vandq_u32(a, b) simde_vandq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vandq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vandq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_and(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values & b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] & b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vandq_u64
+  #define vandq_u64(a, b) simde_vandq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_AND_H) */

--- a/2.0/simde/arm/neon/bsl.h
+++ b/2.0/simde/arm/neon/bsl.h
@@ -1,0 +1,428 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_BSL_H)
+#define SIMDE_ARM_NEON_BSL_H
+
+#include "types.h"
+#include "reinterpret.h"
+#include "and.h"
+#include "eor.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vbsl_u8(simde_uint8x8_t a, simde_uint8x8_t b, simde_uint8x8_t c);
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vbslq_u8(simde_uint8x16_t a, simde_uint8x16_t b, simde_uint8x16_t c);
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vbsl_f32(simde_uint32x2_t a, simde_float32x2_t b, simde_float32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_f32(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u32(a),
+      b_ = simde_vreinterpret_u8_f32(b),
+      c_ = simde_vreinterpret_u8_f32(c);
+    return simde_vreinterpret_f32_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_f32
+  #define vbsl_f32(a, b, c) simde_vbsl_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vbsl_f64(simde_uint64x1_t a, simde_float64x1_t b, simde_float64x1_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vbsl_f64(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u64(a),
+      b_ = simde_vreinterpret_u8_f64(b),
+      c_ = simde_vreinterpret_u8_f64(c);
+    return simde_vreinterpret_f64_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_f64
+  #define vbsl_f64(a, b, c) simde_vbsl_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vbsl_s8(simde_uint8x8_t a, simde_int8x8_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_s8(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = a,
+      b_ = simde_vreinterpret_u8_s8(b),
+      c_ = simde_vreinterpret_u8_s8(c);
+    return simde_vreinterpret_s8_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_s8
+  #define vbsl_s8(a, b, c) simde_vbsl_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vbsl_s16(simde_uint16x4_t a, simde_int16x4_t b, simde_int16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_s16(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u16(a),
+      b_ = simde_vreinterpret_u8_s16(b),
+      c_ = simde_vreinterpret_u8_s16(c);
+    return simde_vreinterpret_s16_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_s16
+  #define vbsl_s16(a, b, c) simde_vbsl_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vbsl_s32(simde_uint32x2_t a, simde_int32x2_t b, simde_int32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_s32(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u32(a),
+      b_ = simde_vreinterpret_u8_s32(b),
+      c_ = simde_vreinterpret_u8_s32(c);
+    return simde_vreinterpret_s32_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_s32
+  #define vbsl_s32(a, b, c) simde_vbsl_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vbsl_s64(simde_uint64x1_t a, simde_int64x1_t b, simde_int64x1_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_s64(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u64(a),
+      b_ = simde_vreinterpret_u8_s64(b),
+      c_ = simde_vreinterpret_u8_s64(c);
+    return simde_vreinterpret_s64_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_s64
+  #define vbsl_s64(a, b, c) simde_vbsl_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vbsl_u8(simde_uint8x8_t a, simde_uint8x8_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_u8(a, b, c);
+  #else
+    return simde_veor_u8(c, simde_vand_u8(simde_veor_u8(b, c), a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_u8
+  #define vbsl_u8(a, b, c) simde_vbsl_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vbsl_u16(simde_uint16x4_t a, simde_uint16x4_t b, simde_uint16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_u16(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u16(a),
+      b_ = simde_vreinterpret_u8_u16(b),
+      c_ = simde_vreinterpret_u8_u16(c);
+    return simde_vreinterpret_u16_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_u16
+  #define vbsl_u16(a, b, c) simde_vbsl_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vbsl_u32(simde_uint32x2_t a, simde_uint32x2_t b, simde_uint32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_u32(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u32(a),
+      b_ = simde_vreinterpret_u8_u32(b),
+      c_ = simde_vreinterpret_u8_u32(c);
+    return simde_vreinterpret_u32_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_u32
+  #define vbsl_u32(a, b, c) simde_vbsl_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vbsl_u64(simde_uint64x1_t a, simde_uint64x1_t b, simde_uint64x1_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbsl_u64(a, b, c);
+  #else
+    simde_uint8x8_t
+      a_ = simde_vreinterpret_u8_u64(a),
+      b_ = simde_vreinterpret_u8_u64(b),
+      c_ = simde_vreinterpret_u8_u64(c);
+    return simde_vreinterpret_u64_u8(simde_vbsl_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbsl_u64
+  #define vbsl_u64(a, b, c) simde_vbsl_u64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vbslq_f32(simde_uint32x4_t a, simde_float32x4_t b, simde_float32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_f32(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u32(a),
+      b_ = simde_vreinterpretq_u8_f32(b),
+      c_ = simde_vreinterpretq_u8_f32(c);
+    return simde_vreinterpretq_f32_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_f32
+  #define vbslq_f32(a, b, c) simde_vbslq_f32((a), (b), (c))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vbslq_f64(simde_uint64x2_t a, simde_float64x2_t b, simde_float64x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vbslq_f64(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u64(a),
+      b_ = simde_vreinterpretq_u8_f64(b),
+      c_ = simde_vreinterpretq_u8_f64(c);
+    return simde_vreinterpretq_f64_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_f64
+  #define vbslq_f64(a, b, c) simde_vbslq_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vbslq_s8(simde_uint8x16_t a, simde_int8x16_t b, simde_int8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_s8(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = (a),
+      b_ = simde_vreinterpretq_u8_s8(b),
+      c_ = simde_vreinterpretq_u8_s8(c);
+    return simde_vreinterpretq_s8_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_s8
+  #define vbslq_s8(a, b, c) simde_vbslq_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vbslq_s16(simde_uint16x8_t a, simde_int16x8_t b, simde_int16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_s16(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sel(c, b, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u16(a),
+      b_ = simde_vreinterpretq_u8_s16(b),
+      c_ = simde_vreinterpretq_u8_s16(c);
+    return simde_vreinterpretq_s16_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_s16
+  #define vbslq_s16(a, b, c) simde_vbslq_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vbslq_s32(simde_uint32x4_t a, simde_int32x4_t b, simde_int32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_s32(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u32(a),
+      b_ = simde_vreinterpretq_u8_s32(b),
+      c_ = simde_vreinterpretq_u8_s32(c);
+    return simde_vreinterpretq_s32_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_s32
+  #define vbslq_s32(a, b, c) simde_vbslq_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vbslq_s64(simde_uint64x2_t a, simde_int64x2_t b, simde_int64x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_s64(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u64(a),
+      b_ = simde_vreinterpretq_u8_s64(b),
+      c_ = simde_vreinterpretq_u8_s64(c);
+    return simde_vreinterpretq_s64_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_s64
+  #define vbslq_s64(a, b, c) simde_vbslq_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vbslq_u8(simde_uint8x16_t a, simde_uint8x16_t b, simde_uint8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_u8(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sel(c, b, a);
+  #else
+    return simde_veorq_u8(c, simde_vandq_u8(simde_veorq_u8(c, b), a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_u8
+  #define vbslq_u8(a, b, c) simde_vbslq_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vbslq_u16(simde_uint16x8_t a, simde_uint16x8_t b, simde_uint16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_u16(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u16(a),
+      b_ = simde_vreinterpretq_u8_u16(b),
+      c_ = simde_vreinterpretq_u8_u16(c);
+    return simde_vreinterpretq_u16_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_u16
+  #define vbslq_u16(a, b, c) simde_vbslq_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vbslq_u32(simde_uint32x4_t a, simde_uint32x4_t b, simde_uint32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_u32(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u32(a),
+      b_ = simde_vreinterpretq_u8_u32(b),
+      c_ = simde_vreinterpretq_u8_u32(c);
+    return simde_vreinterpretq_u32_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_u32
+  #define vbslq_u32(a, b, c) simde_vbslq_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vbslq_u64(simde_uint64x2_t a, simde_uint64x2_t b, simde_uint64x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vbslq_u64(a, b, c);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_bitselect(b, c, a);
+  #else
+    simde_uint8x16_t
+      a_ = simde_vreinterpretq_u8_u64(a),
+      b_ = simde_vreinterpretq_u8_u64(b),
+      c_ = simde_vreinterpretq_u8_u64(c);
+    return simde_vreinterpretq_u64_u8(simde_vbslq_u8(a_, b_, c_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vbslq_u64
+  #define vbslq_u64(a, b, c) simde_vbslq_u64((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_BSL_H) */

--- a/2.0/simde/arm/neon/cagt.h
+++ b/2.0/simde/arm/neon/cagt.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_CAGT_H)
+#define SIMDE_ARM_NEON_CAGT_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcagt_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcagt_f32(a, b);
+  #else
+    simde_uint32x2_private r_;
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (simde_math_fabsf(a_.values[i]) > simde_math_fabsf(b_.values[i])) ? 0xffffffff : 0;
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcagt_f32
+  #define vcagt_f32(a, b) simde_vcagt_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcagt_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcagt_f64(a, b);
+  #else
+    simde_uint64x1_private r_;
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (simde_math_fabs(a_.values[i]) > simde_math_fabs(b_.values[i])) ? 0xffffffffffffffff : 0;
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcagt_f64
+  #define vcagt_f64(a, b) simde_vcagt_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcagtq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcagtq_f32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_gt(wasm_f32x4_abs(a), wasm_f32x4_abs(b));
+  #else
+    simde_uint32x4_private r_;
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (simde_math_fabsf(a_.values[i]) > simde_math_fabsf(b_.values[i])) ? 0xffffffff : 0;
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcagtq_f32
+  #define vcagtq_f32(a, b) simde_vcagtq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcagtq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcagtq_f64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_gt(wasm_f64x2_abs(a), wasm_f64x2_abs(b));
+  #else
+    simde_uint64x2_private r_;
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (simde_math_fabs(a_.values[i]) > simde_math_fabs(b_.values[i])) ? 0xffffffffffffffff : 0;
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcagtq_f64
+  #define vcagtq_f64(a, b) simde_vcagtq_f64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CAGT_H) */

--- a/2.0/simde/arm/neon/ceq.h
+++ b/2.0/simde/arm/neon/ceq.h
@@ -1,0 +1,655 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CEQ_H)
+#define SIMDE_ARM_NEON_CEQ_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceq_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_f32(a, b);
+  #else
+    simde_uint32x2_private r_;
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_f32
+  #define vceq_f32(a, b) simde_vceq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceq_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceq_f64(a, b);
+  #else
+    simde_uint64x1_private r_;
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vceq_f64
+  #define vceq_f64(a, b) simde_vceq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vceq_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi8(a, b);
+  #else
+    simde_uint8x8_private r_;
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT8_C(0) : UINT8_C(0);
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_s8
+  #define vceq_s8(a, b) simde_vceq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vceq_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi16(a, b);
+  #else
+    simde_uint16x4_private r_;
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT16_C(0) : UINT16_C(0);
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_s16
+  #define vceq_s16(a, b) simde_vceq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceq_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi32(a, b);
+  #else
+    simde_uint32x2_private r_;
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_s32
+  #define vceq_s32(a, b) simde_vceq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceq_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceq_s64(a, b);
+  #else
+    simde_uint64x1_private r_;
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_s64
+  #define vceq_s64(a, b) simde_vceq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vceq_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_u8(a, b);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint8x8_private
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT8_C(0) : UINT8_C(0);
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_u8
+  #define vceq_u8(a, b) simde_vceq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vceq_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_u16(a, b);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint16x4_private
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT16_C(0) : UINT16_C(0);
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_u16
+  #define vceq_u16(a, b) simde_vceq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceq_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceq_u32(a, b);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint32x2_private
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_u32
+  #define vceq_u32(a, b) simde_vceq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceq_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceq_u64(a, b);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint64x1_private
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceq_u64
+  #define vceq_u64(a, b) simde_vceq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(_mm_cmpeq_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpeq(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_eq(a, b);
+  #else
+    simde_uint32x4_private r_;
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_f32
+  #define vceqq_f32(a, b) simde_vceqq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(_mm_cmpeq_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpeq(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_eq(a, b);
+  #else
+    simde_uint64x2_private r_;
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_f64
+  #define vceqq_f64(a, b) simde_vceqq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vceqq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpeq(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_eq(a, b);
+  #else
+    simde_uint8x16_private r_;
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT8_C(0) : UINT8_C(0);
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_s8
+  #define vceqq_s8(a, b) simde_vceqq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vceqq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpeq(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_eq(a, b);
+  #else
+    simde_uint16x8_private r_;
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT16_C(0) : UINT16_C(0);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_s16
+  #define vceqq_s16(a, b) simde_vceqq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpeq(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_eq(a, b);
+  #else
+    simde_uint32x4_private r_;
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_s32
+  #define vceqq_s32(a, b) simde_vceqq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cmpeq_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpeq(a, b));
+  #else
+    simde_uint64x2_private r_;
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_s64
+  #define vceqq_s64(a, b) simde_vceqq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vceqq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpeq(a, b));
+  #else
+    simde_uint8x16_private r_;
+    simde_uint8x16_private
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT8_C(0) : UINT8_C(0);
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_u8
+  #define vceqq_u8(a, b) simde_vceqq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vceqq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpeq(a, b));
+  #else
+    simde_uint16x8_private r_;
+    simde_uint16x8_private
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT16_C(0) : UINT16_C(0);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_u16
+  #define vceqq_u16(a, b) simde_vceqq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vceqq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpeq(a, b));
+  #else
+    simde_uint32x4_private r_;
+    simde_uint32x4_private
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_u32
+  #define vceqq_u32(a, b) simde_vceqq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cmpeq_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpeq(a, b));
+  #else
+    simde_uint64x2_private r_;
+    simde_uint64x2_private
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values == b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] == b_.values[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqq_u64
+  #define vceqq_u64(a, b) simde_vceqq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CEQ_H) */

--- a/2.0/simde/arm/neon/ceqz.h
+++ b/2.0/simde/arm/neon/ceqz.h
@@ -1,0 +1,335 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_CEQZ_H)
+#define SIMDE_ARM_NEON_CEQZ_H
+
+#include "ceq.h"
+#include "dup_n.h"
+#include "types.h"
+#include "reinterpret.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceqz_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_f32(a);
+  #else
+    return simde_vceq_f32(a, simde_vdup_n_f32(0.0f));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_f32
+  #define vceqz_f32(a) simde_vceqz_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceqz_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_f64(a);
+  #else
+    return simde_vceq_f64(a, simde_vdup_n_f64(0.0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_f64
+  #define vceqz_f64(a) simde_vceqz_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vceqz_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_s8(a);
+  #else
+    return simde_vceq_s8(a, simde_vdup_n_s8(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_s8
+  #define vceqz_s8(a) simde_vceqz_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vceqz_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_s16(a);
+  #else
+    return simde_vceq_s16(a, simde_vdup_n_s16(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_s16
+  #define vceqz_s16(a) simde_vceqz_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceqz_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_s32(a);
+  #else
+    return simde_vceq_s32(a, simde_vdup_n_s32(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_s32
+  #define vceqz_s32(a) simde_vceqz_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceqz_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_s64(a);
+  #else
+    return simde_vceq_s64(a, simde_vdup_n_s64(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_s64
+  #define vceqz_s64(a) simde_vceqz_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vceqz_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_u8(a);
+  #else
+    return simde_vceq_u8(a, simde_vdup_n_u8(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_u8
+  #define vceqz_u8(a) simde_vceqz_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vceqz_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_u16(a);
+  #else
+    return simde_vceq_u16(a, simde_vdup_n_u16(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_u16
+  #define vceqz_u16(a) simde_vceqz_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vceqz_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_u32(a);
+  #else
+    return simde_vceq_u32(a, simde_vdup_n_u32(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_u32
+  #define vceqz_u32(a) simde_vceqz_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vceqz_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqz_u64(a);
+  #else
+    return simde_vceq_u64(a, simde_vdup_n_u64(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqz_u64
+  #define vceqz_u64(a) simde_vceqz_u64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqzq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_f32(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_eq(wasm_f32x4_splat(0), a);
+  #else
+    return simde_vceqq_f32(a, simde_vdupq_n_f32(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_f32
+  #define vceqzq_f32(a) simde_vceqzq_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqzq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_f64(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_eq(wasm_f64x2_splat(0), a);
+  #else
+    return simde_vceqq_f64(a, simde_vdupq_n_f64(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_f64
+  #define vceqzq_f64(a) simde_vceqzq_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vceqzq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_s8(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_eq(wasm_i8x16_splat(0), a);
+  #else
+    return simde_vceqq_s8(a, simde_vdupq_n_s8(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_s8
+  #define vceqzq_s8(a) simde_vceqzq_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vceqzq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_s16(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_eq(wasm_i16x8_splat(0), a);
+  #else
+    return simde_vceqq_s16(a, simde_vdupq_n_s16(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_s16
+  #define vceqzq_s16(a) simde_vceqzq_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqzq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_s32(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_eq(wasm_i32x4_splat(0), a);
+  #else
+    return simde_vceqq_s32(a, simde_vdupq_n_s32(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_s32
+  #define vceqzq_s32(a) simde_vceqzq_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqzq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_s64(a);
+  #else
+    return simde_vceqq_s64(a, simde_vdupq_n_s64(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_s64
+  #define vceqzq_s64(a) simde_vceqzq_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vceqzq_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_u8(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_eq(wasm_i8x16_splat(0), a);
+  #else
+    return simde_vceqq_u8(a, simde_vdupq_n_u8(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_u8
+  #define vceqzq_u8(a) simde_vceqzq_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vceqzq_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_u16(a);
+  #else
+    return simde_vceqq_u16(a, simde_vdupq_n_u16(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_u16
+  #define vceqzq_u16(a) simde_vceqzq_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vceqzq_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_u32(a);
+  #else
+    return simde_vceqq_u32(a, simde_vdupq_n_u32(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_u32
+  #define vceqzq_u32(a) simde_vceqzq_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vceqzq_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vceqzq_u64(a);
+  #else
+    return simde_vceqq_u64(a, simde_vdupq_n_u64(0));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vceqzq_u64
+  #define vceqzq_u64(a) simde_vceqzq_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CEQZ_H) */

--- a/2.0/simde/arm/neon/cge.h
+++ b/2.0/simde/arm/neon/cge.h
@@ -1,0 +1,675 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CGE_H)
+#define SIMDE_ARM_NEON_CGE_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgeq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(_mm_cmpge_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_ge(a, b);
+  #else
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_f32
+  #define vcgeq_f32(a, b) simde_vcgeq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgeq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgeq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(_mm_cmpge_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_ge(a, b);
+  #else
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_f64
+  #define vcgeq_f64(a, b) simde_vcgeq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgeq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi8(a, b), _mm_cmpeq_epi8(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_ge(a, b);
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_s8
+  #define vcgeq_s8(a, b) simde_vcgeq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgeq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi16(a, b), _mm_cmpeq_epi16(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_ge(a, b);
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_s16
+  #define vcgeq_s16(a, b) simde_vcgeq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgeq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi32(a, b), _mm_cmpeq_epi32(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_ge(a, b);
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_s32
+  #define vcgeq_s32(a, b) simde_vcgeq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgeq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgeq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi64(a, b), _mm_cmpeq_epi64(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpge(a, b));
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_s64
+  #define vcgeq_s64(a, b) simde_vcgeq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgeq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi8(INT8_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi8(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits)), _mm_cmpeq_epi8(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_ge(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_u8
+  #define vcgeq_u8(a, b) simde_vcgeq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgeq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi16(INT16_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi16(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits)), _mm_cmpeq_epi16(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_ge(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_u16
+  #define vcgeq_u16(a, b) simde_vcgeq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgeq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgeq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi32(INT32_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi32(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits)), _mm_cmpeq_epi32(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpge(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_ge(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_u32
+  #define vcgeq_u32(a, b) simde_vcgeq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgeq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgeq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi64x(INT64_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi64(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits)), _mm_cmpeq_epi64(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpge(a, b));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgeq_u64
+  #define vcgeq_u64(a, b) simde_vcgeq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcge_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_f32(a, b);
+  #else
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_f32
+  #define vcge_f32(a, b) simde_vcge_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcge_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcge_f64(a, b);
+  #else
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcge_f64
+  #define vcge_f64(a, b) simde_vcge_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcge_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi8(a, b), _mm_cmpeq_pi8(a, b));
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_s8
+  #define vcge_s8(a, b) simde_vcge_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcge_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi16(a, b), _mm_cmpeq_pi16(a, b));
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_s16
+  #define vcge_s16(a, b) simde_vcge_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcge_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi32(a, b), _mm_cmpeq_pi32(a, b));
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_s32
+  #define vcge_s32(a, b) simde_vcge_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcge_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcge_s64(a, b);
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcge_s64
+  #define vcge_s64(a, b) simde_vcge_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcge_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi8(INT8_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi8(_mm_xor_si64(a, sign_bits), _mm_xor_si64(b, sign_bits)), _mm_cmpeq_pi8(a, b));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_u8
+  #define vcge_u8(a, b) simde_vcge_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcge_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi16(INT16_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi16(_mm_xor_si64(a, sign_bits), _mm_xor_si64(b, sign_bits)), _mm_cmpeq_pi16(a, b));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_u16
+  #define vcge_u16(a, b) simde_vcge_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcge_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcge_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi32(INT32_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi32(_mm_xor_si64(a, sign_bits), _mm_xor_si64(b, sign_bits)), _mm_cmpeq_pi32(a, b));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcge_u32
+  #define vcge_u32(a, b) simde_vcge_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcge_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcge_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcge_u64
+  #define vcge_u64(a, b) simde_vcge_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CGE_H) */

--- a/2.0/simde/arm/neon/cgez.h
+++ b/2.0/simde/arm/neon/cgez.h
@@ -1,0 +1,378 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CGEZ_H)
+#define SIMDE_ARM_NEON_CGEZ_H
+
+#include "cge.h"
+#include "dup_n.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgezq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_f32(a, simde_vdupq_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_f32
+  #define vcgezq_f32(a) simde_vcgezq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgezq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_f64(a, simde_vdupq_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_f64
+  #define vcgezq_f64(a) simde_vcgezq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgezq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_s8(a, simde_vdupq_n_s8(0));
+  #else
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_s8
+  #define vcgezq_s8(a) simde_vcgezq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgezq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_s16(a, simde_vdupq_n_s16(0));
+  #else
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_s16
+  #define vcgezq_s16(a) simde_vcgezq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgezq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_s32(a, simde_vdupq_n_s32(0));
+  #else
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_s32
+  #define vcgezq_s32(a) simde_vcgezq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgezq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgezq_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgeq_s64(a, simde_vdupq_n_s64(0));
+  #else
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgezq_s64
+  #define vcgezq_s64(a) simde_vcgezq_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgez_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_f32(a, simde_vdup_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_f32
+  #define vcgez_f32(a) simde_vcgez_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgez_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_f64(a, simde_vdup_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values =  HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_f64
+  #define vcgez_f64(a) simde_vcgez_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcgez_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_s8(a, simde_vdup_n_s8(0));
+  #else
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_s8
+  #define vcgez_s8(a) simde_vcgez_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcgez_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_s16(a, simde_vdup_n_s16(0));
+  #else
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_s16
+  #define vcgez_s16(a) simde_vcgez_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgez_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_s32(a, simde_vdup_n_s32(0));
+  #else
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_s32
+  #define vcgez_s32(a) simde_vcgez_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgez_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgez_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcge_s64(a, simde_vdup_n_s64(0));
+  #else
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values >= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] >= 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgez_s64
+  #define vcgez_s64(a) simde_vcgez_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CGEZ_H) */

--- a/2.0/simde/arm/neon/cgt.h
+++ b/2.0/simde/arm/neon/cgt.h
@@ -1,0 +1,679 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CGT_H)
+#define SIMDE_ARM_NEON_CGT_H
+
+#include "combine.h"
+#include "get_low.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgtq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(_mm_cmpgt_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_gt(a, b);
+  #else
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_f32
+  #define vcgtq_f32(a, b) simde_vcgtq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgtq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(_mm_cmpgt_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_gt(a, b);
+  #else
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_f64
+  #define vcgtq_f64(a, b) simde_vcgtq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgtq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_gt(a, b);
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_s8
+  #define vcgtq_s8(a, b) simde_vcgtq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgtq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_gt(a, b);
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_s16
+  #define vcgtq_s16(a, b) simde_vcgtq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgtq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_gt(a, b);
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_s32
+  #define vcgtq_s32(a, b) simde_vcgtq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgtq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_cmpgt_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpgt(a, b));
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_s64
+  #define vcgtq_s64(a, b) simde_vcgtq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgtq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bit = _mm_set1_epi8(INT8_MIN);
+    return _mm_cmpgt_epi8(_mm_xor_si128(a, sign_bit), _mm_xor_si128(b, sign_bit));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_gt(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_u8
+  #define vcgtq_u8(a, b) simde_vcgtq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgtq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bit = _mm_set1_epi16(INT16_MIN);
+    return _mm_cmpgt_epi16(_mm_xor_si128(a, sign_bit), _mm_xor_si128(b, sign_bit));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_gt(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_u16
+  #define vcgtq_u16(a, b) simde_vcgtq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgtq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgtq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bit = _mm_set1_epi32(INT32_MIN);
+    return _mm_cmpgt_epi32(_mm_xor_si128(a, sign_bit), _mm_xor_si128(b, sign_bit));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmpgt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_gt(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_u32
+  #define vcgtq_u32(a, b) simde_vcgtq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgtq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    __m128i sign_bit = _mm_set1_epi64x(INT64_MIN);
+    return _mm_cmpgt_epi64(_mm_xor_si128(a, sign_bit), _mm_xor_si128(b, sign_bit));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpgt(a, b));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtq_u64
+  #define vcgtq_u64(a, b) simde_vcgtq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgt_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_f32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE >= 128
+    return simde_vget_low_u32(simde_vcgtq_f32(simde_vcombine_f32(a, a), simde_vcombine_f32(b, b)));
+  #else
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_f32
+  #define vcgt_f32(a, b) simde_vcgt_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgt_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgt_f64(a, b);
+  #else
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_f64
+  #define vcgt_f64(a, b) simde_vcgt_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcgt_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi8(a, b);
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_s8
+  #define vcgt_s8(a, b) simde_vcgt_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcgt_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi16(a, b);
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_s16
+  #define vcgt_s16(a, b) simde_vcgt_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgt_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi32(a, b);
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_s32
+  #define vcgt_s32(a, b) simde_vcgt_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgt_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgt_s64(a, b);
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_s64
+  #define vcgt_s64(a, b) simde_vcgt_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcgt_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bit = _mm_set1_pi8(INT8_MIN);
+    return _mm_cmpgt_pi8(_mm_xor_si64(a, sign_bit), _mm_xor_si64(b, sign_bit));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_u8
+  #define vcgt_u8(a, b) simde_vcgt_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcgt_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bit = _mm_set1_pi16(INT16_MIN);
+    return _mm_cmpgt_pi16(_mm_xor_si64(a, sign_bit), _mm_xor_si64(b, sign_bit));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_u16
+  #define vcgt_u16(a, b) simde_vcgt_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgt_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcgt_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bit = _mm_set1_pi32(INT32_MIN);
+    return _mm_cmpgt_pi32(_mm_xor_si64(a, sign_bit), _mm_xor_si64(b, sign_bit));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_u32
+  #define vcgt_u32(a, b) simde_vcgt_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgt_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgt_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgt_u64
+  #define vcgt_u64(a, b) simde_vcgt_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CGT_H) */

--- a/2.0/simde/arm/neon/cgtz.h
+++ b/2.0/simde/arm/neon/cgtz.h
@@ -1,0 +1,380 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CGTZ_H)
+#define SIMDE_ARM_NEON_CGTZ_H
+
+#include "cgt.h"
+#include "combine.h"
+#include "dup_n.h"
+#include "get_low.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgtzq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_f32(a, simde_vdupq_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_f32
+  #define vcgtzq_f32(a) simde_vcgtzq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgtzq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_f64(a, simde_vdupq_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_f64
+  #define vcgtzq_f64(a) simde_vcgtzq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcgtzq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_s8(a, simde_vdupq_n_s8(0));
+  #else
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_s8
+  #define vcgtzq_s8(a) simde_vcgtzq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcgtzq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_s16(a, simde_vdupq_n_s16(0));
+  #else
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_s16
+  #define vcgtzq_s16(a) simde_vcgtzq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcgtzq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_s32(a, simde_vdupq_n_s32(0));
+  #else
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_s32
+  #define vcgtzq_s32(a) simde_vcgtzq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcgtzq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtzq_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgtq_s64(a, simde_vdupq_n_s64(0));
+  #else
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtzq_s64
+  #define vcgtzq_s64(a) simde_vcgtzq_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgtz_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_f32(a, simde_vdup_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_f32
+  #define vcgtz_f32(a) simde_vcgtz_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgtz_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_f64(a, simde_vdup_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values =  HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_f64
+  #define vcgtz_f64(a) simde_vcgtz_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcgtz_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_s8(a, simde_vdup_n_s8(0));
+  #else
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_s8
+  #define vcgtz_s8(a) simde_vcgtz_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcgtz_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_s16(a, simde_vdup_n_s16(0));
+  #else
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_s16
+  #define vcgtz_s16(a) simde_vcgtz_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcgtz_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_s32(a, simde_vdup_n_s32(0));
+  #else
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_s32
+  #define vcgtz_s32(a) simde_vcgtz_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcgtz_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcgtz_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcgt_s64(a, simde_vdup_n_s64(0));
+  #else
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values > 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcgtz_s64
+  #define vcgtz_s64(a) simde_vcgtz_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CGTZ_H) */

--- a/2.0/simde/arm/neon/cle.h
+++ b/2.0/simde/arm/neon/cle.h
@@ -1,0 +1,675 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CLE_H)
+#define SIMDE_ARM_NEON_CLE_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcleq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(_mm_cmple_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_le(a, b);
+  #else
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_f32
+  #define vcleq_f32(a, b) simde_vcleq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcleq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcleq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(_mm_cmple_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_le(a, b);
+  #else
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_f64
+  #define vcleq_f64(a, b) simde_vcleq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcleq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi8(b, a), _mm_cmpeq_epi8(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_le(a, b);
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_s8
+  #define vcleq_s8(a, b) simde_vcleq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcleq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi16(b, a), _mm_cmpeq_epi16(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_le(a, b);
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_s16
+  #define vcleq_s16(a, b) simde_vcleq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcleq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi32(b, a), _mm_cmpeq_epi32(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_le(a, b);
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_s32
+  #define vcleq_s32(a, b) simde_vcleq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcleq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcleq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_or_si128(_mm_cmpgt_epi64(b, a), _mm_cmpeq_epi64(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmple(a, b));
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_s64
+  #define vcleq_s64(a, b) simde_vcleq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcleq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi8(INT8_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi8(_mm_xor_si128(b, sign_bits), _mm_xor_si128(a, sign_bits)), _mm_cmpeq_epi8(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_le(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_u8
+  #define vcleq_u8(a, b) simde_vcleq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcleq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi16(INT16_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi16(_mm_xor_si128(b, sign_bits), _mm_xor_si128(a, sign_bits)), _mm_cmpeq_epi16(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_le(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_u16
+  #define vcleq_u16(a, b) simde_vcleq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcleq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcleq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi32(INT32_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi32(_mm_xor_si128(b, sign_bits), _mm_xor_si128(a, sign_bits)), _mm_cmpeq_epi32(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmple(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_le(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_u32
+  #define vcleq_u32(a, b) simde_vcleq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcleq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcleq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi64x(INT64_MIN);
+    return _mm_or_si128(_mm_cmpgt_epi64(_mm_xor_si128(b, sign_bits), _mm_xor_si128(a, sign_bits)), _mm_cmpeq_epi64(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmple(a, b));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcleq_u64
+  #define vcleq_u64(a, b) simde_vcleq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcle_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_f32(a, b);
+  #else
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_f32
+  #define vcle_f32(a, b) simde_vcle_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcle_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcle_f64(a, b);
+  #else
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcle_f64
+  #define vcle_f64(a, b) simde_vcle_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcle_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi8(b, a), _mm_cmpeq_pi8(a, b));
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_s8
+  #define vcle_s8(a, b) simde_vcle_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcle_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi16(b, a), _mm_cmpeq_pi16(a, b));
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_s16
+  #define vcle_s16(a, b) simde_vcle_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcle_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(_mm_cmpgt_pi32(b, a), _mm_cmpeq_pi32(a, b));
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_s32
+  #define vcle_s32(a, b) simde_vcle_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcle_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcle_s64(a, b);
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcle_s64
+  #define vcle_s64(a, b) simde_vcle_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcle_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi8(INT8_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi8(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits)), _mm_cmpeq_pi8(a, b));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_u8
+  #define vcle_u8(a, b) simde_vcle_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcle_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi16(INT16_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi16(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits)), _mm_cmpeq_pi16(a, b));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_u16
+  #define vcle_u16(a, b) simde_vcle_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcle_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcle_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi32(INT32_MIN);
+    return _mm_or_si64(_mm_cmpgt_pi32(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits)), _mm_cmpeq_pi32(a, b));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcle_u32
+  #define vcle_u32(a, b) simde_vcle_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcle_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcle_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcle_u64
+  #define vcle_u64(a, b) simde_vcle_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CLE_H) */

--- a/2.0/simde/arm/neon/clez.h
+++ b/2.0/simde/arm/neon/clez.h
@@ -1,0 +1,378 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CLEZ_H)
+#define SIMDE_ARM_NEON_CLEZ_H
+
+#include "cle.h"
+#include "dup_n.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vclezq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_f32(a, simde_vdupq_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_f32
+  #define vclezq_f32(a) simde_vclezq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vclezq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_f64(a, simde_vdupq_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_f64
+  #define vclezq_f64(a) simde_vclezq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vclezq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_s8(a, simde_vdupq_n_s8(0));
+  #else
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_s8
+  #define vclezq_s8(a) simde_vclezq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vclezq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_s16(a, simde_vdupq_n_s16(0));
+  #else
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_s16
+  #define vclezq_s16(a) simde_vclezq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vclezq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_s32(a, simde_vdupq_n_s32(0));
+  #else
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_s32
+  #define vclezq_s32(a) simde_vclezq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vclezq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclezq_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcleq_s64(a, simde_vdupq_n_s64(0));
+  #else
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclezq_s64
+  #define vclezq_s64(a) simde_vclezq_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vclez_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_f32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_f32(a, simde_vdup_n_f32(SIMDE_FLOAT32_C(0.0)));
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= SIMDE_FLOAT32_C(0.0)) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_f32
+  #define vclez_f32(a) simde_vclez_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vclez_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_f64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_f64(a, simde_vdup_n_f64(SIMDE_FLOAT64_C(0.0)));
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values =  HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= SIMDE_FLOAT64_C(0.0)) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_f64
+  #define vclez_f64(a) simde_vclez_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vclez_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_s8(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_s8(a, simde_vdup_n_s8(0));
+  #else
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_s8
+  #define vclez_s8(a) simde_vclez_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vclez_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_s16(a, simde_vdup_n_s16(0));
+  #else
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_s16
+  #define vclez_s16(a) simde_vclez_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vclez_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_s32(a, simde_vdup_n_s32(0));
+  #else
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_s32
+  #define vclez_s32(a) simde_vclez_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vclez_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclez_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcle_s64(a, simde_vdup_n_s64(0));
+  #else
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values <= 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] <= 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclez_s64
+  #define vclez_s64(a) simde_vclez_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CLEZ_H) */

--- a/2.0/simde/arm/neon/clt.h
+++ b/2.0/simde/arm/neon/clt.h
@@ -1,0 +1,677 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_CLT_H)
+#define SIMDE_ARM_NEON_CLT_H
+
+#include "combine.h"
+#include "get_low.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcltq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(_mm_cmplt_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_lt(a, b);
+  #else
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_f32
+  #define vcltq_f32(a, b) simde_vcltq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcltq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(_mm_cmplt_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_lt(a, b);
+  #else
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_f64
+  #define vcltq_f64(a, b) simde_vcltq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcltq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_lt(a, b);
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_s8
+  #define vcltq_s8(a, b) simde_vcltq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcltq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_lt(a, b);
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_s16
+  #define vcltq_s16(a, b) simde_vcltq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcltq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_lt(a, b);
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_s32
+  #define vcltq_s32(a, b) simde_vcltq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcltq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_cmpgt_epi64(b, a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmplt(a, b));
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_s64
+  #define vcltq_s64(a, b) simde_vcltq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcltq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi8(INT8_MIN);
+    return _mm_cmplt_epi8(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_lt(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_u8
+  #define vcltq_u8(a, b) simde_vcltq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcltq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi16(INT16_MIN);
+    return _mm_cmplt_epi16(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_lt(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_u16
+  #define vcltq_u16(a, b) simde_vcltq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcltq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcltq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi32(INT32_MIN);
+    return _mm_cmplt_epi32(_mm_xor_si128(a, sign_bits), _mm_xor_si128(b, sign_bits));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_cmplt(a, b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_lt(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_u32
+  #define vcltq_u32(a, b) simde_vcltq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcltq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE4_2_NATIVE)
+    __m128i sign_bits = _mm_set1_epi64x(INT64_MIN);
+    return _mm_cmpgt_epi64(_mm_xor_si128(b, sign_bits), _mm_xor_si128(a, sign_bits));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmplt(a, b));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltq_u64
+  #define vcltq_u64(a, b) simde_vcltq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vclt_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_f32(a, b);
+  #else
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_f32
+  #define vclt_f32(a, b) simde_vclt_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vclt_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclt_f64(a, b);
+  #else
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclt_f64
+  #define vclt_f64(a, b) simde_vclt_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vclt_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi8(b, a);
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_s8
+  #define vclt_s8(a, b) simde_vclt_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vclt_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi16(b, a);
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_s16
+  #define vclt_s16(a, b) simde_vclt_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vclt_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi32(b, a);
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_s32
+  #define vclt_s32(a, b) simde_vclt_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vclt_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclt_s64(a, b);
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclt_s64
+  #define vclt_s64(a, b) simde_vclt_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vclt_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi8(INT8_MIN);
+    return _mm_cmpgt_pi8(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_u8
+  #define vclt_u8(a, b) simde_vclt_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vclt_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi16(INT16_MIN);
+    return _mm_cmpgt_pi16(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_u16
+  #define vclt_u16(a, b) simde_vclt_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vclt_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vclt_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 sign_bits = _mm_set1_pi32(INT32_MIN);
+    return _mm_cmpgt_pi32(_mm_xor_si64(b, sign_bits), _mm_xor_si64(a, sign_bits));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vclt_u32
+  #define vclt_u32(a, b) simde_vclt_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vclt_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vclt_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vclt_u64
+  #define vclt_u64(a, b) simde_vclt_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CLT_H) */

--- a/2.0/simde/arm/neon/cltz.h
+++ b/2.0/simde/arm/neon/cltz.h
@@ -1,0 +1,263 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+/* TODO: float fallbacks should use vclt(a, vdup_n(0.0)) */
+
+#if !defined(SIMDE_ARM_NEON_CLTZ_H)
+#define SIMDE_ARM_NEON_CLTZ_H
+
+#include "types.h"
+#include "shr_n.h"
+#include "reinterpret.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcltz_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_f32(a);
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < SIMDE_FLOAT32_C(0.0)) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_f32
+  #define vcltz_f32(a) simde_vcltz_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcltz_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_f64(a);
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < SIMDE_FLOAT64_C(0.0)) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_f64
+  #define vcltz_f64(a) simde_vcltz_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcltz_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_s8(a);
+  #else
+    return simde_vreinterpret_u8_s8(simde_vshr_n_s8(a, 7));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_s8
+  #define vcltz_s8(a) simde_vcltz_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcltz_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_s16(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_srai_pi16(a, 15);
+  #else
+    return simde_vreinterpret_u16_s16(simde_vshr_n_s16(a, 15));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_s16
+  #define vcltz_s16(a) simde_vcltz_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcltz_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_s32(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_srai_pi32(a, 31);
+  #else
+    return simde_vreinterpret_u32_s32(simde_vshr_n_s32(a, 31));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_s32
+  #define vcltz_s32(a) simde_vcltz_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcltz_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltz_s64(a);
+  #else
+    return simde_vreinterpret_u64_s64(simde_vshr_n_s64(a, 63));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltz_s64
+  #define vcltz_s64(a) simde_vcltz_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcltzq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_f32(a);
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < SIMDE_FLOAT32_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < SIMDE_FLOAT32_C(0.0)) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_f32
+  #define vcltzq_f32(a) simde_vcltzq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcltzq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_f64(a);
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && 0
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), a_.values < SIMDE_FLOAT64_C(0.0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] < SIMDE_FLOAT64_C(0.0)) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_f64
+  #define vcltzq_f64(a) simde_vcltzq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcltzq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_s8(a);
+  #else
+    return simde_vreinterpretq_u8_s8(simde_vshrq_n_s8(a, 7));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_s8
+  #define vcltzq_s8(a) simde_vcltzq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcltzq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_s16(a);
+  #else
+    return simde_vreinterpretq_u16_s16(simde_vshrq_n_s16(a, 15));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_s16
+  #define vcltzq_s16(a) simde_vcltzq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcltzq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_s32(a);
+  #else
+    return simde_vreinterpretq_u32_s32(simde_vshrq_n_s32(a, 31));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_s32
+  #define vcltzq_s32(a) simde_vcltzq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcltzq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcltzq_s64(a);
+  #else
+    return simde_vreinterpretq_u64_s64(simde_vshrq_n_s64(a, 63));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcltzq_s64
+  #define vcltzq_s64(a) simde_vcltzq_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CLTZ_H) */

--- a/2.0/simde/arm/neon/combine.h
+++ b/2.0/simde/arm/neon/combine.h
@@ -1,0 +1,343 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the folhighing conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_COMBINE_H)
+#define SIMDE_ARM_NEON_COMBINE_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vcombine_f32(simde_float32x2_t low, simde_float32x2_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_f32(low, high);
+  #else
+    simde_float32x4_private r_;
+    simde_float32x2_private
+      low_ = simde_float32x2_to_private(low),
+      high_ = simde_float32x2_to_private(high);
+
+    /* Note: __builtin_shufflevector can have a the output contain
+     * twice the number of elements, __builtin_shuffle cannot.
+     * Using SIMDE_SHUFFLE_VECTOR_ here would not work. */
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_f32
+  #define vcombine_f32(low, high) simde_vcombine_f32((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vcombine_f64(simde_float64x1_t low, simde_float64x1_t high) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcombine_f64(low, high);
+  #else
+    simde_float64x2_private r_;
+    simde_float64x1_private
+      low_ = simde_float64x1_to_private(low),
+      high_ = simde_float64x1_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_f64
+  #define vcombine_f64(low, high) simde_vcombine_f64((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vcombine_s8(simde_int8x8_t low, simde_int8x8_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_s8(low, high);
+  #else
+    simde_int8x16_private r_;
+    simde_int8x8_private
+      low_ = simde_int8x8_to_private(low),
+      high_ = simde_int8x8_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_s8
+  #define vcombine_s8(low, high) simde_vcombine_s8((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vcombine_s16(simde_int16x4_t low, simde_int16x4_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_s16(low, high);
+  #else
+    simde_int16x8_private r_;
+    simde_int16x4_private
+      low_ = simde_int16x4_to_private(low),
+      high_ = simde_int16x4_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3, 4, 5, 6, 7);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_s16
+  #define vcombine_s16(low, high) simde_vcombine_s16((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vcombine_s32(simde_int32x2_t low, simde_int32x2_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_s32(low, high);
+  #else
+    simde_int32x4_private r_;
+    simde_int32x2_private
+      low_ = simde_int32x2_to_private(low),
+      high_ = simde_int32x2_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_s32
+  #define vcombine_s32(low, high) simde_vcombine_s32((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vcombine_s64(simde_int64x1_t low, simde_int64x1_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_s64(low, high);
+  #else
+    simde_int64x2_private r_;
+    simde_int64x1_private
+      low_ = simde_int64x1_to_private(low),
+      high_ = simde_int64x1_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_s64
+  #define vcombine_s64(low, high) simde_vcombine_s64((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vcombine_u8(simde_uint8x8_t low, simde_uint8x8_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_u8(low, high);
+  #else
+    simde_uint8x16_private r_;
+    simde_uint8x8_private
+      low_ = simde_uint8x8_to_private(low),
+      high_ = simde_uint8x8_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_u8
+  #define vcombine_u8(low, high) simde_vcombine_u8((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vcombine_u16(simde_uint16x4_t low, simde_uint16x4_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_u16(low, high);
+  #else
+    simde_uint16x8_private r_;
+    simde_uint16x4_private
+      low_ = simde_uint16x4_to_private(low),
+      high_ = simde_uint16x4_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3, 4, 5, 6, 7);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_u16
+  #define vcombine_u16(low, high) simde_vcombine_u16((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcombine_u32(simde_uint32x2_t low, simde_uint32x2_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_u32(low, high);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint32x2_private
+      low_ = simde_uint32x2_to_private(low),
+      high_ = simde_uint32x2_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1, 2, 3);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_u32
+  #define vcombine_u32(low, high) simde_vcombine_u32((low), (high))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcombine_u64(simde_uint64x1_t low, simde_uint64x1_t high) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcombine_u64(low, high);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint64x1_private
+      low_ = simde_uint64x1_to_private(low),
+      high_ = simde_uint64x1_to_private(high);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.values = __builtin_shufflevector(low_.values, high_.values, 0, 1);
+    #else
+      size_t halfway = (sizeof(r_.values) / sizeof(r_.values[0])) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway ; i++) {
+        r_.values[i] = low_.values[i];
+        r_.values[i + halfway] = high_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcombine_u64
+  #define vcombine_u64(low, high) simde_vcombine_u64((low), (high))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_COMBINE_H) */

--- a/2.0/simde/arm/neon/create.h
+++ b/2.0/simde/arm/neon/create.h
@@ -1,0 +1,186 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+/* N.B. CM: vcreate_f16 and vcreate_bf16 are omitted as
+ * SIMDe has no 16-bit floating point support.
+ * Idem for the poly types. */
+
+#if !defined(SIMDE_ARM_NEON_CREATE_H)
+#define SIMDE_ARM_NEON_CREATE_H
+
+#include "dup_n.h"
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vcreate_s8(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_s8(a);
+  #else
+    return simde_vreinterpret_s8_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_s8
+  #define vcreate_s8(a) simde_vcreate_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vcreate_s16(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_s16(a);
+  #else
+    return simde_vreinterpret_s16_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_s16
+  #define vcreate_s16(a) simde_vcreate_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vcreate_s32(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_s32(a);
+  #else
+    return simde_vreinterpret_s32_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_s32
+  #define vcreate_s32(a) simde_vcreate_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vcreate_s64(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_s64(a);
+  #else
+    return simde_vreinterpret_s64_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_s64
+  #define vcreate_s64(a) simde_vcreate_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vcreate_u8(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_u8(a);
+  #else
+    return simde_vreinterpret_u8_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_u8
+  #define vcreate_u8(a) simde_vcreate_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vcreate_u16(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_u16(a);
+  #else
+    return simde_vreinterpret_u16_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_u16
+  #define vcreate_u16(a) simde_vcreate_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcreate_u32(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_u32(a);
+  #else
+    return simde_vreinterpret_u32_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_u32
+  #define vcreate_u32(a) simde_vcreate_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcreate_u64(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_u64(a);
+  #else
+    return simde_vdup_n_u64(a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_u64
+  #define vcreate_u64(a) simde_vcreate_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vcreate_f32(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcreate_f32(a);
+  #else
+    return simde_vreinterpret_f32_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_f32
+  #define vcreate_f32(a) simde_vcreate_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vcreate_f64(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcreate_f64(a);
+  #else
+    return simde_vreinterpret_f64_u64(simde_vdup_n_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcreate_f64
+  #define vcreate_f64(a) simde_vcreate_f64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_CREATE_H) */

--- a/2.0/simde/arm/neon/cvt.h
+++ b/2.0/simde/arm/neon/cvt.h
@@ -1,0 +1,492 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com>
+ */
+
+/*
+ * Implementor's notes: seanptmaher
+ *
+ * this intrinsic has many (7 pages worth) of variations on it, so
+ * this file might become a dumping ground for various
+ * implementations. I'm only going to write the `cvt` intrinsics for
+ * now, but off the top of my head, we've got:
+ *
+ * - vcvt* <- round towards 0
+ * - vcvtn* <- round to nearest with ties to even
+ * - vcvtm* <- round towards minus infinity
+ * - vcvtp* <- round towards plus infinity
+ * - vcvta* <- round to nearest with ties to away
+ *
+ * and there are a bunch of variations on these. More information can
+ * be found here:
+ * https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics?page=1&search=vcvt
+ */
+
+#if !defined(SIMDE_ARM_NEON_CVT_H)
+#define SIMDE_ARM_NEON_CVT_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vcvts_s32_f32(simde_float32 a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvts_s32_f32(a);
+  #else
+    return HEDLEY_STATIC_CAST(int32_t, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvts_s32_f32
+  #define vcvts_s32_f32(a) simde_vcvts_s32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vcvts_u32_f32(simde_float32 a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvts_u32_f32(a);
+  #else
+    return HEDLEY_STATIC_CAST(uint32_t, (a < 0) ? 0 : a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvts_u32_f32
+  #define vcvts_u32_f32(a) simde_vcvts_u32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32
+simde_vcvts_f32_s32(int32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvts_f32_s32(a);
+  #else
+    return HEDLEY_STATIC_CAST(simde_float32, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvts_f32_s32
+  #define vcvts_f32_s32(a) simde_vcvts_f32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32
+simde_vcvts_f32_u32 (uint32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvts_f32_u32(a);
+  #else
+    return HEDLEY_STATIC_CAST(simde_float32, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvts_f32_u32
+  #define vcvts_f32_u32(a) simde_vcvts_f32_u32(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_vcvtd_s64_f64(simde_float64 a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvtd_s64_f64(a);
+  #else
+    return HEDLEY_STATIC_CAST(int64_t, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtd_s64_f64
+  #define vcvtd_s64_f64(a) simde_vcvtd_s64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vcvtd_u64_f64(simde_float64 a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtd_u64_f64(a);
+  #else
+    return HEDLEY_STATIC_CAST(uint64_t, (a < 0) ? 0 : a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtd_u64_f64
+  #define vcvtd_u64_f64(a) simde_vcvtd_u64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64
+simde_vcvtd_f64_s64(int64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvtd_f64_s64(a);
+  #else
+    return HEDLEY_STATIC_CAST(simde_float64, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtd_f64_s64
+  #define vcvtd_f64_s64(a) simde_vcvtd_f64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64
+simde_vcvtd_f64_u64(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtd_f64_u64(a);
+  #else
+    return HEDLEY_STATIC_CAST(simde_float64, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtd_f64_u64
+  #define vcvtd_f64_u64(a) simde_vcvtd_f64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vcvt_s32_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcvt_s32_f32(a);
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_int32x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_s32_f32(a_.values[i]);
+    }
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_s32_f32
+  #define vcvt_s32_f32(a) simde_vcvt_s32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vcvt_u32_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvt_u32_f32(a);
+  #else
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_uint32x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_u32_f32(a_.values[i]);
+    }
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_u32_f32
+  #define vcvt_u32_f32(a) simde_vcvt_u32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vcvt_s64_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvt_s64_f64(a);
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_int64x1_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_s64_f64(a_.values[i]);
+    }
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_s64_f64
+  #define vcvt_s64_f64(a) simde_vcvt_s64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vcvt_u64_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvt_u64_f64(a);
+  #else
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_uint64x1_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_u64_f64(a_.values[i]);
+    }
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_u64_f64
+  #define vcvt_u64_f64(a) simde_vcvt_u64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vcvtq_s32_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcvtq_s32_f32(a);
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_int32x4_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_s32_f32(a_.values[i]);
+    }
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_s32_f32
+  #define vcvtq_s32_f32(a) simde_vcvtq_s32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vcvtq_u32_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtq_u32_f32(a);
+  #else
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_uint32x4_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_u32_f32(a_.values[i]);
+    }
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_u32_f32
+  #define vcvtq_u32_f32(a) simde_vcvtq_u32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vcvtq_s64_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvtq_s64_f64(a);
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_int64x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_s64_f64(a_.values[i]);
+    }
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_s64_f64
+  #define vcvtq_s64_f64(a) simde_vcvtq_s64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vcvtq_u64_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtq_u64_f64(a);
+  #else
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_uint64x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_u64_f64(a_.values[i]);
+    }
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_u64_f64
+  #define vcvtq_u64_f64(a) simde_vcvtq_u64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vcvt_f32_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcvt_f32_s32(a);
+  #else
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_float32x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_f32_s32(a_.values[i]);
+    }
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_f32_s32
+  #define vcvt_f32_s32(a) simde_vcvt_f32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vcvt_f32_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvt_f32_u32(a);
+  #else
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_float32x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_f32_u32(a_.values[i]);
+    }
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_f32_u32
+  #define vcvt_f32_u32(a) simde_vcvt_f32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vcvt_f64_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvt_f64_s64(a);
+  #else
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_float64x1_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_f64_s64(a_.values[i]);
+    }
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_f64_s64
+  #define vcvt_f64_s64(a) simde_vcvt_f64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vcvt_f64_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvt_f64_u64(a);
+  #else
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_float64x1_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_f64_u64(a_.values[i]);
+    }
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvt_f64_u64
+  #define vcvt_f64_u64(a) simde_vcvt_f64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vcvtq_f32_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vcvtq_f32_s32(a);
+  #else
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_float32x4_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_f32_s32(a_.values[i]);
+    }
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_f32_s32
+  #define vcvtq_f32_s32(a) simde_vcvtq_f32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vcvtq_f32_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtq_f32_u32(a);
+  #else
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_float32x4_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvts_f32_u32(a_.values[i]);
+    }
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_f32_u32
+  #define vcvtq_f32_u32(a) simde_vcvtq_f32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vcvtq_f64_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vcvtq_f64_s64(a);
+  #else
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_float64x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_f64_s64(a_.values[i]);
+    }
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_f64_s64
+  #define vcvtq_f64_s64(a) simde_vcvtq_f64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vcvtq_f64_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_BUG_CLANG_46844)
+    return vcvtq_f64_u64(a);
+  #else
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_float64x2_private r_;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vcvtd_f64_u64(a_.values[i]);
+    }
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vcvtq_f64_u64
+  #define vcvtq_f64_u64(a) simde_vcvtq_f64_u64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* SIMDE_ARM_NEON_CVT_H */

--- a/2.0/simde/arm/neon/dot.h
+++ b/2.0/simde/arm/neon/dot.h
@@ -1,0 +1,171 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_DOT_H)
+#define SIMDE_ARM_NEON_DOT_H
+
+#include "types.h"
+
+#include "add.h"
+#include "combine.h"
+#include "dup_n.h"
+#include "get_low.h"
+#include "get_high.h"
+#include "paddl.h"
+#include "movn.h"
+#include "mull.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vdot_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    return vdot_s32(r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde_vadd_s32(r, simde_vmovn_s64(simde_vpaddlq_s32(simde_vpaddlq_s16(simde_vmull_s8(a, b)))));
+  #else
+    simde_int32x2_private r_;
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    for (int i = 0 ; i < 2 ; i++) {
+      int32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+      }
+      r_.values[i] = acc;
+    }
+    return simde_vadd_s32(r, simde_int32x2_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_s32
+  #define vdot_s32(r, a, b) simde_vdot_s32((r), (a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vdot_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    return vdot_u32(r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde_vadd_u32(r, simde_vmovn_u64(simde_vpaddlq_u32(simde_vpaddlq_u16(simde_vmull_u8(a, b)))));
+  #else
+    simde_uint32x2_private r_;
+    simde_uint8x8_private
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    for (int i = 0 ; i < 2 ; i++) {
+      uint32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+      }
+      r_.values[i] = acc;
+    }
+    return simde_vadd_u32(r, simde_uint32x2_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_u32
+  #define vdot_u32(r, a, b) simde_vdot_u32((r), (a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vdotq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    return vdotq_s32(r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde_vaddq_s32(r,
+                           simde_vcombine_s32(simde_vmovn_s64(simde_vpaddlq_s32(simde_vpaddlq_s16(simde_vmull_s8(simde_vget_low_s8(a), simde_vget_low_s8(b))))),
+                                                              simde_vmovn_s64(simde_vpaddlq_s32(simde_vpaddlq_s16(simde_vmull_s8(simde_vget_high_s8(a), simde_vget_high_s8(b)))))));
+  #else
+    simde_int32x4_private r_;
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    for (int i = 0 ; i < 4 ; i++) {
+      int32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+      }
+      r_.values[i] = acc;
+    }
+    return simde_vaddq_s32(r, simde_int32x4_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdotq_s32
+  #define vdotq_s32(r, a, b) simde_vdotq_s32((r), (a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vdotq_u32(simde_uint32x4_t r, simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOTPROD)
+    return vdotq_u32(r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde_vaddq_u32(r,
+                           simde_vcombine_u32(simde_vmovn_u64(simde_vpaddlq_u32(simde_vpaddlq_u16(simde_vmull_u8(simde_vget_low_u8(a), simde_vget_low_u8(b))))),
+                                              simde_vmovn_u64(simde_vpaddlq_u32(simde_vpaddlq_u16(simde_vmull_u8(simde_vget_high_u8(a), simde_vget_high_u8(b)))))));
+  #else
+    simde_uint32x4_private r_;
+    simde_uint8x16_private
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+    for (int i = 0 ; i < 4 ; i++) {
+      uint32_t acc = 0;
+      SIMDE_VECTORIZE_REDUCTION(+:acc)
+      for (int j = 0 ; j < 4 ; j++) {
+        const int idx = j + (i << 2);
+        acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+      }
+      r_.values[i] = acc;
+    }
+    return simde_vaddq_u32(r, simde_uint32x4_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdotq_u32
+  #define vdotq_u32(r, a, b) simde_vdotq_u32((r), (a), (b))
+#endif
+
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_DOT_H) */

--- a/2.0/simde/arm/neon/dot_lane.h
+++ b/2.0/simde/arm/neon/dot_lane.h
@@ -1,0 +1,196 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_DOT_LANE_H)
+#define SIMDE_ARM_NEON_DOT_LANE_H
+
+#include "types.h"
+
+#include "add.h"
+#include "combine.h"
+#include "dup_n.h"
+#include "get_low.h"
+#include "get_high.h"
+#include "paddl.h"
+#include "movn.h"
+#include "mull.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vdot_lane_s32(simde_int32x2_t r, simde_int8x8_t a, simde_int8x8_t b, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_int32x2_t result;
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
+    SIMDE_CONSTIFY_2_(vdot_lane_s32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x2_t mask;
+    SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
+    result = vbsl_s32(mask,
+                      vadd_s32(r, vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(a, b))))),
+                      r);
+  #else
+    simde_int32x2_private r_ = simde_int32x2_to_private(simde_vdup_n_s32(0));
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    int32_t acc = 0;
+    SIMDE_VECTORIZE_REDUCTION(+:acc)
+    for (int j = 0 ; j < 4 ; j++) {
+      const int idx = j + (lane << 2);
+      acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+    }
+    r_.values[lane] = acc;
+
+    result = simde_vadd_s32(r, simde_int32x2_from_private(r_));
+    #endif
+  return result;
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_lane_s32
+  #define vdot_lane_s32(r, a, b, lane) simde_vdot_lane_s32((r), (a), (b), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vdot_lane_u32(simde_uint32x2_t r, simde_uint8x8_t a, simde_uint8x8_t b, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_uint32x2_t result;
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
+    SIMDE_CONSTIFY_2_(vdot_lane_u32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x2_t mask;
+    SIMDE_CONSTIFY_2_(vset_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdup_n_u32(0));
+    result = vbsl_u32(mask,
+                      vadd_u32(r, vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(a, b))))),
+                      r);
+  #else
+    simde_uint32x2_private r_ = simde_uint32x2_to_private(simde_vdup_n_u32(0));
+    simde_uint8x8_private
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    uint32_t acc = 0;
+    SIMDE_VECTORIZE_REDUCTION(+:acc)
+    for (int j = 0 ; j < 4 ; j++) {
+      const int idx = j + (lane << 2);
+      acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+    }
+    r_.values[lane] = acc;
+
+    result = simde_vadd_u32(r, simde_uint32x2_from_private(r_));
+    #endif
+  return result;
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_lane_u32
+  #define vdot_lane_u32(r, a, b, lane) simde_vdot_lane_u32((r), (a), (b), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vdot_laneq_s32(simde_int32x4_t r, simde_int8x16_t a, simde_int8x16_t b, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_int32x4_t result;
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
+    SIMDE_CONSTIFY_4_(vdot_laneq_s32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x4_t mask;
+    SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));
+    result = vbslq_s32(mask,
+                       vaddq_s32(r, vcombine_s32(vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(vget_low_s8(a), vget_low_s8(b))))),
+                                                vmovn_s64(vpaddlq_s32(vpaddlq_s16(vmull_s8(vget_high_s8(a), vget_high_s8(b))))))),
+                       r);
+  #else
+    simde_int32x4_private r_ = simde_int32x4_to_private(simde_vdupq_n_s32(0));
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    int32_t acc = 0;
+    SIMDE_VECTORIZE_REDUCTION(+:acc)
+    for (int j = 0 ; j < 4 ; j++) {
+      const int idx = j + (lane << 2);
+      acc += HEDLEY_STATIC_CAST(int32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(int32_t, b_.values[idx]);
+    }
+    r_.values[lane] = acc;
+
+    result = simde_vaddq_s32(r, simde_int32x4_from_private(r_));
+    #endif
+  return result;
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_laneq_s32
+  #define vdot_laneq_s32(r, a, b, lane) simde_vdot_laneq_s32((r), (a), (b), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vdot_laneq_u32(simde_uint32x4_t r, simde_uint8x16_t a, simde_uint8x16_t b, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_uint32x4_t result;
+  #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && defined(__ARM_FEATURE_DOT_PROD)
+    SIMDE_CONSTIFY_4_(vdot_laneq_u32, result, (HEDLEY_UNCREACHABLE(), result), lane, r, a, b);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x4_t mask;
+    SIMDE_CONSTIFY_4_(vsetq_lane_u32, mask, (HEDLEY_UNREACHABLE(), mask), lane, UINT32_MAX, vdupq_n_u32(0));
+    result = vbslq_u32(mask,
+                       vaddq_u32(r, vcombine_u32(vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(vget_low_u8(a), vget_low_u8(b))))),
+                                                 vmovn_u64(vpaddlq_u32(vpaddlq_u16(vmull_u8(vget_high_u8(a), vget_high_u8(b))))))),
+                       r);
+  #else
+    simde_uint32x4_private r_ = simde_uint32x4_to_private(simde_vdupq_n_u32(0));
+    simde_uint8x16_private
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    uint32_t acc = 0;
+    SIMDE_VECTORIZE_REDUCTION(+:acc)
+    for (int j = 0 ; j < 4 ; j++) {
+      const int idx = j + (lane << 2);
+      acc += HEDLEY_STATIC_CAST(uint32_t, a_.values[idx]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[idx]);
+    }
+    r_.values[lane] = acc;
+
+    result = simde_vaddq_u32(r, simde_uint32x4_from_private(r_));
+    #endif
+  return result;
+}
+#if defined(SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES)
+  #undef vdot_laneq_u32
+  #define vdot_laneq_u32(r, a, b, lane) simde_vdot_laneq_u32((r), (a), (b), (lane))
+#endif
+
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_DOT_LANE_H) */

--- a/2.0/simde/arm/neon/dup_n.h
+++ b/2.0/simde/arm/neon/dup_n.h
@@ -1,0 +1,534 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_DUP_N_H)
+#define SIMDE_ARM_NEON_DUP_N_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vdup_n_f32(float value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_f32(value);
+  #else
+    simde_float32x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_f32
+  #define vdup_n_f32(value) simde_vdup_n_f32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vdup_n_f64(double value) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vdup_n_f64(value);
+  #else
+    simde_float64x1_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_f64
+  #define vdup_n_f64(value) simde_vdup_n_f64((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vdup_n_s8(int8_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_s8(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi8(value);
+  #else
+    simde_int8x8_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_s8
+  #define vdup_n_s8(value) simde_vdup_n_s8((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vdup_n_s16(int16_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_s16(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi16(value);
+  #else
+    simde_int16x4_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_s16
+  #define vdup_n_s16(value) simde_vdup_n_s16((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vdup_n_s32(int32_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_s32(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi32(value);
+  #else
+    simde_int32x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_s32
+  #define vdup_n_s32(value) simde_vdup_n_s32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vdup_n_s64(int64_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_s64(value);
+  #else
+    simde_int64x1_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_s64
+  #define vdup_n_s64(value) simde_vdup_n_s64((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vdup_n_u8(uint8_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_u8(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #else
+    simde_uint8x8_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_u8
+  #define vdup_n_u8(value) simde_vdup_n_u8((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vdup_n_u16(uint16_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_u16(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #else
+    simde_uint16x4_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_u16
+  #define vdup_n_u16(value) simde_vdup_n_u16((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vdup_n_u32(uint32_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_u32(value);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #else
+    simde_uint32x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_u32
+  #define vdup_n_u32(value) simde_vdup_n_u32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vdup_n_u64(uint64_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdup_n_u64(value);
+  #else
+    simde_uint64x1_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdup_n_u64
+  #define vdup_n_u64(value) simde_vdup_n_u64((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vdupq_n_f32(float value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_f32(value);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_set1_ps(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    (void) value;
+    return vec_splats(value);
+  #else
+    simde_float32x4_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_f32
+  #define vdupq_n_f32(value) simde_vdupq_n_f32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vdupq_n_f64(double value) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vdupq_n_f64(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_pd(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    (void) value;
+    return vec_splats(value);
+  #else
+    simde_float64x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_f64
+  #define vdupq_n_f64(value) simde_vdupq_n_f64((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vdupq_n_s8(int8_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_s8(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi8(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_int8x16_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_s8
+  #define vdupq_n_s8(value) simde_vdupq_n_s8((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vdupq_n_s16(int16_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_s16(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi16(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_int16x8_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_s16
+  #define vdupq_n_s16(value) simde_vdupq_n_s16((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vdupq_n_s32(int32_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_s32(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi32(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_int32x4_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_s32
+  #define vdupq_n_s32(value) simde_vdupq_n_s32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vdupq_n_s64(int64_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_s64(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set1_epi64x(value);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_splat(value);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_splats(HEDLEY_STATIC_CAST(signed long long, value));
+  #else
+    simde_int64x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_s64
+  #define vdupq_n_s64(value) simde_vdupq_n_s64((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vdupq_n_u8(uint8_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_u8(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #elif defined (SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_splat(HEDLEY_STATIC_CAST(int8_t, value));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_uint8x16_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_u8
+  #define vdupq_n_u8(value) simde_vdupq_n_u8((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vdupq_n_u16(uint16_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_u16(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #elif defined (SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_splat(HEDLEY_STATIC_CAST(int16_t, value));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_uint16x8_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_u16
+  #define vdupq_n_u16(value) simde_vdupq_n_u16((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vdupq_n_u32(uint32_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_u32(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #elif defined (SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_splat(HEDLEY_STATIC_CAST(int32_t, value));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(value);
+  #else
+    simde_uint32x4_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_u32
+  #define vdupq_n_u32(value) simde_vdupq_n_u32((value))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vdupq_n_u64(uint64_t value) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_u64(value);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+  #elif defined (SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_splat(HEDLEY_STATIC_CAST(int64_t, value));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value));
+  #else
+    simde_uint64x2_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = value;
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vdupq_n_u64
+  #define vdupq_n_u64(value) simde_vdupq_n_u64((value))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_DUP_N_H) */

--- a/2.0/simde/arm/neon/eor.h
+++ b/2.0/simde/arm/neon/eor.h
@@ -1,0 +1,552 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_EOR_H)
+#define SIMDE_ARM_NEON_EOR_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_veor_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_s8
+  #define veor_s8(a, b) simde_veor_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_veor_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_s16
+  #define veor_s16(a, b) simde_veor_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_veor_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_s32
+  #define veor_s32(a, b) simde_veor_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_veor_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_s64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_s64
+  #define veor_s64(a, b) simde_veor_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_veor_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_u8
+  #define veor_u8(a, b) simde_veor_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_veor_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_u16
+  #define veor_u16(a, b) simde_veor_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_veor_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_u32
+  #define veor_u32(a, b) simde_veor_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_veor_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veor_u64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veor_u64
+  #define veor_u64(a, b) simde_veor_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_veorq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_s8
+  #define veorq_s8(a, b) simde_veorq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_veorq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_s16
+  #define veorq_s16(a, b) simde_veorq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_veorq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_s32
+  #define veorq_s32(a, b) simde_veorq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_veorq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_s64
+  #define veorq_s64(a, b) simde_veorq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_veorq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_u8
+  #define veorq_u8(a, b) simde_veorq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_veorq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_u16
+  #define veorq_u16(a, b) simde_veorq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_veorq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_u32
+  #define veorq_u32(a, b) simde_veorq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_veorq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return veorq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_xor(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_xor(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values ^ b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] ^ b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef veorq_u64
+  #define veorq_u64(a, b) simde_veorq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_EOR_H) */

--- a/2.0/simde/arm/neon/ext.h
+++ b/2.0/simde/arm/neon/ext.h
@@ -1,0 +1,887 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_EXT_H)
+#define SIMDE_ARM_NEON_EXT_H
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vext_f32(simde_float32x2_t a, simde_float32x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_float32x2_t r;
+    SIMDE_CONSTIFY_2_(vext_f32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_float32x2_private
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_f32(a, b, n) (__extension__ ({ \
+      simde_float32x2_t simde_vext_f32_r; \
+      if (!__builtin_constant_p(n)) { \
+        simde_vext_f32_r = simde_vext_f32(a, b, n); \
+      } else { \
+        const int simde_vext_f32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_float32x2_private simde_vext_f32_r_; \
+        simde_vext_f32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, simde_float32x2_to_private(a).values, simde_float32x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_f32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_f32_n + 1)); \
+        simde_vext_f32_r = simde_float32x2_from_private(simde_vext_f32_r_); \
+      } \
+      simde_vext_f32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_f32
+  #define vext_f32(a, b, n) simde_vext_f32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vext_f64(simde_float64x1_t a, simde_float64x1_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    (void) n;
+    return vext_f64(a, b, 0);
+  #else
+    simde_float64x1_private
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 0];
+    }
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_f64(a, b, n) (__extension__ ({ \
+      simde_float64x1_t simde_vext_f64_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_f64_r = simde_vext_f64(a, b, n); \
+      } else { \
+        const int simde_vext_f64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_float64x1_private simde_vext_f64_r_; \
+        simde_vext_f64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 8, simde_float64x1_to_private(a).values, simde_float64x1_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_f64_n)); \
+        simde_vext_f64_r = simde_float64x1_from_private(simde_vext_f64_r_); \
+      } \
+      simde_vext_f64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vext_f64
+  #define vext_f64(a, b, n) simde_vext_f64((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vext_s8(simde_int8x8_t a, simde_int8x8_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int8x8_t r;
+    SIMDE_CONSTIFY_8_(vext_s8, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 7];
+    }
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_s8(a, b, n) (__extension__ ({ \
+      simde_int8x8_t simde_vext_s8_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_s8_r = simde_vext_s8(a, b, n); \
+      } else { \
+        const int simde_vext_s8_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int8x8_private simde_vext_s8_r_; \
+        simde_vext_s8_r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, simde_int8x8_to_private(a).values, simde_int8x8_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vext_s8_n + 7)); \
+        simde_vext_s8_r = simde_int8x8_from_private(simde_vext_s8_r_); \
+      } \
+      simde_vext_s8_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_s8
+  #define vext_s8(a, b, n) simde_vext_s8((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vext_s16(simde_int16x4_t a, simde_int16x4_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int16x4_t r;
+    SIMDE_CONSTIFY_4_(vext_s16, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 3];
+    }
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_s16(a, b, n) (__extension__ ({ \
+      simde_int16x4_t simde_vext_s16_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_s16_r = simde_vext_s16(a, b, n); \
+      } else { \
+        const int simde_vext_s16_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int16x4_private simde_vext_s16_r_; \
+        simde_vext_s16_r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, simde_int16x4_to_private(a).values, simde_int16x4_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s16_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_s16_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s16_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vext_s16_n + 3)); \
+        simde_vext_s16_r = simde_int16x4_from_private(simde_vext_s16_r_); \
+      } \
+      simde_vext_s16_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_s16
+  #define vext_s16(a, b, n) simde_vext_s16((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vext_s32(simde_int32x2_t a, simde_int32x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int32x2_t r;
+    SIMDE_CONSTIFY_2_(vext_s32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_s32(a, b, n) (__extension__ ({ \
+      simde_int32x2_t simde_vext_s32_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_s32_r = simde_vext_s32(a, b, n); \
+      } else { \
+        const int simde_vext_s32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int32x2_private simde_vext_s32_r_; \
+        simde_vext_s32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, simde_int32x2_to_private(a).values, simde_int32x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_s32_n + 1)); \
+        simde_vext_s32_r = simde_int32x2_from_private(simde_vext_s32_r_); \
+      } \
+      simde_vext_s32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_s32
+  #define vext_s32(a, b, n) simde_vext_s32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vext_s64(simde_int64x1_t a, simde_int64x1_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) n;
+    return vext_s64(a, b, 0);
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 0];
+    }
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_s64(a, b, n) (__extension__ ({ \
+      simde_int64x1_t simde_vext_s64_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_s64_r = simde_vext_s64(a, b, n); \
+      } else { \
+        const int simde_vext_s64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int64x1_private simde_vext_s64_r_; \
+        simde_vext_s64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 8, simde_int64x1_to_private(a).values, simde_int64x1_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_s64_n + 0)); \
+        simde_vext_s64_r = simde_int64x1_from_private(simde_vext_s64_r_); \
+      } \
+      simde_vext_s64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_s64
+  #define vext_s64(a, b, n) simde_vext_s64((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vext_u8(simde_uint8x8_t a, simde_uint8x8_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint8x8_t r;
+    SIMDE_CONSTIFY_8_(vext_u8, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint8x8_private
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 7];
+    }
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_u8(a, b, n) (__extension__ ({ \
+      simde_uint8x8_t simde_vext_u8_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_u8_r = simde_vext_u8(a, b, n); \
+      } else { \
+        const int simde_vext_u8_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint8x8_private simde_vext_u8_r_; \
+        simde_vext_u8_r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, simde_uint8x8_to_private(a).values, simde_uint8x8_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vext_u8_n + 7)); \
+        simde_vext_u8_r = simde_uint8x8_from_private(simde_vext_u8_r_); \
+      } \
+      simde_vext_u8_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_u8
+  #define vext_u8(a, b, n) simde_vext_u8((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vext_u16(simde_uint16x4_t a, simde_uint16x4_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint16x4_t r;
+    SIMDE_CONSTIFY_4_(vext_u16, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint16x4_private
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 3];
+    }
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_u16(a, b, n) (__extension__ ({ \
+      simde_uint16x4_t simde_vext_u16_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_u16_r = simde_vext_u16(a, b, n); \
+      } else { \
+        const int simde_vext_u16_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint16x4_private simde_vext_u16_r_; \
+        simde_vext_u16_r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, simde_uint16x4_to_private(a).values, simde_uint16x4_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u16_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_u16_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u16_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vext_u16_n + 3)); \
+        simde_vext_u16_r = simde_uint16x4_from_private(simde_vext_u16_r_); \
+      } \
+      simde_vext_u16_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_u16
+  #define vext_u16(a, b, n) simde_vext_u16((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vext_u32(simde_uint32x2_t a, simde_uint32x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x2_t r;
+    SIMDE_CONSTIFY_2_(vext_u32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint32x2_private
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_u32(a, b, n) (__extension__ ({ \
+      simde_uint32x2_t simde_vext_u32_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_u32_r = simde_vext_u32(a, b, n); \
+      } else { \
+        const int simde_vext_u32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint32x2_private simde_vext_u32_r_; \
+        simde_vext_u32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, simde_uint32x2_to_private(a).values, simde_uint32x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vext_u32_n + 1)); \
+        simde_vext_u32_r = simde_uint32x2_from_private(simde_vext_u32_r_); \
+      } \
+      simde_vext_u32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_u32
+  #define vext_u32(a, b, n) simde_vext_u32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vext_u64(simde_uint64x1_t a, simde_uint64x1_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) n;
+    return vext_u64(a, b, 0);
+  #else
+    simde_uint64x1_private
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 0];
+    }
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vext_u64(a, b, n) (__extension__ ({ \
+      simde_uint64x1_t simde_vext_u64_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vext_u64_r = simde_vext_u64(a, b, n); \
+      } else { \
+        const int simde_vext_u64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint64x1_private simde_vext_u64_r_; \
+        simde_vext_u64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 8, simde_uint64x1_to_private(a).values, simde_uint64x1_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vext_u64_n + 0)); \
+        simde_vext_u64_r = simde_uint64x1_from_private(simde_vext_u64_r_); \
+      } \
+      simde_vext_u64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vext_u64
+  #define vext_u64(a, b, n) simde_vext_u64((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vextq_f32(simde_float32x4_t a, simde_float32x4_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_float32x4_t r;
+    SIMDE_CONSTIFY_4_(vextq_f32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_float32x4_private
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 3];
+    }
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_f32(a, b, n) (__extension__ ({ \
+      simde_float32x4_t simde_vextq_f32_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_f32_r = simde_vextq_f32(a, b, n); \
+      } else { \
+        const int simde_vextq_f32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_float32x4_private simde_vextq_f32_r_; \
+        simde_vextq_f32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, simde_float32x4_to_private(a).values, simde_float32x4_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_f32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_f32_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_f32_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_f32_n + 3)); \
+        simde_vextq_f32_r = simde_float32x4_from_private(simde_vextq_f32_r_); \
+      } \
+      simde_vextq_f32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_f32
+  #define vextq_f32(a, b, n) simde_vextq_f32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vextq_f64(simde_float64x2_t a, simde_float64x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    simde_float64x2_t r;
+    SIMDE_CONSTIFY_2_(vextq_f64, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_float64x2_private
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_f64(a, b, n) (__extension__ ({ \
+      simde_float64x2_t simde_vextq_f64_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_f64_r = simde_vextq_f64(a, b, n); \
+      } else { \
+        const int simde_vextq_f64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_float64x2_private simde_vextq_f64_r_; \
+        simde_vextq_f64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, simde_float64x2_to_private(a).values, simde_float64x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_f64_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_f64_n + 1)); \
+        simde_vextq_f64_r = simde_float64x2_from_private(simde_vextq_f64_r_); \
+      } \
+      simde_vextq_f64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vextq_f64
+  #define vextq_f64(a, b, n) simde_vextq_f64((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vextq_s8(simde_int8x16_t a, simde_int8x16_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int8x16_t r;
+    SIMDE_CONSTIFY_16_(vextq_s8, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 15];
+    }
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_s8(a, b, n) (__extension__ ({ \
+      simde_int8x16_t simde_vextq_s8_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_s8_r = simde_vextq_s8(a, b, n); \
+      } else { \
+        const int simde_vextq_s8_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int8x16_private simde_vextq_s8_r_; \
+        simde_vextq_s8_r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, simde_int8x16_to_private(a).values, simde_int8x16_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 7), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 8), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 9), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 10), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 11), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 12), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 13), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 14), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s8_n + 15)); \
+        simde_vextq_s8_r = simde_int8x16_from_private(simde_vextq_s8_r_); \
+      } \
+      simde_vextq_s8_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_s8
+  #define vextq_s8(a, b, n) simde_vextq_s8((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vextq_s16(simde_int16x8_t a, simde_int16x8_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int16x8_t r;
+    SIMDE_CONSTIFY_8_(vextq_s16, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 7];
+    }
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_s16(a, b, n) (__extension__ ({ \
+      simde_int16x8_t simde_vextq_s16_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_s16_r = simde_vextq_s16(a, b, n); \
+      } else { \
+        const int simde_vextq_s16_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int16x8_private simde_vextq_s16_r_; \
+        simde_vextq_s16_r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, simde_int16x8_to_private(a).values, simde_int16x8_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s16_n + 7)); \
+        simde_vextq_s16_r = simde_int16x8_from_private(simde_vextq_s16_r_); \
+      } \
+      simde_vextq_s16_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_s16
+  #define vextq_s16(a, b, n) simde_vextq_s16((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vextq_s32(simde_int32x4_t a, simde_int32x4_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int32x4_t r;
+    SIMDE_CONSTIFY_4_(vextq_s32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 3];
+    }
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_s32(a, b, n) (__extension__ ({ \
+      simde_int32x4_t simde_vextq_s32_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_s32_r = simde_vextq_s32(a, b, n); \
+      } else { \
+        const int simde_vextq_s32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int32x4_private simde_vextq_s32_r_; \
+        simde_vextq_s32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, simde_int32x4_to_private(a).values, simde_int32x4_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s32_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s32_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s32_n + 3)); \
+        simde_vextq_s32_r = simde_int32x4_from_private(simde_vextq_s32_r_); \
+      } \
+      simde_vextq_s32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_s32
+  #define vextq_s32(a, b, n) simde_vextq_s32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vextq_s64(simde_int64x2_t a, simde_int64x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_int64x2_t r;
+    SIMDE_CONSTIFY_2_(vextq_s64, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_s64(a, b, n) (__extension__ ({ \
+      simde_int64x2_t simde_vextq_s64_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_s64_r = simde_vextq_s64(a, b, n); \
+      } else { \
+        const int simde_vextq_s64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_int64x2_private simde_vextq_s64_r_; \
+        simde_vextq_s64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, simde_int64x2_to_private(a).values, simde_int64x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_s64_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_s64_n + 1)); \
+        simde_vextq_s64_r = simde_int64x2_from_private(simde_vextq_s64_r_); \
+      } \
+      simde_vextq_s64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_s64
+  #define vextq_s64(a, b, n) simde_vextq_s64((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vextq_u8(simde_uint8x16_t a, simde_uint8x16_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint8x16_t r;
+    SIMDE_CONSTIFY_16_(vextq_u8, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint8x16_private
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 15];
+    }
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_u8(a, b, n) (__extension__ ({ \
+      simde_uint8x16_t simde_vextq_u8_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_u8_r = simde_vextq_u8(a, b, n); \
+      } else { \
+        const int simde_vextq_u8_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint8x16_private simde_vextq_u8_r_; \
+        simde_vextq_u8_r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, simde_uint8x16_to_private(a).values, simde_uint8x16_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 7), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 8), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 9), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 10), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 11), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 12), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 13), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 14), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u8_n + 15)); \
+        simde_vextq_u8_r = simde_uint8x16_from_private(simde_vextq_u8_r_); \
+      } \
+      simde_vextq_u8_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_u8
+  #define vextq_u8(a, b, n) simde_vextq_u8((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vextq_u16(simde_uint16x8_t a, simde_uint16x8_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint16x8_t r;
+    SIMDE_CONSTIFY_8_(vextq_u16, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint16x8_private
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 7];
+    }
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_u16(a, b, n) (__extension__ ({ \
+      simde_uint16x8_t simde_vextq_u16_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_u16_r = simde_vextq_u16(a, b, n); \
+      } else { \
+        const int simde_vextq_u16_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint16x8_private simde_vextq_u16_r_; \
+        simde_vextq_u16_r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, simde_uint16x8_to_private(a).values, simde_uint16x8_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 3), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 4), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 5), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 6), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u16_n + 7)); \
+        simde_vextq_u16_r = simde_uint16x8_from_private(simde_vextq_u16_r_); \
+      } \
+      simde_vextq_u16_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_u16
+  #define vextq_u16(a, b, n) simde_vextq_u16((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vextq_u32(simde_uint32x4_t a, simde_uint32x4_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint32x4_t r;
+    SIMDE_CONSTIFY_4_(vextq_u32, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint32x4_private
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 3];
+    }
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_u32(a, b, n) (__extension__ ({ \
+      simde_uint32x4_t simde_vextq_u32_r; \
+      if (!__builtin_constant_p(n)) { \
+         simde_vextq_u32_r = simde_vextq_u32(a, b, n); \
+      } else { \
+        const int simde_vextq_u32_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint32x4_private simde_vextq_u32_r_; \
+        simde_vextq_u32_r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, simde_uint32x4_to_private(a).values, simde_uint32x4_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u32_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u32_n + 1), \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u32_n + 2), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u32_n + 3)); \
+        simde_vextq_u32_r = simde_uint32x4_from_private(simde_vextq_u32_r_); \
+      } \
+      simde_vextq_u32_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_u32
+  #define vextq_u32(a, b, n) simde_vextq_u32((a), (b), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vextq_u64(simde_uint64x2_t a, simde_uint64x2_t b, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde_uint64x2_t r;
+    SIMDE_CONSTIFY_2_(vextq_u64, r, (HEDLEY_UNREACHABLE(), a), n, a, b);
+    return r;
+  #else
+    simde_uint64x2_private
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b),
+      r_ = a_;
+    const size_t n_ = HEDLEY_STATIC_CAST(size_t, n);
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      size_t src = i + n_;
+      r_.values[i] = (src < (sizeof(r_.values) / sizeof(r_.values[0]))) ? a_.values[src] : b_.values[src & 1];
+    }
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_vextq_u64(a, b, n) (__extension__ ({ \
+      simde_uint64x2_t simde_vextq_u64_r; \
+      if (!__builtin_constant_p(n)) { \
+        simde_vextq_u64_r = simde_vextq_u64(a, b, n);        \
+      } else { \
+        const int simde_vextq_u64_n = HEDLEY_STATIC_CAST(int8_t, n); \
+        simde_uint64x2_private simde_vextq_u64_r_; \
+        simde_vextq_u64_r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, simde_uint64x2_to_private(a).values, simde_uint64x2_to_private(b).values, \
+          HEDLEY_STATIC_CAST(int8_t, simde_vextq_u64_n + 0), HEDLEY_STATIC_CAST(int8_t, simde_vextq_u64_n + 1)); \
+        simde_vextq_u64_r = simde_uint64x2_from_private(simde_vextq_u64_r_); \
+      } \
+      simde_vextq_u64_r; \
+    }))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vextq_u64
+  #define vextq_u64(a, b, n) simde_vextq_u64((a), (b), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_EXT_H) */

--- a/2.0/simde/arm/neon/get_high.h
+++ b/2.0/simde/arm/neon/get_high.h
@@ -1,0 +1,260 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_GET_HIGH_H)
+#define SIMDE_ARM_NEON_GET_HIGH_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vget_high_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_f32(a);
+  #else
+    simde_float32x2_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_f32
+  #define vget_high_f32(a) simde_vget_high_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vget_high_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vget_high_f64(a);
+  #else
+    simde_float64x1_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_f64
+  #define vget_high_f64(a) simde_vget_high_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vget_high_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_s8(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_s8
+  #define vget_high_s8(a) simde_vget_high_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vget_high_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_s16(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_s16
+  #define vget_high_s16(a) simde_vget_high_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vget_high_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_s32(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_s32
+  #define vget_high_s32(a) simde_vget_high_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vget_high_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_s64(a);
+  #else
+    simde_int64x1_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_s64
+  #define vget_high_s64(a) simde_vget_high_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vget_high_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_u8(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_u8
+  #define vget_high_u8(a) simde_vget_high_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vget_high_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_u16(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_u16
+  #define vget_high_u16(a) simde_vget_high_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vget_high_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_u32(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_u32
+  #define vget_high_u32(a) simde_vget_high_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vget_high_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_high_u64(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i + (sizeof(r_.values) / sizeof(r_.values[0]))];
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_high_u64
+  #define vget_high_u64(a) simde_vget_high_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_GET_HIGH_H) */

--- a/2.0/simde/arm/neon/get_lane.h
+++ b/2.0/simde/arm/neon/get_lane.h
@@ -1,0 +1,499 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_GET_LANE_H)
+#define SIMDE_ARM_NEON_GET_LANE_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32_t
+simde_vget_lane_f32(simde_float32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_float32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vget_lane_f32, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT32_C(0.0)), lane, v);
+  #else
+    simde_float32x2_private v_ = simde_float32x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_f32
+  #define vget_lane_f32(v, lane) simde_vget_lane_f32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64_t
+simde_vget_lane_f64(simde_float64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  simde_float64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    (void) lane;
+    return vget_lane_f64(v, 0);
+  #else
+    simde_float64x1_private v_ = simde_float64x1_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_f64
+  #define vget_lane_f64(v, lane) simde_vget_lane_f64((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int8_t
+simde_vget_lane_s8(simde_int8x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  int8_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vget_lane_s8, r, (HEDLEY_UNREACHABLE(), INT8_C(0)), lane, v);
+  #else
+    simde_int8x8_private v_ = simde_int8x8_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_s8
+  #define vget_lane_s8(v, lane) simde_vget_lane_s8((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_vget_lane_s16(simde_int16x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  int16_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vget_lane_s16, r, (HEDLEY_UNREACHABLE(), INT16_C(0)), lane, v);
+  #else
+    simde_int16x4_private v_ = simde_int16x4_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_s16
+  #define vget_lane_s16(v, lane) simde_vget_lane_s16((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vget_lane_s32(simde_int32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  int32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vget_lane_s32, r, (HEDLEY_UNREACHABLE(), INT32_C(0)), lane, v);
+  #else
+    simde_int32x2_private v_ = simde_int32x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_s32
+  #define vget_lane_s32(v, lane) simde_vget_lane_s32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_vget_lane_s64(simde_int64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  int64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    return vget_lane_s64(v, 0);
+  #else
+    simde_int64x1_private v_ = simde_int64x1_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_s64
+  #define vget_lane_s64(v, lane) simde_vget_lane_s64((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_vget_lane_u8(simde_uint8x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  uint8_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vget_lane_u8, r, (HEDLEY_UNREACHABLE(), UINT8_C(0)), lane, v);
+  #else
+    simde_uint8x8_private v_ = simde_uint8x8_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_u8
+  #define vget_lane_u8(v, lane) simde_vget_lane_u8((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint16_t
+simde_vget_lane_u16(simde_uint16x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  uint16_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vget_lane_u16, r, (HEDLEY_UNREACHABLE(), UINT16_C(0)), lane, v);
+  #else
+    simde_uint16x4_private v_ = simde_uint16x4_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_u16
+  #define vget_lane_u16(v, lane) simde_vget_lane_u16((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vget_lane_u32(simde_uint32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  uint32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vget_lane_u32, r, (HEDLEY_UNREACHABLE(), UINT32_C(0)), lane, v);
+  #else
+    simde_uint32x2_private v_ = simde_uint32x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_u32
+  #define vget_lane_u32(v, lane) simde_vget_lane_u32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vget_lane_u64(simde_uint64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  uint64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    return vget_lane_u64(v, 0);
+  #else
+    simde_uint64x1_private v_ = simde_uint64x1_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_lane_u64
+  #define vget_lane_u64(v, lane) simde_vget_lane_u64((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32_t
+simde_vgetq_lane_f32(simde_float32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_float32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vgetq_lane_f32, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT32_C(0.0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_CONSTIFY_4_(wasm_f32x4_extract_lane, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT32_C(0.0)), lane, v);
+  #else
+    simde_float32x4_private v_ = simde_float32x4_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_f32
+  #define vgetq_lane_f32(v, lane) simde_vgetq_lane_f32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64_t
+simde_vgetq_lane_f64(simde_float64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_float64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_CONSTIFY_2_(vgetq_lane_f64, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT64_C(0.0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_CONSTIFY_2_(wasm_f64x2_extract_lane, r, (HEDLEY_UNREACHABLE(), SIMDE_FLOAT64_C(0.0)), lane, v);
+  #else
+    simde_float64x2_private v_ = simde_float64x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_f64
+  #define vgetq_lane_f64(v, lane) simde_vgetq_lane_f64((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int8_t
+simde_vgetq_lane_s8(simde_int8x16_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  int8_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_(vgetq_lane_s8, r, (HEDLEY_UNREACHABLE(), INT8_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_16_(wasm_i8x16_extract_lane, r_, (HEDLEY_UNREACHABLE(), INT8_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(int8_t, r_);
+  #else
+    simde_int8x16_private v_ = simde_int8x16_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_s8
+  #define vgetq_lane_s8(v, lane) simde_vgetq_lane_s8((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_vgetq_lane_s16(simde_int16x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  int16_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vgetq_lane_s16, r, (HEDLEY_UNREACHABLE(), INT16_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_8_(wasm_i16x8_extract_lane, r_, (HEDLEY_UNREACHABLE(), INT16_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(int16_t, r_);
+  #else
+    simde_int16x8_private v_ = simde_int16x8_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_s16
+  #define vgetq_lane_s16(v, lane) simde_vgetq_lane_s16((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vgetq_lane_s32(simde_int32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  int32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vgetq_lane_s32, r, (HEDLEY_UNREACHABLE(), INT32_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_4_(wasm_i32x4_extract_lane, r_, (HEDLEY_UNREACHABLE(), INT32_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(int32_t, r_);
+  #else
+    simde_int32x4_private v_ = simde_int32x4_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_s32
+  #define vgetq_lane_s32(v, lane) simde_vgetq_lane_s32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_vgetq_lane_s64(simde_int64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  int64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vgetq_lane_s64, r, (HEDLEY_UNREACHABLE(), INT64_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    long long r_;
+    SIMDE_CONSTIFY_2_(wasm_i64x2_extract_lane, r_, (HEDLEY_UNREACHABLE(), INT64_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(int64_t, r_);
+  #else
+    simde_int64x2_private v_ = simde_int64x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_s64
+  #define vgetq_lane_s64(v, lane) simde_vgetq_lane_s64((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_vgetq_lane_u8(simde_uint8x16_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  uint8_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_(vgetq_lane_u8, r, (HEDLEY_UNREACHABLE(), UINT8_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_16_(wasm_i8x16_extract_lane, r_, (HEDLEY_UNREACHABLE(), UINT8_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(uint8_t, r_);
+  #else
+    simde_uint8x16_private v_ = simde_uint8x16_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_u8
+  #define vgetq_lane_u8(v, lane) simde_vgetq_lane_u8((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint16_t
+simde_vgetq_lane_u16(simde_uint16x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  uint16_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vgetq_lane_u16, r, (HEDLEY_UNREACHABLE(), UINT16_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_8_(wasm_i16x8_extract_lane, r_, (HEDLEY_UNREACHABLE(), UINT16_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(uint16_t, r_);
+  #else
+    simde_uint16x8_private v_ = simde_uint16x8_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_u16
+  #define vgetq_lane_u16(v, lane) simde_vgetq_lane_u16((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vgetq_lane_u32(simde_uint32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  uint32_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vgetq_lane_u32, r, (HEDLEY_UNREACHABLE(), UINT32_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    int r_;
+    SIMDE_CONSTIFY_4_(wasm_i32x4_extract_lane, r_, (HEDLEY_UNREACHABLE(), UINT32_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(uint32_t, r_);
+  #else
+    simde_uint32x4_private v_ = simde_uint32x4_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_u32
+  #define vgetq_lane_u32(v, lane) simde_vgetq_lane_u32((v), (lane))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_vgetq_lane_u64(simde_uint64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  uint64_t r;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vgetq_lane_u64, r, (HEDLEY_UNREACHABLE(), UINT64_C(0)), lane, v);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    long long r_;
+    SIMDE_CONSTIFY_2_(wasm_i64x2_extract_lane, r_, (HEDLEY_UNREACHABLE(), UINT64_C(0)), lane, v);
+    r = HEDLEY_STATIC_CAST(uint64_t, r_);
+  #else
+    simde_uint64x2_private v_ = simde_uint64x2_to_private(v);
+
+    r = v_.values[lane];
+  #endif
+
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vgetq_lane_u64
+  #define vgetq_lane_u64(v, lane) simde_vgetq_lane_u64((v), (lane))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_GET_LANE_H) */

--- a/2.0/simde/arm/neon/get_low.h
+++ b/2.0/simde/arm/neon/get_low.h
@@ -1,0 +1,276 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_GET_LOW_H)
+#define SIMDE_ARM_NEON_GET_LOW_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vget_low_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_f32(a);
+  #else
+    simde_float32x2_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_f32
+  #define vget_low_f32(a) simde_vget_low_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vget_low_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vget_low_f64(a);
+  #else
+    simde_float64x1_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_f64
+  #define vget_low_f64(a) simde_vget_low_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vget_low_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_s8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_s8
+  #define vget_low_s8(a) simde_vget_low_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vget_low_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_s16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_s16
+  #define vget_low_s16(a) simde_vget_low_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vget_low_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_s32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_s32
+  #define vget_low_s32(a) simde_vget_low_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vget_low_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_s64(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_int64x1_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_s64
+  #define vget_low_s64(a) simde_vget_low_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vget_low_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_u8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_u8
+  #define vget_low_u8(a) simde_vget_low_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vget_low_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_u16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_u16
+  #define vget_low_u16(a) simde_vget_low_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vget_low_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_u32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_u32
+  #define vget_low_u32(a) simde_vget_low_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vget_low_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vget_low_u64(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i];
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vget_low_u64
+  #define vget_low_u64(a) simde_vget_low_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_GET_LOW_H) */

--- a/2.0/simde/arm/neon/ld1.h
+++ b/2.0/simde/arm/neon/ld1.h
@@ -1,0 +1,420 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_LD1_H)
+#define SIMDE_ARM_NEON_LD1_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vld1_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_f32(ptr);
+  #else
+    simde_float32x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_f32
+  #define vld1_f32(a) simde_vld1_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vld1_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(1)]) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld1_f64(ptr);
+  #else
+    simde_float64x1_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld1_f64
+  #define vld1_f64(a) simde_vld1_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vld1_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_s8(ptr);
+  #else
+    simde_int8x8_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_s8
+  #define vld1_s8(a) simde_vld1_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vld1_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_s16(ptr);
+  #else
+    simde_int16x4_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_s16
+  #define vld1_s16(a) simde_vld1_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vld1_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_s32(ptr);
+  #else
+    simde_int32x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_s32
+  #define vld1_s32(a) simde_vld1_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vld1_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_s64(ptr);
+  #else
+    simde_int64x1_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_s64
+  #define vld1_s64(a) simde_vld1_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vld1_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_u8(ptr);
+  #else
+    simde_uint8x8_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_u8
+  #define vld1_u8(a) simde_vld1_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vld1_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_u16(ptr);
+  #else
+    simde_uint16x4_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_u16
+  #define vld1_u16(a) simde_vld1_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vld1_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_u32(ptr);
+  #else
+    simde_uint32x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_u32
+  #define vld1_u32(a) simde_vld1_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vld1_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(1)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1_u64(ptr);
+  #else
+    simde_uint64x1_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1_u64
+  #define vld1_u64(a) simde_vld1_u64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vld1q_f32(simde_float32 const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_f32(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_ps(ptr);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, HEDLEY_REINTERPRET_CAST(const float*, ptr));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_float32x4_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_f32
+  #define vld1q_f32(a) simde_vld1q_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vld1q_f64(simde_float64 const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld1q_f64(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_pd(ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_float64x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_f64
+  #define vld1q_f64(a) simde_vld1q_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vld1q_s8(int8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_s8(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_int8x16_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_s8
+  #define vld1q_s8(a) simde_vld1q_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vld1q_s16(int16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_s16(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_int16x8_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_s16
+  #define vld1q_s16(a) simde_vld1q_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vld1q_s32(int32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_s32(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_int32x4_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_s32
+  #define vld1q_s32(a) simde_vld1q_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vld1q_s64(int64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_s64(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_int64x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_s64
+  #define vld1q_s64(a) simde_vld1q_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vld1q_u8(uint8_t const ptr[HEDLEY_ARRAY_PARAM(16)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_u8(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_uint8x16_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_u8
+  #define vld1q_u8(a) simde_vld1q_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vld1q_u16(uint16_t const ptr[HEDLEY_ARRAY_PARAM(8)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_u16(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_uint16x8_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_u16
+  #define vld1q_u16(a) simde_vld1q_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vld1q_u32(uint32_t const ptr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_u32(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    (void) ptr;
+    return vec_ld(0, ptr);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_uint32x4_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_u32
+  #define vld1q_u32(a) simde_vld1q_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vld1q_u64(uint64_t const ptr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld1q_u64(ptr);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(const __m128i*, ptr));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_load(ptr);
+  #else
+    simde_uint64x2_private r_;
+    simde_memcpy(&r_, ptr, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld1q_u64
+  #define vld1q_u64(a) simde_vld1q_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_LD1_H) */

--- a/2.0/simde/arm/neon/ld3.h
+++ b/2.0/simde/arm/neon/ld3.h
@@ -1,0 +1,425 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_LD3_H)
+#define SIMDE_ARM_NEON_LD3_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2x3_t
+simde_vld3_f32(simde_float32 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_f32(ptr);
+  #else
+    simde_float32x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_float32x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_float32x2x3_t s_ = { { simde_float32x2_from_private(a_[0]), simde_float32x2_from_private(a_[1]), simde_float32x2_from_private(a_[2]) } };
+    return (s_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_f32
+  #define vld3_f32(a) simde_vld3_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1x3_t
+simde_vld3_f64(simde_float64 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld3_f64(ptr);
+  #else
+    simde_float64x1_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_float64x1_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_float64x1x3_t s_ = { { simde_float64x1_from_private(a_[0]), simde_float64x1_from_private(a_[1]), simde_float64x1_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3_f64
+  #define vld3_f64(a) simde_vld3_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8x3_t
+simde_vld3_s8(int8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_s8(ptr);
+  #else
+    simde_int8x8_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int8x8_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int8x8x3_t s_ = { { simde_int8x8_from_private(a_[0]), simde_int8x8_from_private(a_[1]), simde_int8x8_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_s8
+  #define vld3_s8(a) simde_vld3_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4x3_t
+simde_vld3_s16(int16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_s16(ptr);
+  #else
+    simde_int16x4_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int16x4_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int16x4x3_t s_ = { { simde_int16x4_from_private(a_[0]), simde_int16x4_from_private(a_[1]), simde_int16x4_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_s16
+  #define vld3_s16(a) simde_vld3_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2x3_t
+simde_vld3_s32(int32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_s32(ptr);
+  #else
+    simde_int32x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int32x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int32x2x3_t s_ = { { simde_int32x2_from_private(a_[0]), simde_int32x2_from_private(a_[1]), simde_int32x2_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_s32
+  #define vld3_s32(a) simde_vld3_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1x3_t
+simde_vld3_s64(int64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_s64(ptr);
+  #else
+    simde_int64x1_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int64x1_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int64x1x3_t s_ = { { simde_int64x1_from_private(a_[0]), simde_int64x1_from_private(a_[1]), simde_int64x1_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3_s64
+  #define vld3_s64(a) simde_vld3_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8x3_t
+simde_vld3_u8(uint8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_u8(ptr);
+  #else
+    simde_uint8x8_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint8x8_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint8x8x3_t s_ = { { simde_uint8x8_from_private(a_[0]), simde_uint8x8_from_private(a_[1]), simde_uint8x8_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_u8
+  #define vld3_u8(a) simde_vld3_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4x3_t
+simde_vld3_u16(uint16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_u16(ptr);
+  #else
+    simde_uint16x4_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint16x4_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint16x4x3_t s_ = { { simde_uint16x4_from_private(a_[0]), simde_uint16x4_from_private(a_[1]), simde_uint16x4_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_u16
+  #define vld3_u16(a) simde_vld3_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2x3_t
+simde_vld3_u32(uint32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_u32(ptr);
+  #else
+    simde_uint32x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint32x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint32x2x3_t s_ = { { simde_uint32x2_from_private(a_[0]), simde_uint32x2_from_private(a_[1]), simde_uint32x2_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3_u32
+  #define vld3_u32(a) simde_vld3_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1x3_t
+simde_vld3_u64(uint64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3_u64(ptr);
+  #else
+    simde_uint64x1_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint64x1_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint64x1x3_t s_ = { { simde_uint64x1_from_private(a_[0]), simde_uint64x1_from_private(a_[1]), simde_uint64x1_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3_u64
+  #define vld3_u64(a) simde_vld3_u64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4x3_t
+simde_vld3q_f32(simde_float32 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_f32(ptr);
+  #else
+    simde_float32x4_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_float32x4_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_float32x4x3_t s_ = { { simde_float32x4_from_private(a_[0]), simde_float32x4_from_private(a_[1]), simde_float32x4_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_f32
+  #define vld3q_f32(a) simde_vld3q_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2x3_t
+simde_vld3q_f64(simde_float64 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld3q_f64(ptr);
+  #else
+    simde_float64x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_float64x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_float64x2x3_t s_ = { { simde_float64x2_from_private(a_[0]), simde_float64x2_from_private(a_[1]), simde_float64x2_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_f64
+  #define vld3q_f64(a) simde_vld3q_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16x3_t
+simde_vld3q_s8(int8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_s8(ptr);
+  #else
+    simde_int8x16_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int8x16_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int8x16x3_t s_ = { { simde_int8x16_from_private(a_[0]), simde_int8x16_from_private(a_[1]), simde_int8x16_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_s8
+  #define vld3q_s8(a) simde_vld3q_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8x3_t
+simde_vld3q_s16(int16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_s16(ptr);
+  #else
+    simde_int16x8_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int16x8_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int16x8x3_t s_ = { { simde_int16x8_from_private(a_[0]), simde_int16x8_from_private(a_[1]), simde_int16x8_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_s16
+  #define vld3q_s16(a) simde_vld3q_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4x3_t
+simde_vld3q_s32(int32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_s32(ptr);
+  #else
+    simde_int32x4_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int32x4_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int32x4x3_t s_ = { { simde_int32x4_from_private(a_[0]), simde_int32x4_from_private(a_[1]), simde_int32x4_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_s32
+  #define vld3q_s32(a) simde_vld3q_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2x3_t
+simde_vld3q_s64(int64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld3q_s64(ptr);
+  #else
+    simde_int64x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_int64x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_int64x2x3_t s_ = { { simde_int64x2_from_private(a_[0]), simde_int64x2_from_private(a_[1]), simde_int64x2_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_s64
+  #define vld3q_s64(a) simde_vld3q_s64((a))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16x3_t
+simde_vld3q_u8(uint8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_u8(ptr);
+  #else
+    simde_uint8x16_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint8x16_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint8x16x3_t s_ = { { simde_uint8x16_from_private(a_[0]), simde_uint8x16_from_private(a_[1]), simde_uint8x16_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_u8
+  #define vld3q_u8(a) simde_vld3q_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8x3_t
+simde_vld3q_u16(uint16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_u16(ptr);
+  #else
+    simde_uint16x8_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint16x8_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint16x8x3_t s_ = { { simde_uint16x8_from_private(a_[0]), simde_uint16x8_from_private(a_[1]), simde_uint16x8_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_u16
+  #define vld3q_u16(a) simde_vld3q_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4x3_t
+simde_vld3q_u32(uint32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld3q_u32(ptr);
+  #else
+    simde_uint32x4_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint32x4_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint32x4x3_t s_ = { { simde_uint32x4_from_private(a_[0]), simde_uint32x4_from_private(a_[1]), simde_uint32x4_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_u32
+  #define vld3q_u32(a) simde_vld3q_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2x3_t
+simde_vld3q_u64(uint64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld3q_u64(ptr);
+  #else
+    simde_uint64x2_private a_[3];
+    for (size_t i = 0; i < (sizeof(simde_uint64x2_t) / sizeof(*ptr)) * 3 ; i++) {
+      a_[i % 3].values[i / 3] = ptr[i];
+    }
+    simde_uint64x2x3_t s_ = { { simde_uint64x2_from_private(a_[0]), simde_uint64x2_from_private(a_[1]), simde_uint64x2_from_private(a_[2]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld3q_u64
+  #define vld3q_u64(a) simde_vld3q_u64((a))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_LD3_H) */

--- a/2.0/simde/arm/neon/ld4.h
+++ b/2.0/simde/arm/neon/ld4.h
@@ -1,0 +1,445 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_LD4_H)
+#define SIMDE_ARM_NEON_LD4_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2x4_t
+simde_vld4_f32(simde_float32 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_f32(ptr);
+  #else
+    simde_float32x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_float32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_float32x2x4_t s_ = { { simde_float32x2_from_private(a_[0]), simde_float32x2_from_private(a_[1]),
+                                 simde_float32x2_from_private(a_[2]), simde_float32x2_from_private(a_[3]) } };
+    return (s_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_f32
+  #define vld4_f32(a) simde_vld4_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1x4_t
+simde_vld4_f64(simde_float64 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld4_f64(ptr);
+  #else
+    simde_float64x1_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_float64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_float64x1x4_t s_ = { { simde_float64x1_from_private(a_[0]), simde_float64x1_from_private(a_[1]),
+                                 simde_float64x1_from_private(a_[2]), simde_float64x1_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4_f64
+  #define vld4_f64(a) simde_vld4_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8x4_t
+simde_vld4_s8(int8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_s8(ptr);
+  #else
+    simde_int8x8_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int8x8_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int8x8x4_t s_ = { { simde_int8x8_from_private(a_[0]), simde_int8x8_from_private(a_[1]),
+                              simde_int8x8_from_private(a_[2]), simde_int8x8_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_s8
+  #define vld4_s8(a) simde_vld4_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4x4_t
+simde_vld4_s16(int16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_s16(ptr);
+  #else
+    simde_int16x4_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int16x4_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int16x4x4_t s_ = { { simde_int16x4_from_private(a_[0]), simde_int16x4_from_private(a_[1]),
+                               simde_int16x4_from_private(a_[2]), simde_int16x4_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_s16
+  #define vld4_s16(a) simde_vld4_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2x4_t
+simde_vld4_s32(int32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_s32(ptr);
+  #else
+    simde_int32x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int32x2x4_t s_ = { { simde_int32x2_from_private(a_[0]), simde_int32x2_from_private(a_[1]),
+                               simde_int32x2_from_private(a_[2]), simde_int32x2_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_s32
+  #define vld4_s32(a) simde_vld4_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1x4_t
+simde_vld4_s64(int64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_s64(ptr);
+  #else
+    simde_int64x1_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int64x1x4_t s_ = { { simde_int64x1_from_private(a_[0]), simde_int64x1_from_private(a_[1]),
+                               simde_int64x1_from_private(a_[2]), simde_int64x1_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4_s64
+  #define vld4_s64(a) simde_vld4_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8x4_t
+simde_vld4_u8(uint8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_u8(ptr);
+  #else
+    simde_uint8x8_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint8x8_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint8x8x4_t s_ = { { simde_uint8x8_from_private(a_[0]), simde_uint8x8_from_private(a_[1]),
+                               simde_uint8x8_from_private(a_[2]), simde_uint8x8_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_u8
+  #define vld4_u8(a) simde_vld4_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4x4_t
+simde_vld4_u16(uint16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_u16(ptr);
+  #else
+    simde_uint16x4_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint16x4_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint16x4x4_t s_ = { { simde_uint16x4_from_private(a_[0]), simde_uint16x4_from_private(a_[1]),
+                                simde_uint16x4_from_private(a_[2]), simde_uint16x4_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_u16
+  #define vld4_u16(a) simde_vld4_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2x4_t
+simde_vld4_u32(uint32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_u32(ptr);
+  #else
+    simde_uint32x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint32x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint32x2x4_t s_ = { { simde_uint32x2_from_private(a_[0]), simde_uint32x2_from_private(a_[1]),
+                                simde_uint32x2_from_private(a_[2]), simde_uint32x2_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4_u32
+  #define vld4_u32(a) simde_vld4_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1x4_t
+simde_vld4_u64(uint64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4_u64(ptr);
+  #else
+    simde_uint64x1_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint64x1_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint64x1x4_t s_ = { { simde_uint64x1_from_private(a_[0]), simde_uint64x1_from_private(a_[1]),
+                                simde_uint64x1_from_private(a_[2]), simde_uint64x1_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4_u64
+  #define vld4_u64(a) simde_vld4_u64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4x4_t
+simde_vld4q_f32(simde_float32 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_f32(ptr);
+  #else
+    simde_float32x4_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_float32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_float32x4x4_t s_ = { { simde_float32x4_from_private(a_[0]), simde_float32x4_from_private(a_[1]),
+                                 simde_float32x4_from_private(a_[2]), simde_float32x4_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_f32
+  #define vld4q_f32(a) simde_vld4q_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2x4_t
+simde_vld4q_f64(simde_float64 const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld4q_f64(ptr);
+  #else
+    simde_float64x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_float64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_float64x2x4_t s_ = { { simde_float64x2_from_private(a_[0]), simde_float64x2_from_private(a_[1]),
+                                 simde_float64x2_from_private(a_[2]), simde_float64x2_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_f64
+  #define vld4q_f64(a) simde_vld4q_f64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16x4_t
+simde_vld4q_s8(int8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_s8(ptr);
+  #else
+    simde_int8x16_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int8x16_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int8x16x4_t s_ = { { simde_int8x16_from_private(a_[0]), simde_int8x16_from_private(a_[1]),
+                               simde_int8x16_from_private(a_[2]), simde_int8x16_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_s8
+  #define vld4q_s8(a) simde_vld4q_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8x4_t
+simde_vld4q_s16(int16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_s16(ptr);
+  #else
+    simde_int16x8_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int16x8_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int16x8x4_t s_ = { { simde_int16x8_from_private(a_[0]), simde_int16x8_from_private(a_[1]),
+                               simde_int16x8_from_private(a_[2]), simde_int16x8_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_s16
+  #define vld4q_s16(a) simde_vld4q_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4x4_t
+simde_vld4q_s32(int32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_s32(ptr);
+  #else
+    simde_int32x4_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int32x4x4_t s_ = { { simde_int32x4_from_private(a_[0]), simde_int32x4_from_private(a_[1]),
+                               simde_int32x4_from_private(a_[2]), simde_int32x4_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_s32
+  #define vld4q_s32(a) simde_vld4q_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2x4_t
+simde_vld4q_s64(int64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld4q_s64(ptr);
+  #else
+    simde_int64x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_int64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_int64x2x4_t s_ = { { simde_int64x2_from_private(a_[0]), simde_int64x2_from_private(a_[1]),
+                               simde_int64x2_from_private(a_[2]), simde_int64x2_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_s64
+  #define vld4q_s64(a) simde_vld4q_s64((a))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16x4_t
+simde_vld4q_u8(uint8_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_u8(ptr);
+  #else
+    simde_uint8x16_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint8x16_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint8x16x4_t s_ = { { simde_uint8x16_from_private(a_[0]), simde_uint8x16_from_private(a_[1]),
+                                simde_uint8x16_from_private(a_[2]), simde_uint8x16_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_u8
+  #define vld4q_u8(a) simde_vld4q_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8x4_t
+simde_vld4q_u16(uint16_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_u16(ptr);
+  #else
+    simde_uint16x8_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint16x8_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint16x8x4_t s_ = { { simde_uint16x8_from_private(a_[0]), simde_uint16x8_from_private(a_[1]),
+                                simde_uint16x8_from_private(a_[2]), simde_uint16x8_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_u16
+  #define vld4q_u16(a) simde_vld4q_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4x4_t
+simde_vld4q_u32(uint32_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vld4q_u32(ptr);
+  #else
+    simde_uint32x4_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint32x4_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint32x4x4_t s_ = { { simde_uint32x4_from_private(a_[0]), simde_uint32x4_from_private(a_[1]),
+                                simde_uint32x4_from_private(a_[2]), simde_uint32x4_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_u32
+  #define vld4q_u32(a) simde_vld4q_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2x4_t
+simde_vld4q_u64(uint64_t const *ptr) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld4q_u64(ptr);
+  #else
+    simde_uint64x2_private a_[4];
+    for (size_t i = 0; i < (sizeof(simde_uint64x2_t) / sizeof(*ptr)) * 4 ; i++) {
+      a_[i % 4].values[i / 4] = ptr[i];
+    }
+    simde_uint64x2x4_t s_ = { { simde_uint64x2_from_private(a_[0]), simde_uint64x2_from_private(a_[1]),
+                                simde_uint64x2_from_private(a_[2]), simde_uint64x2_from_private(a_[3]) } };
+    return s_;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vld4q_u64
+  #define vld4q_u64(a) simde_vld4q_u64((a))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_LD4_H) */

--- a/2.0/simde/arm/neon/max.h
+++ b/2.0/simde/arm/neon/max.h
@@ -1,0 +1,590 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MAX_H)
+#define SIMDE_ARM_NEON_MAX_H
+
+#include "types.h"
+#include "cgt.h"
+#include "bsl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmax_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_f32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_f32(simde_vcgt_f32(a, b), a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_f32
+  #define vmax_f32(a, b) simde_vmax_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vmax_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmax_f64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_f64(simde_vcgt_f64(a, b), a, b);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmax_f64
+  #define vmax_f64(a, b) simde_vmax_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmax_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_s8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s8(simde_vcgt_s8(a, b), a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_s8
+  #define vmax_s8(a, b) simde_vmax_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmax_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s16(simde_vcgt_s16(a, b), a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_s16
+  #define vmax_s16(a, b) simde_vmax_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmax_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_s32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s32(simde_vcgt_s32(a, b), a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_s32
+  #define vmax_s32(a, b) simde_vmax_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_x_vmax_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s64(simde_vcgt_s64(a, b), a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmax_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_u8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u8(simde_vcgt_u8(a, b), a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_u8
+  #define vmax_u8(a, b) simde_vmax_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmax_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u16(simde_vcgt_u16(a, b), a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_u16
+  #define vmax_u16(a, b) simde_vmax_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmax_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmax_u32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u32(simde_vcgt_u32(a, b), a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmax_u32
+  #define vmax_u32(a, b) simde_vmax_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_x_vmax_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u64(simde_vcgt_u64(a, b), a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vmaxq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_max_ps(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_f32(simde_vcgtq_f32(a, b), a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_f32
+  #define vmaxq_f32(a, b) simde_vmaxq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vmaxq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmaxq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_pd(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_f64(simde_vcgtq_f64(a, b), a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_f64
+  #define vmaxq_f64(a, b) simde_vmaxq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vmaxq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s8(simde_vcgtq_s8(a, b), a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_s8
+  #define vmaxq_s8(a, b) simde_vmaxq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmaxq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s16(simde_vcgtq_s16(a, b), a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_s16
+  #define vmaxq_s16(a, b) simde_vmaxq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmaxq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s32(simde_vcgtq_s32(a, b), a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_s32
+  #define vmaxq_s32(a, b) simde_vmaxq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_x_vmaxq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s64(simde_vcgtq_s64(a, b), a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vmaxq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epu8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u8(simde_vcgtq_u8(a, b), a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_u8
+  #define vmaxq_u8(a, b) simde_vmaxq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmaxq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epu16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u16(simde_vcgtq_u16(a, b), a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_u16
+  #define vmaxq_u16(a, b) simde_vmaxq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmaxq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmaxq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epu32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_max(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u32(simde_vcgtq_u32(a, b), a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmaxq_u32
+  #define vmaxq_u32(a, b) simde_vmaxq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_x_vmaxq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_max(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u64(simde_vcgtq_u64(a, b), a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] > b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MAX_H) */

--- a/2.0/simde/arm/neon/min.h
+++ b/2.0/simde/arm/neon/min.h
@@ -1,0 +1,660 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_MIN_H)
+#define SIMDE_ARM_NEON_MIN_H
+
+#include "types.h"
+#include "cgt.h"
+#include "ceq.h"
+#include "bsl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmin_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_f32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(64)
+    simde_float32x2_t r = simde_vbsl_f32(simde_vcgt_f32(b, a), a, b);
+
+    #if !defined(SIMDE_FAST_NANS)
+      r = simde_vbsl_f32(simde_vceq_f32(a, a), simde_vbsl_f32(simde_vceq_f32(b, b), r, b), a);
+    #endif
+
+    return r;
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      #if !defined(SIMDE_FAST_NANS)
+        if (simde_math_isnanf(a_.values[i])) {
+          r_.values[i] = a_.values[i];
+        } else if (simde_math_isnanf(b_.values[i])) {
+          r_.values[i] = b_.values[i];
+        } else {
+          r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+        }
+      #else
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+      #endif
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_f32
+  #define vmin_f32(a, b) simde_vmin_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vmin_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmin_f64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(64)
+    simde_float64x1_t r = simde_vbsl_f64(simde_vcgt_f64(b, a), a, b);
+
+    #if !defined(SIMDE_FAST_NANS)
+      r = simde_vbsl_f64(simde_vceq_f64(a, a), simde_vbsl_f64(simde_vceq_f64(b, b), r, b), a);
+    #endif
+
+    return r;
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      #if !defined(SIMDE_FAST_NANS)
+        if (simde_math_isnan(a_.values[i])) {
+          r_.values[i] = a_.values[i];
+        } else if (simde_math_isnan(b_.values[i])) {
+          r_.values[i] = b_.values[i];
+        } else {
+          r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+        }
+      #else
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+      #endif
+    }
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmin_f64
+  #define vmin_f64(a, b) simde_vmin_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmin_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_s8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s8(simde_vcgt_s8(b, a), a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_s8
+  #define vmin_s8(a, b) simde_vmin_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmin_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s16(simde_vcgt_s16(b, a), a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_s16
+  #define vmin_s16(a, b) simde_vmin_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmin_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_s32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s32(simde_vcgt_s32(b, a), a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_s32
+  #define vmin_s32(a, b) simde_vmin_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_x_vmin_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_s64(simde_vcgt_s64(b, a), a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmin_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_u8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u8(simde_vcgt_u8(b, a), a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_u8
+  #define vmin_u8(a, b) simde_vmin_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmin_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u16(simde_vcgt_u16(b, a), a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_u16
+  #define vmin_u16(a, b) simde_vmin_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmin_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmin_u32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u32(simde_vcgt_u32(b, a), a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmin_u32
+  #define vmin_u32(a, b) simde_vmin_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_x_vmin_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbsl_u64(simde_vcgt_u64(b, a), a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vminq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_FAST_NANS)
+    return _mm_min_ps(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_ps(_mm_set1_ps(SIMDE_MATH_NANF), _mm_min_ps(a, b), _mm_cmpord_ps(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_FAST_NANS)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    simde_float32x4_t r = simde_vbslq_f32(simde_vcgtq_f32(b, a), a, b);
+
+    #if !defined(SIMDE_FAST_NANS)
+      r = simde_vbslq_f32(simde_vceqq_f32(a, a), simde_vbslq_f32(simde_vceqq_f32(b, b), r, b), a);
+    #endif
+
+    return r;
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      #if !defined(SIMDE_FAST_NANS)
+        if (simde_math_isnanf(a_.values[i])) {
+          r_.values[i] = a_.values[i];
+        } else if (simde_math_isnanf(b_.values[i])) {
+          r_.values[i] = b_.values[i];
+        } else {
+          r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+        }
+      #else
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+      #endif
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_f32
+  #define vminq_f32(a, b) simde_vminq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vminq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vminq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_FAST_NANS)
+    return _mm_min_pd(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_pd(_mm_set1_pd(SIMDE_MATH_NAN), _mm_min_pd(a, b), _mm_cmpord_pd(a, b));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && defined(SIMDE_FAST_NANS)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    simde_float64x2_t r = simde_vbslq_f64(simde_vcgtq_f64(b, a), a, b);
+
+    #if !defined(SIMDE_FAST_NANS)
+      r = simde_vbslq_f64(simde_vceqq_f64(a, a), simde_vbslq_f64(simde_vceqq_f64(b, b), r, b), a);
+    #endif
+
+    return r;
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      #if !defined(SIMDE_FAST_NANS)
+        if (simde_math_isnan(a_.values[i])) {
+          r_.values[i] = a_.values[i];
+        } else if (simde_math_isnan(b_.values[i])) {
+          r_.values[i] = b_.values[i];
+        } else {
+          r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+        }
+      #else
+        r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+      #endif
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vminq_f64
+  #define vminq_f64(a, b) simde_vminq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vminq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s8(simde_vcgtq_s8(b, a), a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_s8
+  #define vminq_s8(a, b) simde_vminq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vminq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s16(simde_vcgtq_s16(b, a), a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_s16
+  #define vminq_s16(a, b) simde_vminq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vminq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s32(simde_vcgtq_s32(b, a), a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_s32
+  #define vminq_s32(a, b) simde_vminq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_x_vminq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_min_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_s64(simde_vcgtq_s64(b, a), a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vminq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epu8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u8(simde_vcgtq_u8(b, a), a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_u8
+  #define vminq_u8(a, b) simde_vminq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vminq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epu16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u16(simde_vcgtq_u16(b, a), a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_u16
+  #define vminq_u16(a, b) simde_vminq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vminq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vminq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epu32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_min(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u32(simde_vcgtq_u32(b, a), a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vminq_u32
+  #define vminq_u32(a, b) simde_vminq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_x_vminq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_min(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vbslq_u64(simde_vcgtq_u64(b, a), a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (a_.values[i] < b_.values[i]) ? a_.values[i] : b_.values[i];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MIN_H) */

--- a/2.0/simde/arm/neon/mla.h
+++ b/2.0/simde/arm/neon/mla.h
@@ -1,0 +1,530 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MLA_H)
+#define SIMDE_ARM_NEON_MLA_H
+
+#include "types.h"
+#include "add.h"
+#include "mul.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmla_f32(simde_float32x2_t a, simde_float32x2_t b, simde_float32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_f32(a, b, c);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b),
+      c_ = simde_float32x2_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_f32
+  #define vmla_f32(a, b, c) simde_vmla_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vmla_f64(simde_float64x1_t a, simde_float64x1_t b, simde_float64x1_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmla_f64(a, b, c);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b),
+      c_ = simde_float64x1_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmla_f64
+  #define vmla_f64(a, b, c) simde_vmla_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmla_s8(simde_int8x8_t a, simde_int8x8_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_s8(a, b, c);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b),
+      c_ = simde_int8x8_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_s8
+  #define vmla_s8(a, b, c) simde_vmla_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmla_s16(simde_int16x4_t a, simde_int16x4_t b, simde_int16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_s16(a, b, c);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b),
+      c_ = simde_int16x4_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_s16
+  #define vmla_s16(a, b, c) simde_vmla_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmla_s32(simde_int32x2_t a, simde_int32x2_t b, simde_int32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_s32(a, b, c);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b),
+      c_ = simde_int32x2_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_s32
+  #define vmla_s32(a, b, c) simde_vmla_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmla_u8(simde_uint8x8_t a, simde_uint8x8_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_u8(a, b, c);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b),
+      c_ = simde_uint8x8_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_u8
+  #define vmla_u8(a, b, c) simde_vmla_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmla_u16(simde_uint16x4_t a, simde_uint16x4_t b, simde_uint16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_u16(a, b, c);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b),
+      c_ = simde_uint16x4_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_u16
+  #define vmla_u16(a, b, c) simde_vmla_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmla_u32(simde_uint32x2_t a, simde_uint32x2_t b, simde_uint32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_u32(a, b, c);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b),
+      c_ = simde_uint32x2_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_u32
+  #define vmla_u32(a, b, c) simde_vmla_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vmlaq_f32(simde_float32x4_t a, simde_float32x4_t b, simde_float32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_f32(a, b, c);
+  #elif defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_ps(b, c, a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_madd(b, c, a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_f32(simde_vmulq_f32(b, c), a);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b),
+      c_ = simde_float32x4_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_f32
+  #define vmlaq_f32(a, b, c) simde_vmlaq_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vmlaq_f64(simde_float64x2_t a, simde_float64x2_t b, simde_float64x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlaq_f64(a, b, c);
+  #elif defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_pd(b, c, a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_madd(b, c, a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_f64(simde_vmulq_f64(b, c), a);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b),
+      c_ = simde_float64x2_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_f64
+  #define vmlaq_f64(a, b, c) simde_vmlaq_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vmlaq_s8(simde_int8x16_t a, simde_int8x16_t b, simde_int8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_s8(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_s8(simde_vmulq_s8(b, c), a);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b),
+      c_ = simde_int8x16_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_s8
+  #define vmlaq_s8(a, b, c) simde_vmlaq_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmlaq_s16(simde_int16x8_t a, simde_int16x8_t b, simde_int16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_s16(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_s16(simde_vmulq_s16(b, c), a);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b),
+      c_ = simde_int16x8_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_s16
+  #define vmlaq_s16(a, b, c) simde_vmlaq_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmlaq_s32(simde_int32x4_t a, simde_int32x4_t b, simde_int32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_s32(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_s32(simde_vmulq_s32(b, c), a);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b),
+      c_ = simde_int32x4_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_s32
+  #define vmlaq_s32(a, b, c) simde_vmlaq_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vmlaq_u8(simde_uint8x16_t a, simde_uint8x16_t b, simde_uint8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_u8(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_u8(simde_vmulq_u8(b, c), a);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b),
+      c_ = simde_uint8x16_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_u8
+  #define vmlaq_u8(a, b, c) simde_vmlaq_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmlaq_u16(simde_uint16x8_t a, simde_uint16x8_t b, simde_uint16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_u16(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_u16(simde_vmulq_u16(b, c), a);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b),
+      c_ = simde_uint16x8_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_u16
+  #define vmlaq_u16(a, b, c) simde_vmlaq_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmlaq_u32(simde_uint32x4_t a, simde_uint32x4_t b, simde_uint32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_u32(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_u32(simde_vmulq_u32(b, c), a);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b),
+      c_ = simde_uint32x4_to_private(c);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_u32
+  #define vmlaq_u32(a, b, c) simde_vmlaq_u32((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MLA_H) */

--- a/2.0/simde/arm/neon/mla_n.h
+++ b/2.0/simde/arm/neon/mla_n.h
@@ -1,0 +1,333 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MLA_N_H)
+#define SIMDE_ARM_NEON_MLA_N_H
+
+#include "types.h"
+#include "add.h"
+#include "mul.h"
+#include "mul_n.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmla_n_f32(simde_float32x2_t a, simde_float32x2_t b, simde_float32 c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_n_f32(a, b, c);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_n_f32
+  #define vmla_n_f32(a, b, c) simde_vmla_n_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmla_n_s16(simde_int16x4_t a, simde_int16x4_t b, int16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_n_s16(a, b, c);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_n_s16
+  #define vmla_n_s16(a, b, c) simde_vmla_n_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmla_n_s32(simde_int32x2_t a, simde_int32x2_t b, int32_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_n_s32(a, b, c);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_n_s32
+  #define vmla_n_s32(a, b, c) simde_vmla_n_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmla_n_u16(simde_uint16x4_t a, simde_uint16x4_t b, uint16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_n_u16(a, b, c);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_n_u16
+  #define vmla_n_u16(a, b, c) simde_vmla_n_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmla_n_u32(simde_uint32x2_t a, simde_uint32x2_t b, uint32_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmla_n_u32(a, b, c);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmla_n_u32
+  #define vmla_n_u32(a, b, c) simde_vmla_n_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vmlaq_n_f32(simde_float32x4_t a, simde_float32x4_t b, simde_float32 c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_n_f32(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_f32(simde_vmulq_n_f32(b, c), a);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_n_f32
+  #define vmlaq_n_f32(a, b, c) simde_vmlaq_n_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmlaq_n_s16(simde_int16x8_t a, simde_int16x8_t b, int16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_n_s16(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_s16(simde_vmulq_n_s16(b, c), a);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_n_s16
+  #define vmlaq_n_s16(a, b, c) simde_vmlaq_n_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmlaq_n_s32(simde_int32x4_t a, simde_int32x4_t b, int32_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_n_s32(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_s32(simde_vmulq_n_s32(b, c), a);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_n_s32
+  #define vmlaq_n_s32(a, b, c) simde_vmlaq_n_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmlaq_n_u16(simde_uint16x8_t a, simde_uint16x8_t b, uint16_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_n_u16(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_u16(simde_vmulq_n_u16(b, c), a);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_n_u16
+  #define vmlaq_n_u16(a, b, c) simde_vmlaq_n_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmlaq_n_u32(simde_uint32x4_t a, simde_uint32x4_t b, uint32_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlaq_n_u32(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    return simde_vaddq_u32(simde_vmulq_n_u32(b, c), a);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (b_.values * c) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlaq_n_u32
+  #define vmlaq_n_u32(a, b, c) simde_vmlaq_n_u32((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MLA_N_H) */

--- a/2.0/simde/arm/neon/mlal.h
+++ b/2.0/simde/arm/neon/mlal.h
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MLAL_H)
+#define SIMDE_ARM_NEON_MLAL_H
+
+#include "movl.h"
+#include "mla.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmlal_s8(simde_int16x8_t a, simde_int8x8_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_s8(a, b, c);
+  #else
+    return simde_vmlaq_s16(a, simde_vmovl_s8(b), simde_vmovl_s8(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_s8
+  #define vmlal_s8(a, b, c) simde_vmlal_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmlal_s16(simde_int32x4_t a, simde_int16x4_t b, simde_int16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_s16(a, b, c);
+  #else
+    return simde_vmlaq_s32(a, simde_vmovl_s16(b), simde_vmovl_s16(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_s16
+  #define vmlal_s16(a, b, c) simde_vmlal_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmlal_s32(simde_int64x2_t a, simde_int32x2_t b, simde_int32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_s32(a, b, c);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(simde_vmovl_s32(b)),
+      c_ = simde_int64x2_to_private(simde_vmovl_s32(c));
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_s32
+  #define vmlal_s32(a, b, c) simde_vmlal_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmlal_u8(simde_uint16x8_t a, simde_uint8x8_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_u8(a, b, c);
+  #else
+    return simde_vmlaq_u16(a, simde_vmovl_u8(b), simde_vmovl_u8(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_u8
+  #define vmlal_u8(a, b, c) simde_vmlal_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmlal_u16(simde_uint32x4_t a, simde_uint16x4_t b, simde_uint16x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_u16(a, b, c);
+  #else
+    return simde_vmlaq_u32(a, simde_vmovl_u16(b), simde_vmovl_u16(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_u16
+  #define vmlal_u16(a, b, c) simde_vmlal_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmlal_u32(simde_uint64x2_t a, simde_uint32x2_t b, simde_uint32x2_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmlal_u32(a, b, c);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(simde_vmovl_u32(b)),
+      c_ = simde_uint64x2_to_private(simde_vmovl_u32(c));
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_u32
+  #define vmlal_u32(a, b, c) simde_vmlal_u32((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MLAL_H) */

--- a/2.0/simde/arm/neon/mlal_high.h
+++ b/2.0/simde/arm/neon/mlal_high.h
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MLAL_HIGH_H)
+#define SIMDE_ARM_NEON_MLAL_HIGH_H
+
+#include "movl_high.h"
+#include "mla.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmlal_high_s8(simde_int16x8_t a, simde_int8x16_t b, simde_int8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_s8(a, b, c);
+  #else
+    return simde_vmlaq_s16(a, simde_vmovl_high_s8(b), simde_vmovl_high_s8(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_s8
+  #define vmlal_high_s8(a, b, c) simde_vmlal_high_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmlal_high_s16(simde_int32x4_t a, simde_int16x8_t b, simde_int16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_s16(a, b, c);
+  #else
+    return simde_vmlaq_s32(a, simde_vmovl_high_s16(b), simde_vmovl_high_s16(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_s16
+  #define vmlal_high_s16(a, b, c) simde_vmlal_high_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmlal_high_s32(simde_int64x2_t a, simde_int32x4_t b, simde_int32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_s32(a, b, c);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(simde_vmovl_high_s32(b)),
+      c_ = simde_int64x2_to_private(simde_vmovl_high_s32(c));
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_s32
+  #define vmlal_high_s32(a, b, c) simde_vmlal_high_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmlal_high_u8(simde_uint16x8_t a, simde_uint8x16_t b, simde_uint8x16_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_u8(a, b, c);
+  #else
+    return simde_vmlaq_u16(a, simde_vmovl_high_u8(b), simde_vmovl_high_u8(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_u8
+  #define vmlal_high_u8(a, b, c) simde_vmlal_high_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmlal_high_u16(simde_uint32x4_t a, simde_uint16x8_t b, simde_uint16x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_u16(a, b, c);
+  #else
+    return simde_vmlaq_u32(a, simde_vmovl_high_u16(b), simde_vmovl_high_u16(c));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_u16
+  #define vmlal_high_u16(a, b, c) simde_vmlal_high_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmlal_high_u32(simde_uint64x2_t a, simde_uint32x4_t b, simde_uint32x4_t c) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmlal_high_u32(a, b, c);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(simde_vmovl_high_u32(b)),
+      c_ = simde_uint64x2_to_private(simde_vmovl_high_u32(c));
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = (b_.values * c_.values) + a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (b_.values[i] * c_.values[i]) + a_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmlal_high_u32
+  #define vmlal_high_u32(a, b, c) simde_vmlal_high_u32((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MLAL_HIGH_H) */

--- a/2.0/simde/arm/neon/movl.h
+++ b/2.0/simde/arm/neon/movl.h
@@ -1,0 +1,208 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MOVL_H)
+#define SIMDE_ARM_NEON_MOVL_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmovl_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_s8(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_load_8x8(&a);
+  #else
+    simde_int16x8_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_s8
+  #define vmovl_s8(a) simde_vmovl_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmovl_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_s16(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_load_16x4(&a);
+  #else
+    simde_int32x4_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_s16
+  #define vmovl_s16(a) simde_vmovl_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmovl_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_s32(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_load_32x2(&a);
+  #else
+    simde_int64x2_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int64_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_s32
+  #define vmovl_s32(a) simde_vmovl_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmovl_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_u8(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_load_8x8(&a);
+  #else
+    simde_uint16x8_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_u8
+  #define vmovl_u8(a) simde_vmovl_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmovl_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_u16(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u32x4_load_16x4(&a);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_u16
+  #define vmovl_u16(a) simde_vmovl_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmovl_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovl_u32(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u64x2_load_32x2(&a);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint64_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_u32
+  #define vmovl_u32(a) simde_vmovl_u32((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MOVL_H) */

--- a/2.0/simde/arm/neon/movl_high.h
+++ b/2.0/simde/arm/neon/movl_high.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MOVL_HIGH_H)
+#define SIMDE_ARM_NEON_MOVL_HIGH_H
+
+#include "types.h"
+#include "movl.h"
+#include "get_high.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmovl_high_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_s8(a);
+  #else
+    return simde_vmovl_s8(simde_vget_high_s8(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_s8
+  #define vmovl_high_s8(a) simde_vmovl_high_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmovl_high_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_s16(a);
+  #else
+    return simde_vmovl_s16(simde_vget_high_s16(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_s16
+  #define vmovl_high_s16(a) simde_vmovl_high_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmovl_high_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_s32(a);
+  #else
+    return simde_vmovl_s32(simde_vget_high_s32(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_s32
+  #define vmovl_high_s32(a) simde_vmovl_high_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmovl_high_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_u8(a);
+  #else
+    return simde_vmovl_u8(simde_vget_high_u8(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_u8
+  #define vmovl_high_u8(a) simde_vmovl_high_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmovl_high_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_u16(a);
+  #else
+    return simde_vmovl_u16(simde_vget_high_u16(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_u16
+  #define vmovl_high_u16(a) simde_vmovl_high_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmovl_high_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmovl_high_u32(a);
+  #else
+    return simde_vmovl_u32(simde_vget_high_u32(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmovl_high_u32
+  #define vmovl_high_u32(a) simde_vmovl_high_u32((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MOVL_HIGH_H) */

--- a/2.0/simde/arm/neon/movn.h
+++ b/2.0/simde/arm/neon/movn.h
@@ -1,0 +1,195 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_MOVN_H)
+#define SIMDE_ARM_NEON_MOVN_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmovn_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_s16(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int8_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_s16
+  #define vmovn_s16(a) simde_vmovn_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmovn_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_s32(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_s32
+  #define vmovn_s32(a) simde_vmovn_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmovn_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_s64(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_s64
+  #define vmovn_s64(a) simde_vmovn_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmovn_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_u16(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_u16
+  #define vmovn_u16(a) simde_vmovn_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmovn_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_u32(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_u32
+  #define vmovn_u32(a) simde_vmovn_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmovn_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmovn_u64(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.values, a_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i]);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmovn_u64
+  #define vmovn_u64(a) simde_vmovn_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MOVN_H) */

--- a/2.0/simde/arm/neon/mul.h
+++ b/2.0/simde/arm/neon/mul.h
@@ -1,0 +1,507 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MUL_H)
+#define SIMDE_ARM_NEON_MUL_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmul_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_f32
+  #define vmul_f32(a, b) simde_vmul_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vmul_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmul_f64(a, b);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmul_f64
+  #define vmul_f64(a, b) simde_vmul_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmul_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_s8
+  #define vmul_s8(a, b) simde_vmul_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmul_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _m_pmullw(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_s16
+  #define vmul_s16(a, b) simde_vmul_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmul_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_s32
+  #define vmul_s32(a, b) simde_vmul_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmul_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_u8
+  #define vmul_u8(a, b) simde_vmul_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmul_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_u16
+  #define vmul_u16(a, b) simde_vmul_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmul_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_u32
+  #define vmul_u32(a, b) simde_vmul_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vmulq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_mul_ps(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_mul(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_f32
+  #define vmulq_f32(a, b) simde_vmulq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vmulq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmulq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_pd(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_mul(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_f64
+  #define vmulq_f64(a, b) simde_vmulq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vmulq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_s8
+  #define vmulq_s8(a, b) simde_vmulq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmulq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mullo_epi16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_s16
+  #define vmulq_s16(a, b) simde_vmulq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmulq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_s32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_mul(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_s32
+  #define vmulq_s32(a, b) simde_vmulq_s32((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vmulq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_u8(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_u8
+  #define vmulq_u8(a, b) simde_vmulq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmulq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_mul(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_u16
+  #define vmulq_u16(a, b) simde_vmulq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmulq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_mul(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values * b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_u32
+  #define vmulq_u32(a, b) simde_vmulq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MUL_H) */

--- a/2.0/simde/arm/neon/mul_n.h
+++ b/2.0/simde/arm/neon/mul_n.h
@@ -1,0 +1,383 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MUL_N_H)
+#define SIMDE_ARM_NEON_MUL_N_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vmul_n_f32(simde_float32x2_t a, simde_float32 b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_n_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_f32
+  #define vmul_n_f32(a, b) simde_vmul_n_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vmul_n_f64(simde_float64x1_t a, simde_float64 b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmul_n_f64(a, b);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_f64
+  #define vmul_n_f64(a, b) simde_vmul_n_f64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmul_n_s16(simde_int16x4_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_n_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _m_pmullw(a, _mm_set1_pi16(b));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_s16
+  #define vmul_n_s16(a, b) simde_vmul_n_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmul_n_s32(simde_int32x2_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_n_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_s32
+  #define vmul_n_s32(a, b) simde_vmul_n_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmul_n_u16(simde_uint16x4_t a, uint16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_n_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_u16
+  #define vmul_n_u16(a, b) simde_vmul_n_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmul_n_u32(simde_uint32x2_t a, uint32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmul_n_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmul_n_u32
+  #define vmul_n_u32(a, b) simde_vmul_n_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vmulq_n_f32(simde_float32x4_t a, simde_float32 b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_n_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_mul_ps(a, _mm_set1_ps(b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_mul(a, wasm_f32x4_splat(b));
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_f32
+  #define vmulq_n_f32(a, b) simde_vmulq_n_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vmulq_n_f64(simde_float64x2_t a, simde_float64 b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmulq_n_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_pd(a, _mm_set1_pd(b));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_mul(a, wasm_f64x2_splat(b));
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_f64
+  #define vmulq_n_f64(a, b) simde_vmulq_n_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmulq_n_s16(simde_int16x8_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_n_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mullo_epi16(a, _mm_set1_epi16(b));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_s16
+  #define vmulq_n_s16(a, b) simde_vmulq_n_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmulq_n_s32(simde_int32x4_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_n_s32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_mul(a, wasm_i32x4_splat(b));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_s32
+  #define vmulq_n_s32(a, b) simde_vmulq_n_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmulq_n_u16(simde_uint16x8_t a, uint16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_n_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_mul(a, wasm_i16x8_splat(HEDLEY_STATIC_CAST(int16_t, b)));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_u16
+  #define vmulq_n_u16(a, b) simde_vmulq_n_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmulq_n_u32(simde_uint32x4_t a, uint32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmulq_n_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_mul(a, wasm_i32x4_splat(HEDLEY_STATIC_CAST(int32_t, b)));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] * b;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmulq_n_u32
+  #define vmulq_n_u32(a, b) simde_vmulq_n_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MUL_N_H) */

--- a/2.0/simde/arm/neon/mull.h
+++ b/2.0/simde/arm/neon/mull.h
@@ -1,0 +1,236 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MULL_H)
+#define SIMDE_ARM_NEON_MULL_H
+
+#include "types.h"
+#include "mul.h"
+#include "movl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmull_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_s8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_s16(simde_vmovl_s8(a), simde_vmovl_s8(b));
+  #else
+    simde_int16x8_private r_;
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i]) * HEDLEY_STATIC_CAST(int16_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_s8
+  #define vmull_s8(a, b) simde_vmull_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmull_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_s32(simde_vmovl_s16(a), simde_vmovl_s16(b));
+  #else
+    simde_int32x4_private r_;
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i]) * HEDLEY_STATIC_CAST(int32_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_s16
+  #define vmull_s16(a, b) simde_vmull_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmull_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_s32(a, b);
+  #else
+    simde_int64x2_private r_;
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int64_t, a_.values[i]) * HEDLEY_STATIC_CAST(int64_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_s32
+  #define vmull_s32(a, b) simde_vmull_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmull_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_u8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_u16(simde_vmovl_u8(a), simde_vmovl_u8(b));
+  #else
+    simde_uint16x8_private r_;
+    simde_uint8x8_private
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, a_.values[i]) * HEDLEY_STATIC_CAST(uint16_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_u8
+  #define vmull_u8(a, b) simde_vmull_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmull_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_u32(simde_vmovl_u16(a), simde_vmovl_u16(b));
+  #else
+    simde_uint32x4_private r_;
+    simde_uint16x4_private
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_u16
+  #define vmull_u16(a, b) simde_vmull_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmull_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_u32(a, b);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint32x2_private
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      __typeof__(r_.values) av, bv;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      SIMDE_CONVERT_VECTOR_(bv, b_.values);
+      r_.values = av * bv;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint64_t, a_.values[i]) * HEDLEY_STATIC_CAST(uint64_t, b_.values[i]);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_u32
+  #define vmull_u32(a, b) simde_vmull_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MULL_H) */

--- a/2.0/simde/arm/neon/mull_n.h
+++ b/2.0/simde/arm/neon/mull_n.h
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_MULL_N_H)
+#define SIMDE_ARM_NEON_MULL_N_H
+
+#include "types.h"
+#include "mul_n.h"
+#include "movl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmull_n_s16(simde_int16x4_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_n_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_n_s32(simde_vmovl_s16(a), b);
+  #else
+    simde_int32x4_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) av;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      r_.values = av * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i]) * HEDLEY_STATIC_CAST(int32_t, b);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_n_s16
+  #define vmull_n_s16(a, b) simde_vmull_n_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vmull_n_s32(simde_int32x2_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_n_s32(a, b);
+  #else
+    simde_int64x2_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) av;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      r_.values = av * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int64_t, a_.values[i]) * HEDLEY_STATIC_CAST(int64_t, b);
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_n_s32
+  #define vmull_n_s32(a, b) simde_vmull_n_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmull_n_u16(simde_uint16x4_t a, uint16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_n_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_vmulq_n_u32(simde_vmovl_u16(a), b);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) av;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      r_.values = av * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i]) * HEDLEY_STATIC_CAST(uint32_t, b);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_n_u16
+  #define vmull_n_u16(a, b) simde_vmull_n_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vmull_n_u32(simde_uint32x2_t a, uint32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmull_n_u32(a, b);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      __typeof__(r_.values) av;
+      SIMDE_CONVERT_VECTOR_(av, a_.values);
+      r_.values = av * b;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint64_t, a_.values[i]) * HEDLEY_STATIC_CAST(uint64_t, b);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmull_n_u32
+  #define vmull_n_u32(a, b) simde_vmull_n_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MULL_H) */

--- a/2.0/simde/arm/neon/mvn.h
+++ b/2.0/simde/arm/neon/mvn.h
@@ -1,0 +1,414 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_MVN_H)
+#define SIMDE_ARM_NEON_MVN_H
+
+#include "combine.h"
+#include "get_low.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vmvnq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_s8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi8(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_s8
+  #define vmvnq_s8(a) simde_vmvnq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vmvnq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_s16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi16(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_s16
+  #define vmvnq_s16(a) simde_vmvnq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vmvnq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_s32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi32(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_s32
+  #define vmvnq_s32(a) simde_vmvnq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vmvnq_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_u8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi8(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_u8
+  #define vmvnq_u8(a) simde_vmvnq_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vmvnq_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_u16(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi16(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_u16
+  #define vmvnq_u16(a) simde_vmvnq_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vmvnq_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvnq_u32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, _mm_cmpeq_epi32(a, a));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_nor(a, a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_not(a);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvnq_u32
+  #define vmvnq_u32(a) simde_vmvnq_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vmvn_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_s8(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi8(a, a));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_s8
+  #define vmvn_s8(a) simde_vmvn_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vmvn_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_s16(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi16(a, a));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_s16
+  #define vmvn_s16(a) simde_vmvn_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vmvn_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_s32(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi32(a, a));
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_s32
+  #define vmvn_s32(a) simde_vmvn_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vmvn_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_u8(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi8(a, a));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_u8
+  #define vmvn_u8(a) simde_vmvn_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vmvn_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_u16(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi16(a, a));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_u16
+  #define vmvn_u16(a) simde_vmvn_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vmvn_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vmvn_u32(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, _mm_cmpeq_pi32(a, a));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = ~a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ~(a_.values[i]);
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vmvn_u32
+  #define vmvn_u32(a) simde_vmvn_u32(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_MVN_H) */

--- a/2.0/simde/arm/neon/neg.h
+++ b/2.0/simde/arm/neon/neg.h
@@ -1,0 +1,393 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_NEG_H)
+#define SIMDE_ARM_NEON_NEG_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vneg_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vneg_f32(a);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vneg_f32
+  #define vneg_f32(a) simde_vneg_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vneg_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vneg_f64(a);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vneg_f64
+  #define vneg_f64(a) simde_vneg_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vneg_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vneg_s8(a);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vneg_s8
+  #define vneg_s8(a) simde_vneg_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vneg_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vneg_s16(a);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vneg_s16
+  #define vneg_s16(a) simde_vneg_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vneg_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vneg_s32(a);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vneg_s32
+  #define vneg_s32(a) simde_vneg_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vneg_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vneg_s64(a);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vneg_s64
+  #define vneg_s64(a) simde_vneg_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vnegq_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vnegq_f32(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_neg(a);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_f32
+  #define vnegq_f32(a) simde_vnegq_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vnegq_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vnegq_f64(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_neg(a);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_f64
+  #define vnegq_f64(a) simde_vnegq_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vnegq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vnegq_s8(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_neg(a);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_s8
+  #define vnegq_s8(a) simde_vnegq_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vnegq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vnegq_s16(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_neg(a);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_s16
+  #define vnegq_s16(a) simde_vnegq_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vnegq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vnegq_s32(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_neg(a);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_s32
+  #define vnegq_s32(a) simde_vnegq_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vnegq_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vnegq_s64(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return vec_neg(a);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_neg(a);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = -a_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = -(a_.values[i]);
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vnegq_s64
+  #define vnegq_s64(a) simde_vnegq_s64(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_NEG_H) */

--- a/2.0/simde/arm/neon/orr.h
+++ b/2.0/simde/arm/neon/orr.h
@@ -1,0 +1,552 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ORR_H)
+#define SIMDE_ARM_NEON_ORR_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vorr_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_s8
+  #define vorr_s8(a, b) simde_vorr_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vorr_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_s16
+  #define vorr_s16(a, b) simde_vorr_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vorr_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_s32
+  #define vorr_s32(a, b) simde_vorr_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vorr_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_s64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_s64
+  #define vorr_s64(a, b) simde_vorr_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vorr_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_u8
+  #define vorr_u8(a, b) simde_vorr_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vorr_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_u16
+  #define vorr_u16(a, b) simde_vorr_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vorr_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_u32
+  #define vorr_u32(a, b) simde_vorr_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vorr_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorr_u64(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorr_u64
+  #define vorr_u64(a, b) simde_vorr_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vorrq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_s8
+  #define vorrq_s8(a, b) simde_vorrq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vorrq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_s16
+  #define vorrq_s16(a, b) simde_vorrq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vorrq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_s32
+  #define vorrq_s32(a, b) simde_vorrq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vorrq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_s64
+  #define vorrq_s64(a, b) simde_vorrq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vorrq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_u8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_u8
+  #define vorrq_u8(a, b) simde_vorrq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vorrq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_u16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_u16
+  #define vorrq_u16(a, b) simde_vorrq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vorrq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_u32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_u32
+  #define vorrq_u32(a, b) simde_vorrq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vorrq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vorrq_u64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_or(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values | b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] | b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vorrq_u64
+  #define vorrq_u64(a, b) simde_vorrq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ORR_H) */

--- a/2.0/simde/arm/neon/padal.h
+++ b/2.0/simde/arm/neon/padal.h
@@ -1,0 +1,211 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_PADAL_H)
+#define SIMDE_ARM_NEON_PADAL_H
+
+#include "types.h"
+
+#include "add.h"
+#include "paddl.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vpadal_s8(simde_int16x4_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_s8(a, b);
+  #else
+    return simde_vadd_s16(a, simde_vpaddl_s8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_s8
+  #define vpadal_s8(a, b) simde_vpadal_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vpadal_s16(simde_int32x2_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_s16(a, b);
+  #else
+    return simde_vadd_s32(a, simde_vpaddl_s16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_s16
+  #define vpadal_s16(a, b) simde_vpadal_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vpadal_s32(simde_int64x1_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_s32(a, b);
+  #else
+    return simde_vadd_s64(a, simde_vpaddl_s32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_s32
+  #define vpadal_s32(a, b) simde_vpadal_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vpadal_u8(simde_uint16x4_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_u8(a, b);
+  #else
+    return simde_vadd_u16(a, simde_vpaddl_u8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_u8
+  #define vpadal_u8(a, b) simde_vpadal_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vpadal_u16(simde_uint32x2_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_u16(a, b);
+  #else
+    return simde_vadd_u32(a, simde_vpaddl_u16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_u16
+  #define vpadal_u16(a, b) simde_vpadal_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vpadal_u32(simde_uint64x1_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadal_u32(a, b);
+  #else
+    return simde_vadd_u64(a, simde_vpaddl_u32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadal_u32
+  #define vpadal_u32(a, b) simde_vpadal_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vpadalq_s8(simde_int16x8_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_s8(a, b);
+  #else
+    return simde_vaddq_s16(a, simde_vpaddlq_s8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_s8
+  #define vpadalq_s8(a, b) simde_vpadalq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vpadalq_s16(simde_int32x4_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_s16(a, b);
+  #else
+    return simde_vaddq_s32(a, simde_vpaddlq_s16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_s16
+  #define vpadalq_s16(a, b) simde_vpadalq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vpadalq_s32(simde_int64x2_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_s32(a, b);
+  #else
+    return simde_vaddq_s64(a, simde_vpaddlq_s32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_s32
+  #define vpadalq_s32(a, b) simde_vpadalq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vpadalq_u8(simde_uint16x8_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_u8(a, b);
+  #else
+    return simde_vaddq_u16(a, simde_vpaddlq_u8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_u8
+  #define vpadalq_u8(a, b) simde_vpadalq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vpadalq_u16(simde_uint32x4_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_u16(a, b);
+  #else
+    return simde_vaddq_u32(a, simde_vpaddlq_u16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_u16
+  #define vpadalq_u16(a, b) simde_vpadalq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vpadalq_u32(simde_uint64x2_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadalq_u32(a, b);
+  #else
+    return simde_vaddq_u64(a, simde_vpaddlq_u32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadalq_u32
+  #define vpadalq_u32(a, b) simde_vpadalq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* SIMDE_ARM_NEON_PADAL_H */

--- a/2.0/simde/arm/neon/padd.h
+++ b/2.0/simde/arm/neon/padd.h
@@ -1,0 +1,293 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_PADD_H)
+#define SIMDE_ARM_NEON_PADD_H
+
+#include "add.h"
+#include "uzp1.h"
+#include "uzp2.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vpadd_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_f32(a, b);
+  #else
+    return simde_vadd_f32(simde_vuzp1_f32(a, b), simde_vuzp2_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_f32
+  #define vpadd_f32(a, b) simde_vpadd_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vpadd_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_s8(a, b);
+  #else
+    return simde_vadd_s8(simde_vuzp1_s8(a, b), simde_vuzp2_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_s8
+  #define vpadd_s8(a, b) simde_vpadd_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vpadd_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_s16(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hadd_pi16(a, b);
+  #else
+    return simde_vadd_s16(simde_vuzp1_s16(a, b), simde_vuzp2_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_s16
+  #define vpadd_s16(a, b) simde_vpadd_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vpadd_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_s32(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hadd_pi32(a, b);
+  #else
+    return simde_vadd_s32(simde_vuzp1_s32(a, b), simde_vuzp2_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_s32
+  #define vpadd_s32(a, b) simde_vpadd_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vpadd_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_u8(a, b);
+  #else
+    return simde_vadd_u8(simde_vuzp1_u8(a, b), simde_vuzp2_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_u8
+  #define vpadd_u8(a, b) simde_vpadd_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vpadd_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_u16(a, b);
+  #else
+    return simde_vadd_u16(simde_vuzp1_u16(a, b), simde_vuzp2_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_u16
+  #define vpadd_u16(a, b) simde_vpadd_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vpadd_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpadd_u32(a, b);
+  #else
+    return simde_vadd_u32(simde_vuzp1_u32(a, b), simde_vuzp2_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpadd_u32
+  #define vpadd_u32(a, b) simde_vpadd_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vpaddq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hadd_ps(a, b);
+  #else
+    return simde_vaddq_f32(simde_vuzp1q_f32(a, b), simde_vuzp2q_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_f32
+  #define vpaddq_f32(a, b) simde_vpaddq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vpaddq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hadd_pd(a, b);
+  #else
+    return simde_vaddq_f64(simde_vuzp1q_f64(a, b), simde_vuzp2q_f64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_f64
+  #define vpaddq_f64(a, b) simde_vpaddq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vpaddq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_s8(a, b);
+  #else
+    return simde_vaddq_s8(simde_vuzp1q_s8(a, b), simde_vuzp2q_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_s8
+  #define vpaddq_s8(a, b) simde_vpaddq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vpaddq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_s16(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hadd_epi16(a, b);
+  #else
+    return simde_vaddq_s16(simde_vuzp1q_s16(a, b), simde_vuzp2q_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_s16
+  #define vpaddq_s16(a, b) simde_vpaddq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vpaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_s32(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hadd_epi32(a, b);
+  #else
+    return simde_vaddq_s32(simde_vuzp1q_s32(a, b), simde_vuzp2q_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_s32
+  #define vpaddq_s32(a, b) simde_vpaddq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vpaddq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_s64(a, b);
+  #else
+    return simde_vaddq_s64(simde_vuzp1q_s64(a, b), simde_vuzp2q_s64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_s64
+  #define vpaddq_s64(a, b) simde_vpaddq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vpaddq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_u8(a, b);
+  #else
+    return simde_vaddq_u8(simde_vuzp1q_u8(a, b), simde_vuzp2q_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_u8
+  #define vpaddq_u8(a, b) simde_vpaddq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vpaddq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_u16(a, b);
+  #else
+    return simde_vaddq_u16(simde_vuzp1q_u16(a, b), simde_vuzp2q_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_u16
+  #define vpaddq_u16(a, b) simde_vpaddq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vpaddq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_u32(a, b);
+  #else
+    return simde_vaddq_u32(simde_vuzp1q_u32(a, b), simde_vuzp2q_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_u32
+  #define vpaddq_u32(a, b) simde_vpaddq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vpaddq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpaddq_u64(a, b);
+  #else
+    return simde_vaddq_u64(simde_vuzp1q_u64(a, b), simde_vuzp2q_u64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddq_u64
+  #define vpaddq_u64(a, b) simde_vpaddq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_PADD_H) */

--- a/2.0/simde/arm/neon/paddl.h
+++ b/2.0/simde/arm/neon/paddl.h
@@ -1,0 +1,232 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_PADDL_H)
+#define SIMDE_ARM_NEON_PADDL_H
+
+#include "add.h"
+#include "get_high.h"
+#include "get_low.h"
+#include "movl.h"
+#include "movl_high.h"
+#include "padd.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vpaddl_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_s8(a);
+  #else
+    simde_int16x8_t tmp = simde_vmovl_s8(a);
+    return simde_vpadd_s16(simde_vget_low_s16(tmp), simde_vget_high_s16(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_s8
+  #define vpaddl_s8(a) simde_vpaddl_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vpaddl_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_s16(a);
+  #else
+    simde_int32x4_t tmp = simde_vmovl_s16(a);
+    return simde_vpadd_s32(simde_vget_low_s32(tmp), simde_vget_high_s32(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_s16
+  #define vpaddl_s16(a) simde_vpaddl_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vpaddl_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_s32(a);
+  #else
+    simde_int64x2_t tmp = simde_vmovl_s32(a);
+    return simde_vadd_s64(simde_vget_low_s64(tmp), simde_vget_high_s64(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_s32
+  #define vpaddl_s32(a) simde_vpaddl_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vpaddl_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_u8(a);
+  #else
+    simde_uint16x8_t tmp = simde_vmovl_u8(a);
+    return simde_vpadd_u16(simde_vget_low_u16(tmp), simde_vget_high_u16(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_u8
+  #define vpaddl_u8(a) simde_vpaddl_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vpaddl_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_u16(a);
+  #else
+    simde_uint32x4_t tmp = simde_vmovl_u16(a);
+    return simde_vpadd_u32(simde_vget_low_u32(tmp), simde_vget_high_u32(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_u16
+  #define vpaddl_u16(a) simde_vpaddl_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vpaddl_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddl_u32(a);
+  #else
+    simde_uint64x2_t tmp = simde_vmovl_u32(a);
+    return simde_vadd_u64(simde_vget_low_u64(tmp), simde_vget_high_u64(tmp));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddl_u32
+  #define vpaddl_u32(a) simde_vpaddl_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vpaddlq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_s8(a);
+  #else
+    simde_int16x8_t lo = simde_vmovl_s8(simde_vget_low_s8(a));
+    simde_int16x8_t hi = simde_vmovl_s8(simde_vget_high_s8(a));
+    return simde_vpaddq_s16(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_s8
+  #define vpaddlq_s8(a) simde_vpaddlq_s8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vpaddlq_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_s16(a);
+  #else
+    simde_int32x4_t lo = simde_vmovl_s16(simde_vget_low_s16(a));
+    simde_int32x4_t hi = simde_vmovl_s16(simde_vget_high_s16(a));
+    return simde_vpaddq_s32(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_s16
+  #define vpaddlq_s16(a) simde_vpaddlq_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vpaddlq_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_s32(a);
+  #else
+    simde_int64x2_t lo = simde_vmovl_s32(simde_vget_low_s32(a));
+    simde_int64x2_t hi = simde_vmovl_s32(simde_vget_high_s32(a));
+    return simde_vpaddq_s64(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_s32
+  #define vpaddlq_s32(a) simde_vpaddlq_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vpaddlq_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_u8(a);
+  #else
+    simde_uint16x8_t lo = simde_vmovl_u8(simde_vget_low_u8(a));
+    simde_uint16x8_t hi = simde_vmovl_u8(simde_vget_high_u8(a));
+    return simde_vpaddq_u16(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_u8
+  #define vpaddlq_u8(a) simde_vpaddlq_u8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vpaddlq_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_u16(a);
+  #else
+    simde_uint32x4_t lo = simde_vmovl_u16(simde_vget_low_u16(a));
+    simde_uint32x4_t hi = simde_vmovl_u16(simde_vget_high_u16(a));
+    return simde_vpaddq_u32(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_u16
+  #define vpaddlq_u16(a) simde_vpaddlq_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vpaddlq_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpaddlq_u32(a);
+  #else
+    simde_uint64x2_t lo = simde_vmovl_u32(simde_vget_low_u32(a));
+    simde_uint64x2_t hi = simde_vmovl_u32(simde_vget_high_u32(a));
+    return simde_vpaddq_u64(lo, hi);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpaddlq_u32
+  #define vpaddlq_u32(a) simde_vpaddlq_u32((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* SIMDE_ARM_NEON_PADDL_H */

--- a/2.0/simde/arm/neon/pmax.h
+++ b/2.0/simde/arm/neon/pmax.h
@@ -1,0 +1,253 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_PMAX_H)
+#define SIMDE_ARM_NEON_PMAX_H
+
+#include "types.h"
+#include "max.h"
+#include "uzp1.h"
+#include "uzp2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vpmax_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_f32(a, b);
+  #else
+    return simde_vmax_f32(simde_vuzp1_f32(a, b), simde_vuzp2_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_f32
+  #define vpmax_f32(a, b) simde_vpmax_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vpmax_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_s8(a, b);
+  #else
+    return simde_vmax_s8(simde_vuzp1_s8(a, b), simde_vuzp2_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_s8
+  #define vpmax_s8(a, b) simde_vpmax_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vpmax_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_s16(a, b);
+  #else
+    return simde_vmax_s16(simde_vuzp1_s16(a, b), simde_vuzp2_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_s16
+  #define vpmax_s16(a, b) simde_vpmax_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vpmax_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_s32(a, b);
+  #else
+    return simde_vmax_s32(simde_vuzp1_s32(a, b), simde_vuzp2_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_s32
+  #define vpmax_s32(a, b) simde_vpmax_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vpmax_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_u8(a, b);
+  #else
+    return simde_vmax_u8(simde_vuzp1_u8(a, b), simde_vuzp2_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_u8
+  #define vpmax_u8(a, b) simde_vpmax_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vpmax_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_u16(a, b);
+  #else
+    return simde_vmax_u16(simde_vuzp1_u16(a, b), simde_vuzp2_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_u16
+  #define vpmax_u16(a, b) simde_vpmax_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vpmax_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmax_u32(a, b);
+  #else
+    return simde_vmax_u32(simde_vuzp1_u32(a, b), simde_vuzp2_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmax_u32
+  #define vpmax_u32(a, b) simde_vpmax_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vpmaxq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_f32(a, b);
+  #else
+    return simde_vmaxq_f32(simde_vuzp1q_f32(a, b), simde_vuzp2q_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_f32
+  #define vpmaxq_f32(a, b) simde_vpmaxq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vpmaxq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_f64(a, b);
+  #else
+    return simde_vmaxq_f64(simde_vuzp1q_f64(a, b), simde_vuzp2q_f64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_f64
+  #define vpmaxq_f64(a, b) simde_vpmaxq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vpmaxq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_s8(a, b);
+  #else
+    return simde_vmaxq_s8(simde_vuzp1q_s8(a, b), simde_vuzp2q_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_s8
+  #define vpmaxq_s8(a, b) simde_vpmaxq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vpmaxq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_s16(a, b);
+  #else
+    return simde_vmaxq_s16(simde_vuzp1q_s16(a, b), simde_vuzp2q_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_s16
+  #define vpmaxq_s16(a, b) simde_vpmaxq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vpmaxq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_s32(a, b);
+  #else
+    return simde_vmaxq_s32(simde_vuzp1q_s32(a, b), simde_vuzp2q_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_s32
+  #define vpmaxq_s32(a, b) simde_vpmaxq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vpmaxq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_u8(a, b);
+  #else
+    return simde_vmaxq_u8(simde_vuzp1q_u8(a, b), simde_vuzp2q_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_u8
+  #define vpmaxq_u8(a, b) simde_vpmaxq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vpmaxq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_u16(a, b);
+  #else
+    return simde_vmaxq_u16(simde_vuzp1q_u16(a, b), simde_vuzp2q_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_u16
+  #define vpmaxq_u16(a, b) simde_vpmaxq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vpmaxq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpmaxq_u32(a, b);
+  #else
+    return simde_vmaxq_u32(simde_vuzp1q_u32(a, b), simde_vuzp2q_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmaxq_u32
+  #define vpmaxq_u32(a, b) simde_vpmaxq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_PMAX_H) */

--- a/2.0/simde/arm/neon/pmin.h
+++ b/2.0/simde/arm/neon/pmin.h
@@ -1,0 +1,260 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_PMIN_H)
+#define SIMDE_ARM_NEON_PMIN_H
+
+#include "types.h"
+#include "min.h"
+#include "uzp1.h"
+#include "uzp2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vpmin_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_f32(a, b);
+  #else
+    return simde_vmin_f32(simde_vuzp1_f32(a, b), simde_vuzp2_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_f32
+  #define vpmin_f32(a, b) simde_vpmin_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vpmin_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_s8(a, b);
+  #else
+    return simde_vmin_s8(simde_vuzp1_s8(a, b), simde_vuzp2_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_s8
+  #define vpmin_s8(a, b) simde_vpmin_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vpmin_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_s16(a, b);
+  #else
+    return simde_vmin_s16(simde_vuzp1_s16(a, b), simde_vuzp2_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_s16
+  #define vpmin_s16(a, b) simde_vpmin_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vpmin_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_s32(a, b);
+  #else
+    return simde_vmin_s32(simde_vuzp1_s32(a, b), simde_vuzp2_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_s32
+  #define vpmin_s32(a, b) simde_vpmin_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vpmin_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_u8(a, b);
+  #else
+    return simde_vmin_u8(simde_vuzp1_u8(a, b), simde_vuzp2_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_u8
+  #define vpmin_u8(a, b) simde_vpmin_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vpmin_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_u16(a, b);
+  #else
+    return simde_vmin_u16(simde_vuzp1_u16(a, b), simde_vuzp2_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_u16
+  #define vpmin_u16(a, b) simde_vpmin_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vpmin_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vpmin_u32(a, b);
+  #else
+    return simde_vmin_u32(simde_vuzp1_u32(a, b), simde_vuzp2_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpmin_u32
+  #define vpmin_u32(a, b) simde_vpmin_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vpminq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    __m128 e = _mm_shuffle_ps(a, b, _MM_SHUFFLE(2, 0, 2, 0));
+    __m128 o = _mm_shuffle_ps(a, b, _MM_SHUFFLE(3, 1, 3, 1));
+    return _mm_min_ps(e, o);
+  #else
+    return simde_vminq_f32(simde_vuzp1q_f32(a, b), simde_vuzp2q_f32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_f32
+  #define vpminq_f32(a, b) simde_vpminq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vpminq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128d e = _mm_unpacklo_pd(a, b);
+    __m128d o = _mm_unpackhi_pd(a, b);
+    return _mm_min_pd(e, o);
+  #else
+    return simde_vminq_f64(simde_vuzp1q_f64(a, b), simde_vuzp2q_f64(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_f64
+  #define vpminq_f64(a, b) simde_vpminq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vpminq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_s8(a, b);
+  #else
+    return simde_vminq_s8(simde_vuzp1q_s8(a, b), simde_vuzp2q_s8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_s8
+  #define vpminq_s8(a, b) simde_vpminq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vpminq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_s16(a, b);
+  #else
+    return simde_vminq_s16(simde_vuzp1q_s16(a, b), simde_vuzp2q_s16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_s16
+  #define vpminq_s16(a, b) simde_vpminq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vpminq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_s32(a, b);
+  #else
+    return simde_vminq_s32(simde_vuzp1q_s32(a, b), simde_vuzp2q_s32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_s32
+  #define vpminq_s32(a, b) simde_vpminq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vpminq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_u8(a, b);
+  #else
+    return simde_vminq_u8(simde_vuzp1q_u8(a, b), simde_vuzp2q_u8(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_u8
+  #define vpminq_u8(a, b) simde_vpminq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vpminq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_u16(a, b);
+  #else
+    return simde_vminq_u16(simde_vuzp1q_u16(a, b), simde_vuzp2q_u16(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_u16
+  #define vpminq_u16(a, b) simde_vpminq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vpminq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vpminq_u32(a, b);
+  #else
+    return simde_vminq_u32(simde_vuzp1q_u32(a, b), simde_vuzp2q_u32(a, b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vpminq_u32
+  #define vpminq_u32(a, b) simde_vpminq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_PMIN_H) */

--- a/2.0/simde/arm/neon/qadd.h
+++ b/2.0/simde/arm/neon/qadd.h
@@ -1,0 +1,566 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QADD_H)
+#define SIMDE_ARM_NEON_QADD_H
+
+#include "types.h"
+
+#include "add.h"
+#include "movl.h"
+#include "qmovn.h"
+#include "combine.h"
+#include "get_low.h"
+#include "get_high.h"
+#include "bsl.h"
+#include "cgt.h"
+#include "sub.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqadd_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pi8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vqmovn_s16(simde_vaddq_s16(simde_vmovl_s8(a), simde_vmovl_s8(b)));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnh_s16(HEDLEY_STATIC_CAST(int16_t, a_.values[i]) + HEDLEY_STATIC_CAST(int16_t, b_.values[i]));
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_s8
+  #define vqadd_s8(a, b) simde_vqadd_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vqadd_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pi16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vqmovn_s32(simde_vaddq_s32(simde_vmovl_s16(a), simde_vmovl_s16(b)));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovns_s32(HEDLEY_STATIC_CAST(int32_t, a_.values[i]) + HEDLEY_STATIC_CAST(int32_t, b_.values[i]));
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_s16
+  #define vqadd_s16(a, b) simde_vqadd_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vqadd_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_s32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vqmovn_s64(simde_vaddq_s64(simde_vmovl_s32(a), simde_vmovl_s32(b)));
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnd_s64(HEDLEY_STATIC_CAST(int64_t, a_.values[i]) + HEDLEY_STATIC_CAST(int64_t, b_.values[i]));
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_s32
+  #define vqadd_s32(a, b) simde_vqadd_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vqadd_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_s64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      if (a_.values[i] > 0 && b_.values[i] > 0) {
+        r_.values[i] = (a_.values[i] > (INT64_MAX - b_.values[i])) ? INT64_MAX : a_.values[i] + b_.values[i];
+      } else if (a_.values[i] < 0 && b_.values[i] < 0) {
+        r_.values[i] = (a_.values[i] < (INT64_MIN - b_.values[i])) ? INT64_MIN : a_.values[i] + b_.values[i];
+      } else {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    }
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_s64
+  #define vqadd_s64(a, b) simde_vqadd_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqadd_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pu8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint8x8_t max = simde_vdup_n_u8(UINT8_MAX);
+    return simde_vbsl_u8(simde_vcgt_u8(a, simde_vsub_u8(max, b)), max, simde_vadd_u8(a, b));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT8_MAX - b_.values));
+      r_.values  =  m & UINT8_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT8_MAX - b_.values[i]) ? UINT8_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_u8
+  #define vqadd_u8(a, b) simde_vqadd_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vqadd_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pu16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint16x4_t max = simde_vdup_n_u16(UINT16_MAX);
+    return simde_vbsl_u16(simde_vcgt_u16(a, simde_vsub_u16(max, b)), max, simde_vadd_u16(a, b));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT16_MAX - b_.values));
+      r_.values  =  m & UINT16_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT16_MAX - b_.values[i]) ? UINT16_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_u16
+  #define vqadd_u16(a, b) simde_vqadd_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vqadd_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_u32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint32x2_t max = simde_vdup_n_u32(UINT32_MAX);
+    return simde_vbsl_u32(simde_vcgt_u32(a, simde_vsub_u32(max, b)), max, simde_vadd_u32(a, b));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT32_MAX - b_.values));
+      r_.values  =  m & UINT32_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > (UINT32_MAX - b_.values[i])) ? UINT32_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_u32
+  #define vqadd_u32(a, b) simde_vqadd_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vqadd_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqadd_u64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint64x1_t max = simde_vdup_n_u64(UINT64_MAX);
+    return simde_vbsl_u64(simde_vcgt_u64(a, simde_vsub_u64(max, b)), max, simde_vadd_u64(a, b));
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT64_MAX - b_.values));
+      r_.values  =  m & UINT64_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT64_MAX - b_.values[i]) ? UINT64_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqadd_u64
+  #define vqadd_u64(a, b) simde_vqadd_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqaddq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_s8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_add_saturate(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcombine_s8(simde_vqadd_s8(simde_vget_low_s8(a), simde_vget_low_s8(b)), simde_vqadd_s8(simde_vget_high_s8(a), simde_vget_high_s8(b)));
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnh_s16(HEDLEY_STATIC_CAST(int16_t, a_.values[i]) + HEDLEY_STATIC_CAST(int16_t, b_.values[i]));
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_s8
+  #define vqaddq_s8(a, b) simde_vqaddq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vqaddq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_s16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_add_saturate(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcombine_s16(simde_vqadd_s16(simde_vget_low_s16(a), simde_vget_low_s16(b)), simde_vqadd_s16(simde_vget_high_s16(a), simde_vget_high_s16(b)));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovns_s32(HEDLEY_STATIC_CAST(int32_t, a_.values[i]) + HEDLEY_STATIC_CAST(int32_t, b_.values[i]));
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_s16
+  #define vqaddq_s16(a, b) simde_vqaddq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_s32(a, b);
+  #elif defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_cvtsepi64_epi32(_mm256_add_epi64(_mm256_cvtepi32_epi64(a), _mm256_cvtepi32_epi64(b)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vcombine_s32(simde_vqadd_s32(simde_vget_low_s32(a), simde_vget_low_s32(b)), simde_vqadd_s32(simde_vget_high_s32(a), simde_vget_high_s32(b)));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnd_s64(HEDLEY_STATIC_CAST(int64_t, a_.values[i]) + HEDLEY_STATIC_CAST(int64_t, b_.values[i]));
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_s32
+  #define vqaddq_s32(a, b) simde_vqaddq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vqaddq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_s64(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      if (a_.values[i] > 0 && b_.values[i] > 0) {
+        r_.values[i] = (a_.values[i] > (INT64_MAX - b_.values[i])) ? INT64_MAX : a_.values[i] + b_.values[i];
+      } else if (a_.values[i] < 0 && b_.values[i] < 0) {
+        r_.values[i] = (a_.values[i] < (INT64_MIN - b_.values[i])) ? INT64_MIN : a_.values[i] + b_.values[i];
+      } else {
+        r_.values[i] = a_.values[i] + b_.values[i];
+      }
+    }
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_s64
+  #define vqaddq_s64(a, b) simde_vqaddq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqaddq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_u8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_add_saturate(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint8x16_t max = simde_vdupq_n_u8(UINT8_MAX);
+    return simde_vbslq_u8(simde_vcgtq_u8(a, simde_vsubq_u8(max, b)), max, simde_vaddq_u8(a, b));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT8_MAX - b_.values));
+      r_.values  =  m & UINT8_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT8_MAX - b_.values[i]) ? UINT8_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_u8
+  #define vqaddq_u8(a, b) simde_vqaddq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vqaddq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_add_saturate(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint16x8_t max = simde_vdupq_n_u16(UINT16_MAX);
+    return simde_vbslq_u16(simde_vcgtq_u16(a, simde_vsubq_u16(max, b)), max, simde_vaddq_u16(a, b));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT16_MAX - b_.values));
+      r_.values  =  m & UINT16_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT16_MAX - b_.values[i]) ? UINT16_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_u16
+  #define vqaddq_u16(a, b) simde_vqaddq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vqaddq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_u32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6)
+    return vec_adds(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint32x4_t max = simde_vdupq_n_u32(UINT32_MAX);
+    return simde_vbslq_u32(simde_vcgtq_u32(a, simde_vsubq_u32(max, b)), max, simde_vaddq_u32(a, b));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT32_MAX - b_.values));
+      r_.values  =  m & UINT32_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT32_MAX - b_.values[i]) ? UINT32_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_u32
+  #define vqaddq_u32(a, b) simde_vqaddq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vqaddq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqaddq_u64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    const simde_uint64x2_t max = simde_vdupq_n_u64(UINT64_MAX);
+    return simde_vbslq_u64(simde_vcgtq_u64(a, simde_vsubq_u64(max, b)), max, simde_vaddq_u64(a, b));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SCALAR)
+      __typeof__(r_.values) m = HEDLEY_STATIC_CAST(__typeof__(r_.values), a_.values > (UINT64_MAX - b_.values));
+      r_.values  =  m & UINT64_MAX;
+      r_.values |= ~m & (a_.values + b_.values);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (a_.values[i] > UINT64_MAX - b_.values[i]) ? UINT64_MAX : a_.values[i] + b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqaddq_u64
+  #define vqaddq_u64(a, b) simde_vqaddq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QADD_H) */

--- a/2.0/simde/arm/neon/qdmulh.h
+++ b/2.0/simde/arm/neon/qdmulh.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QDMULH_H)
+#define SIMDE_ARM_NEON_QDMULH_H
+
+#include "types.h"
+
+#include "combine.h"
+#include "get_high.h"
+#include "get_low.h"
+#include "qdmull.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vqdmulh_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmulh_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_;
+
+    simde_int32x4_t r = simde_vqdmull_s16(a, b);
+    simde_int32x4_private r_2 = simde_int32x4_to_private(r);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t, r_2.values[i] >> 16);
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmulh_s16
+  #define vqdmulh_s16(a, b) simde_vqdmulh_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vqdmulh_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmulh_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_;
+
+    simde_int64x2_t r = simde_vqdmull_s32(a, b);
+    simde_int64x2_private r_2 = simde_int64x2_to_private(r);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int32_t, r_2.values[i] >> 32);
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmulh_s32
+  #define vqdmulh_s32(a, b) simde_vqdmulh_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vqdmulhq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmulhq_s16(a, b);
+  #else
+    return simde_vcombine_s16(simde_vqdmulh_s16(simde_vget_low_s16(a), simde_vget_low_s16(b)),
+                              simde_vqdmulh_s16(simde_vget_high_s16(a), simde_vget_high_s16(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmulhq_s16
+  #define vqdmulhq_s16(a, b) simde_vqdmulhq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqdmulhq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmulhq_s32(a, b);
+  #else
+    return simde_vcombine_s32(simde_vqdmulh_s32(simde_vget_low_s32(a), simde_vget_low_s32(b)),
+                              simde_vqdmulh_s32(simde_vget_high_s32(a), simde_vget_high_s32(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmulhq_s32
+  #define vqdmulhq_s32(a, b) simde_vqdmulhq_s32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QDMULH_H) */

--- a/2.0/simde/arm/neon/qdmull.h
+++ b/2.0/simde/arm/neon/qdmull.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+/* Implementation notes (seanptmaher):
+ *
+ * It won't overflow during the multiplication, it'll ever only double
+ * the bit length, we only care about the overflow during the shift,
+ * so do the multiplication, then the shift with saturation
+ */
+
+#if !defined(SIMDE_ARM_NEON_QDMULL_H)
+#define SIMDE_ARM_NEON_QDMULL_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vqdmullh_s16(int16_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqdmullh_s16(a, b);
+  #else
+    int32_t mul = (HEDLEY_STATIC_CAST(int32_t, a) * HEDLEY_STATIC_CAST(int32_t, b));
+    return (labs(mul) & (1 << 30)) ? ((mul < 0) ? INT32_MIN : INT32_MAX) : mul << 1;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmullh_s16
+  #define vqdmullh_s16(a, b) simde_vqdmullh_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_vqdmulls_s32(int32_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqdmulls_s32(a, b);
+  #else
+    int64_t mul = (HEDLEY_STATIC_CAST(int64_t, a) * HEDLEY_STATIC_CAST(int64_t, b));
+    return ((a > 0 ? a : -a) & (HEDLEY_STATIC_CAST(int64_t, 1) << 62)) ? ((mul < 0) ? INT64_MIN : INT64_MAX) : mul << 1;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmulls_s16
+  #define vqdmulls_s16(a, b) simde_vqdmulls_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqdmull_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmull_s16(a, b);
+  #else
+    simde_int32x4_private r_;
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqdmullh_s16(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmull_s16
+  #define vqdmull_s16(a, b) simde_vqdmull_s16((a), (b))
+#endif
+SIMDE_FUNCTION_ATTRIBUTES
+
+simde_int64x2_t
+simde_vqdmull_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqdmull_s32(a, b);
+  #else
+    simde_int64x2_private r_;
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqdmulls_s32(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqdmull_s32
+  #define vqdmull_s32(a, b) simde_vqdmull_s32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QDMULL_H) */

--- a/2.0/simde/arm/neon/qmovn.h
+++ b/2.0/simde/arm/neon/qmovn.h
@@ -1,0 +1,273 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QMOVN_H)
+#define SIMDE_ARM_NEON_QMOVN_H
+
+#include "types.h"
+#include "dup_n.h"
+#include "min.h"
+#include "max.h"
+#include "movn.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+int8_t
+simde_vqmovnh_s16(int16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovnh_s16(a);
+  #else
+    return (a > INT8_MAX) ? INT8_MAX : ((a < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovnh_s16
+  #define vqmovnh_s16(a) simde_vqmovnh_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_vqmovns_s32(int32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovns_s32(a);
+  #else
+    return (a > INT16_MAX) ? INT16_MAX : ((a < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovns_s32
+  #define vqmovns_s32(a) simde_vqmovns_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vqmovnd_s64(int64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovnd_s64(a);
+  #else
+    return (a > INT32_MAX) ? INT32_MAX : ((a < INT32_MIN) ? INT32_MIN : HEDLEY_STATIC_CAST(int32_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovnd_s64
+  #define vqmovnd_s64(a) simde_vqmovnd_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_vqmovnh_u16(uint16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovnh_u16(a);
+  #else
+    return (a > UINT8_MAX) ? UINT8_MAX : HEDLEY_STATIC_CAST(uint8_t, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovnh_u16
+  #define vqmovnh_u16(a) simde_vqmovnh_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint16_t
+simde_vqmovns_u32(uint32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovns_u32(a);
+  #else
+    return (a > UINT16_MAX) ? UINT16_MAX : HEDLEY_STATIC_CAST(uint16_t, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovns_u32
+  #define vqmovns_u32(a) simde_vqmovns_u32((a))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vqmovnd_u64(uint64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovnd_u64(a);
+  #else
+    return (a > UINT32_MAX) ? UINT32_MAX : HEDLEY_STATIC_CAST(uint32_t, a);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovnd_u64
+  #define vqmovnd_u64(a) simde_vqmovnd_u64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqmovn_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_s16(simde_vmaxq_s16(simde_vdupq_n_s16(INT8_MIN), simde_vminq_s16(simde_vdupq_n_s16(INT8_MAX), a)));
+  #else
+    simde_int8x8_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnh_s16(a_.values[i]);
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_s16
+  #define vqmovn_s16(a) simde_vqmovn_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vqmovn_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_s32(simde_vmaxq_s32(simde_vdupq_n_s32(INT16_MIN), simde_vminq_s32(simde_vdupq_n_s32(INT16_MAX), a)));
+  #else
+    simde_int16x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovns_s32(a_.values[i]);
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_s32
+  #define vqmovn_s32(a) simde_vqmovn_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vqmovn_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_s64(simde_x_vmaxq_s64(simde_vdupq_n_s64(INT32_MIN), simde_x_vminq_s64(simde_vdupq_n_s64(INT32_MAX), a)));
+  #else
+    simde_int32x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnd_s64(a_.values[i]);
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_s64
+  #define vqmovn_s64(a) simde_vqmovn_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqmovn_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_u16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u16(simde_vminq_u16(a, simde_vdupq_n_u16(UINT8_MAX)));
+  #else
+    simde_uint8x8_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnh_u16(a_.values[i]);
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_u16
+  #define vqmovn_u16(a) simde_vqmovn_u16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vqmovn_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_u32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u32(simde_vminq_u32(a, simde_vdupq_n_u32(UINT16_MAX)));
+  #else
+    simde_uint16x4_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovns_u32(a_.values[i]);
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_u32
+  #define vqmovn_u32(a) simde_vqmovn_u32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vqmovn_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovn_u64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u64(simde_x_vminq_u64(a, simde_vdupq_n_u64(UINT32_MAX)));
+  #else
+    simde_uint32x2_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovnd_u64(a_.values[i]);
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_u64
+  #define vqmovn_u64(a) simde_vqmovn_u64((a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QMOVN_H) */

--- a/2.0/simde/arm/neon/qmovn_high.h
+++ b/2.0/simde/arm/neon/qmovn_high.h
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QMOVN_HIGH_H)
+#define SIMDE_ARM_NEON_QMOVN_HIGH_H
+
+#include "types.h"
+
+#include "combine.h"
+#include "qmovn.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqmovn_high_s16(simde_int8x8_t r, simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_s16(r, a);
+  #else
+    return simde_vcombine_s8(r, simde_vqmovn_s16(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_s16
+  #define vqmovn_high_s16(r, a) simde_vqmovn_high_s16((r), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vqmovn_high_s32(simde_int16x4_t r, simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_s32(r, a);
+  #else
+    return simde_vcombine_s16(r, simde_vqmovn_s32(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_s32
+  #define vqmovn_high_s32(r, a) simde_vqmovn_high_s32((r), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqmovn_high_s64(simde_int32x2_t r, simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_s64(r, a);
+  #else
+    return simde_vcombine_s32(r, simde_vqmovn_s64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_s64
+  #define vqmovn_high_s64(r, a) simde_vqmovn_high_s64((r), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqmovn_high_u16(simde_uint8x8_t r, simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_u16(r, a);
+  #else
+    return simde_vcombine_u8(r, simde_vqmovn_u16(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_u16
+  #define vqmovn_high_u16(r, a) simde_vqmovn_high_u16((r), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vqmovn_high_u32(simde_uint16x4_t r, simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_u32(r, a);
+  #else
+    return simde_vcombine_u16(r, simde_vqmovn_u32(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_u32
+  #define vqmovn_high_u32(r, a) simde_vqmovn_high_u32((r), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vqmovn_high_u64(simde_uint32x2_t r, simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqmovn_high_u64(r, a);
+  #else
+    return simde_vcombine_u32(r, simde_vqmovn_u64(a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovn_high_u64
+  #define vqmovn_high_u64(r, a) simde_vqmovn_high_u64((r), (a))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QMOVN_HIGH_H) */

--- a/2.0/simde/arm/neon/qmovun.h
+++ b/2.0/simde/arm/neon/qmovun.h
@@ -1,0 +1,159 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QMOVUN_H)
+#define SIMDE_ARM_NEON_QMOVUN_H
+
+#include "types.h"
+#include "dup_n.h"
+#include "min.h"
+#include "max.h"
+#include "movn.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint8_t
+simde_vqmovunh_s16(int16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint8_t, vqmovunh_s16(a));
+  #else
+    return (a > UINT8_MAX) ? UINT8_MAX : ((a < 0) ? 0 : HEDLEY_STATIC_CAST(uint8_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovunh_s16
+  #define vqmovunh_s16(a) simde_vqmovunh_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint16_t
+simde_vqmovuns_s32(int32_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint16_t, vqmovuns_s32(a));
+  #else
+    return (a > UINT16_MAX) ? UINT16_MAX : ((a < 0) ? 0 : HEDLEY_STATIC_CAST(uint16_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovuns_s32
+  #define vqmovuns_s32(a) simde_vqmovuns_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_vqmovund_s64(int64_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return HEDLEY_STATIC_CAST(uint32_t, vqmovund_s64(a));
+  #else
+    return (a > UINT32_MAX) ? UINT32_MAX : ((a < 0) ? 0 : HEDLEY_STATIC_CAST(uint32_t, a));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqmovund_s64
+  #define vqmovund_s64(a) simde_vqmovund_s64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqmovun_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovun_s16(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u16(simde_vreinterpretq_u16_s16(simde_vmaxq_s16(simde_vdupq_n_s16(0), simde_vminq_s16(simde_vdupq_n_s16(UINT8_MAX), a))));
+  #else
+    simde_uint8x8_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovunh_s16(a_.values[i]);
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovun_s16
+  #define vqmovun_s16(a) simde_vqmovun_s16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vqmovun_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovun_s32(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u32(simde_vreinterpretq_u32_s32(simde_vmaxq_s32(simde_vdupq_n_s32(0), simde_vminq_s32(simde_vdupq_n_s32(UINT16_MAX), a))));
+  #else
+    simde_uint16x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovuns_s32(a_.values[i]);
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovun_s32
+  #define vqmovun_s32(a) simde_vqmovun_s32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vqmovun_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqmovun_s64(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmovn_u64(simde_vreinterpretq_u64_s64(simde_x_vmaxq_s64(simde_vdupq_n_s64(0), simde_x_vminq_s64(simde_vdupq_n_s64(UINT32_MAX), a))));
+  #else
+    simde_uint32x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqmovund_s64(a_.values[i]);
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqmovun_s64
+  #define vqmovun_s64(a) simde_vqmovun_s64((a))
+#endif
+
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QMOVUN_H) */

--- a/2.0/simde/arm/neon/qrdmulh.h
+++ b/2.0/simde/arm/neon/qrdmulh.h
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QRDMULH_H)
+#define SIMDE_ARM_NEON_QRDMULH_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_vqrdmulhh_s16(int16_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqrdmulhh_s16(a, b);
+  #else
+    return HEDLEY_STATIC_CAST(int16_t, (((1 << 15) + ((HEDLEY_STATIC_CAST(int32_t, (HEDLEY_STATIC_CAST(int32_t, a) * HEDLEY_STATIC_CAST(int32_t, b)))) << 1)) >> 16) & 0xffff);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhh_s16
+  #define vqrdmulhh_s16(a, b) simde_vqrdmulhh_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_vqrdmulhs_s32(int32_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqrdmulhs_s32(a, b);
+  #else
+    return HEDLEY_STATIC_CAST(int32_t, (((HEDLEY_STATIC_CAST(int64_t, 1) << 31) + ((HEDLEY_STATIC_CAST(int64_t, (HEDLEY_STATIC_CAST(int64_t, a) * HEDLEY_STATIC_CAST(int64_t, b)))) << 1)) >> 32) & 0xffffffff);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhs_s32
+  #define vqrdmulhs_s32(a, b) simde_vqrdmulhs_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vqrdmulh_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulh_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhh_s16(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulh_s16
+  #define vqrdmulh_s16(a, b) simde_vqrdmulh_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vqrdmulh_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulh_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhs_s32(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulh_s32
+  #define vqrdmulh_s32(a, b) simde_vqrdmulh_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vqrdmulhq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulhq_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhh_s16(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhq_s16
+  #define vqrdmulhq_s16(a, b) simde_vqrdmulhq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqrdmulhq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulhq_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhs_s32(a_.values[i], b_.values[i]);
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhq_s32
+  #define vqrdmulhq_s32(a, b) simde_vqrdmulhq_s32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QRDMULH_H) */

--- a/2.0/simde/arm/neon/qrdmulh_n.h
+++ b/2.0/simde/arm/neon/qrdmulh_n.h
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_QRDMULH_N_H)
+#define SIMDE_ARM_NEON_QRDMULH_N_H
+
+#include "types.h"
+
+#include "combine.h"
+#include "qrdmulh.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vqrdmulh_n_s16(simde_int16x4_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulh_n_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhh_s16(a_.values[i], b);
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulh_n_s16
+  #define vqrdmulh_n_s16(a, b) simde_vqrdmulh_n_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vqrdmulh_n_s32(simde_int32x2_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulh_n_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhs_s32(a_.values[i], b);
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulh_n_s32
+  #define vqrdmulh_n_s32(a, b) simde_vqrdmulh_n_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vqrdmulhq_n_s16(simde_int16x8_t a, int16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulhq_n_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhh_s16(a_.values[i], b);
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhq_n_s16
+  #define vqrdmulhq_n_s16(a, b) simde_vqrdmulhq_n_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vqrdmulhq_n_s32(simde_int32x4_t a, int32_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vqrdmulhq_n_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = simde_vqrdmulhs_s32(a_.values[i], b);
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vqrdmulhq_n_s32
+  #define vqrdmulhq_n_s32(a, b) simde_vqrdmulhq_n_s32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QRDMULH_H) */

--- a/2.0/simde/arm/neon/qtbl.h
+++ b/2.0/simde/arm/neon/qtbl.h
@@ -1,0 +1,455 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_QTBL_H)
+#define SIMDE_ARM_NEON_QTBL_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbl1_u8(simde_uint8x16_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl1_u8(t, idx);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    __m128i r128 = _mm_shuffle_epi8(t, _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(15))));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
+    simde_uint8x8_private
+      r_,
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 16) ? t_.values[idx_.values[i]] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl1_u8
+  #define vqtbl1_u8(t, idx) simde_vqtbl1_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbl1_s8(simde_int8x16_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl1_s8(t, idx);
+  #else
+    return simde_vreinterpret_s8_u8(simde_vqtbl1_u8(simde_vreinterpretq_u8_s8(t), idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl1_s8
+  #define vqtbl1_s8(t, idx) simde_vqtbl1_s8((t), (idx))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbl2_u8(simde_uint8x16x2_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl2_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(31)));
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128 = _mm_blendv_epi8(r128_0, r128_1, _mm_slli_epi32(idx128, 3));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
+    simde_uint8x8_private
+      r_,
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 32) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl2_u8
+  #define vqtbl2_u8(t, idx) simde_vqtbl2_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbl2_s8(simde_int8x16x2_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl2_s8(t, idx);
+  #else
+    simde_uint8x16x2_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbl2_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl2_s8
+  #define vqtbl2_s8(t, idx) simde_vqtbl2_s8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbl3_u8(simde_uint8x16x3_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl3_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(47)));
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128_01 = _mm_blendv_epi8(r128_0, r128_1, _mm_slli_epi32(idx128, 3));
+    __m128i r128_2 = _mm_shuffle_epi8(t.val[2], idx128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_2, _mm_slli_epi32(idx128, 2));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
+                                     simde_uint8x16_to_private(t.val[2]) };
+    simde_uint8x8_private
+      r_,
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 48) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl3_u8
+  #define vqtbl3_u8(t, idx) simde_vqtbl3_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbl3_s8(simde_int8x16x3_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl3_s8(t, idx);
+  #else
+    simde_uint8x16x3_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbl3_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl3_s8
+  #define vqtbl3_s8(t, idx) simde_vqtbl3_s8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbl4_u8(simde_uint8x16x4_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl4_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(63)));
+    __m128i idx128_shl3 = _mm_slli_epi32(idx128, 3);
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128_01 = _mm_blendv_epi8(r128_0, r128_1, idx128_shl3);
+    __m128i r128_2 = _mm_shuffle_epi8(t.val[2], idx128);
+    __m128i r128_3 = _mm_shuffle_epi8(t.val[3], idx128);
+    __m128i r128_23 = _mm_blendv_epi8(r128_2, r128_3, idx128_shl3);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_23, _mm_slli_epi32(idx128, 2));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
+                                     simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) };
+    simde_uint8x8_private
+      r_,
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 64) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl4_u8
+  #define vqtbl4_u8(t, idx) simde_vqtbl4_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbl4_s8(simde_int8x16x4_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl4_s8(t, idx);
+  #else
+    simde_uint8x16x4_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbl4_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl4_s8
+  #define vqtbl4_s8(t, idx) simde_vqtbl4_s8((t), (idx))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbl1q_u8(simde_uint8x16_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl1q_u8(t, idx);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_epi8(t, _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(15))));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(vec_perm(t, t, idx),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 16))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_swizzle(t, idx);
+  #else
+    simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
+    simde_uint8x16_private
+      r_,
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 16) ? t_.values[idx_.values[i]] : 0;
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl1q_u8
+  #define vqtbl1q_u8(t, idx) simde_vqtbl1q_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbl1q_s8(simde_int8x16_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl1q_s8(t, idx);
+  #else
+    return simde_vreinterpretq_s8_u8(simde_vqtbl1q_u8(simde_vreinterpretq_u8_s8(t), idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl1q_s8
+  #define vqtbl1q_s8(t, idx) simde_vqtbl1q_s8((t), (idx))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbl2q_u8(simde_uint8x16x2_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl2q_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(31)));
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    return _mm_blendv_epi8(r_0, r_1, _mm_slli_epi32(idx, 3));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_and(vec_perm(t.val[0], t.val[1], idx),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 32))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                        wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16))));
+  #else
+    simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
+    simde_uint8x16_private
+      r_,
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 32) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl2q_u8
+  #define vqtbl2q_u8(t, idx) simde_vqtbl2q_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbl2q_s8(simde_int8x16x2_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl2q_s8(t, idx);
+  #else
+    simde_uint8x16x2_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbl2q_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl2q_s8
+  #define vqtbl2q_s8(t, idx) simde_vqtbl2q_s8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbl3q_u8(simde_uint8x16x3_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl3q_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(47)));
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    __m128i r_01 = _mm_blendv_epi8(r_0, r_1, _mm_slli_epi32(idx, 3));
+    __m128i r_2 = _mm_shuffle_epi8(t.val[2], idx);
+    return _mm_blendv_epi8(r_01, r_2, _mm_slli_epi32(idx, 2));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_2 = vec_perm(t.val[2], t.val[2], idx);
+    return vec_and(vec_sel(r_01, r_2, vec_cmpgt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 31)))),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 48))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                                     wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16)))),
+                                     wasm_v8x16_swizzle(t.val[2], wasm_i8x16_sub(idx, wasm_i8x16_splat(32))));
+  #else
+    simde_uint8x16_private t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
+                                     simde_uint8x16_to_private(t.val[2]) };
+    simde_uint8x16_private
+      r_,
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 48) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl3q_u8
+  #define vqtbl3q_u8(t, idx) simde_vqtbl3q_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbl3q_s8(simde_int8x16x3_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl3q_s8(t, idx);
+  #else
+    simde_uint8x16x3_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbl3q_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl3q_s8
+  #define vqtbl3q_s8(t, idx) simde_vqtbl3q_s8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbl4q_u8(simde_uint8x16x4_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl4q_u8(t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(63)));
+    __m128i idx_shl3 = _mm_slli_epi32(idx, 3);
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    __m128i r_01 = _mm_blendv_epi8(r_0, r_1, idx_shl3);
+    __m128i r_2 = _mm_shuffle_epi8(t.val[2], idx);
+    __m128i r_3 = _mm_shuffle_epi8(t.val[3], idx);
+    __m128i r_23 = _mm_blendv_epi8(r_2, r_3, idx_shl3);
+    return _mm_blendv_epi8(r_01, r_23, _mm_slli_epi32(idx, 2));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_23 = vec_perm(t.val[2], t.val[3], idx);
+    return vec_and(vec_sel(r_01, r_23, vec_cmpgt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 31)))),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 64))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                                     wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16)))),
+                        wasm_v128_or(wasm_v8x16_swizzle(t.val[2], wasm_i8x16_sub(idx, wasm_i8x16_splat(32))),
+                                     wasm_v8x16_swizzle(t.val[3], wasm_i8x16_sub(idx, wasm_i8x16_splat(48)))));
+  #else
+    simde_uint8x16_private t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]),
+                                     simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) };
+    simde_uint8x16_private
+      r_,
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 64) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : 0;
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl4q_u8
+  #define vqtbl4q_u8(t, idx) simde_vqtbl4q_u8((t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbl4q_s8(simde_int8x16x4_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbl4q_s8(t, idx);
+  #else
+    simde_uint8x16x4_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbl4q_u8(t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbl4q_s8
+  #define vqtbl4q_s8(t, idx) simde_vqtbl4q_s8((t), (idx))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QTBL_H) */

--- a/2.0/simde/arm/neon/qtbx.h
+++ b/2.0/simde/arm/neon/qtbx.h
@@ -1,0 +1,470 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_QTBX_H)
+#define SIMDE_ARM_NEON_QTBX_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbx1_u8(simde_uint8x8_t a, simde_uint8x16_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx1_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(15)));
+    __m128i r128 = _mm_shuffle_epi8(t, idx128);
+    r128 =  _mm_blendv_epi8(r128, _mm_set1_epi64(a), idx128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_ = simde_uint8x16_to_private(t);
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 16) ? t_.values[idx_.values[i]] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx1_u8
+  #define vqtbx1_u8(a, t, idx) simde_vqtbx1_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbx1_s8(simde_int8x8_t a, simde_int8x16_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx1_s8(a, t, idx);
+  #else
+    return simde_vreinterpret_s8_u8(simde_vqtbx1_u8(simde_vreinterpret_u8_s8(a), simde_vreinterpretq_u8_s8(t), idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx1_s8
+  #define vqtbx1_s8(a, t, idx) simde_vqtbx1_s8((a), (t), (idx))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbx2_u8(simde_uint8x8_t a, simde_uint8x16x2_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx2_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(31)));
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128 = _mm_blendv_epi8(r128_0, r128_1, _mm_slli_epi32(idx128, 3));
+    r128 =  _mm_blendv_epi8(r128, _mm_set1_epi64(a), idx128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) };
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 32) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx2_u8
+  #define vqtbx2_u8(a, t, idx) simde_vqtbx2_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbx2_s8(simde_int8x8_t a, simde_int8x16x2_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx2_s8(a, t, idx);
+  #else
+    simde_uint8x16x2_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbx2_u8(simde_vreinterpret_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx2_s8
+  #define vqtbx2_s8(a, t, idx) simde_vqtbx2_s8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbx3_u8(simde_uint8x8_t a, simde_uint8x16x3_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx3_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(47)));
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128_01 = _mm_blendv_epi8(r128_0, r128_1, _mm_slli_epi32(idx128, 3));
+    __m128i r128_2 = _mm_shuffle_epi8(t.val[2], idx128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_2, _mm_slli_epi32(idx128, 2));
+    r128 =  _mm_blendv_epi8(r128, _mm_set1_epi64(a), idx128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]) };
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 48) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx3_u8
+  #define vqtbx3_u8(a, t, idx) simde_vqtbx3_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbx3_s8(simde_int8x8_t a, simde_int8x16x3_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx3_s8(a, t, idx);
+  #else
+    simde_uint8x16x3_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbx3_u8(simde_vreinterpret_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx3_s8
+  #define vqtbx3_s8(a, t, idx) simde_vqtbx3_s8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vqtbx4_u8(simde_uint8x8_t a, simde_uint8x16x4_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx4_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i idx128 = _mm_set1_epi64(idx);
+    idx128 = _mm_or_si128(idx128, _mm_cmpgt_epi8(idx128, _mm_set1_epi8(63)));
+    __m128i idx128_shl3 = _mm_slli_epi32(idx128, 3);
+    __m128i r128_0 = _mm_shuffle_epi8(t.val[0], idx128);
+    __m128i r128_1 = _mm_shuffle_epi8(t.val[1], idx128);
+    __m128i r128_01 = _mm_blendv_epi8(r128_0, r128_1, idx128_shl3);
+    __m128i r128_2 = _mm_shuffle_epi8(t.val[2], idx128);
+    __m128i r128_3 = _mm_shuffle_epi8(t.val[3], idx128);
+    __m128i r128_23 = _mm_blendv_epi8(r128_2, r128_3, idx128_shl3);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_23, _mm_slli_epi32(idx128, 2));
+    r128 =  _mm_blendv_epi8(r128, _mm_set1_epi64(a), idx128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x16_private t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) };
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      idx_ = simde_uint8x8_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 64) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx4_u8
+  #define vqtbx4_u8(a, t, idx) simde_vqtbx4_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vqtbx4_s8(simde_int8x8_t a, simde_int8x16x4_t t, simde_uint8x8_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx4_s8(a, t, idx);
+  #else
+    simde_uint8x16x4_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpret_s8_u8(simde_vqtbx4_u8(simde_vreinterpret_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx4_s8
+  #define vqtbx4_s8(a, t, idx) simde_vqtbx4_s8((a), (t), (idx))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbx1q_u8(simde_uint8x16_t a, simde_uint8x16_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx1q_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(15)));
+    return  _mm_blendv_epi8(_mm_shuffle_epi8(t, idx), a, idx);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sel(a, vec_perm(t, t, idx), vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 16))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v8x16_swizzle(t, idx),
+                        wasm_v128_and(a, wasm_u8x16_gt(idx, wasm_i8x16_splat(15))));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      t_ = simde_uint8x16_to_private(t),
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 16) ? t_.values[idx_.values[i]] : a_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx1q_u8
+  #define vqtbx1q_u8(a, t, idx) simde_vqtbx1q_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbx1q_s8(simde_int8x16_t a, simde_int8x16_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx1q_s8(a, t, idx);
+  #else
+    return simde_vreinterpretq_s8_u8(simde_vqtbx1q_u8(simde_vreinterpretq_u8_s8(a), simde_vreinterpretq_u8_s8(t), idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx1q_s8
+  #define vqtbx1q_s8(a, t, idx) simde_vqtbx1q_s8((a), (t), (idx))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbx2q_u8(simde_uint8x16_t a, simde_uint8x16x2_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx2q_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(31)));
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    __m128i r =  _mm_blendv_epi8(r_0, r_1, _mm_slli_epi32(idx, 3));
+    return _mm_blendv_epi8(r, a, idx);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sel(a, vec_perm(t.val[0], t.val[1], idx), vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 32))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                                     wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16)))),
+                        wasm_v128_and(a, wasm_u8x16_gt(idx, wasm_i8x16_splat(31))));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      t_[2] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]) },
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 32) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx2q_u8
+  #define vqtbx2q_u8(a, t, idx) simde_vqtbx2q_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbx2q_s8(simde_int8x16_t a, simde_int8x16x2_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx2q_s8(a, t, idx);
+  #else
+    simde_uint8x16x2_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbx2q_u8(simde_vreinterpretq_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx2q_s8
+  #define vqtbx2q_s8(a, t, idx) simde_vqtbx2q_s8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbx3q_u8(simde_uint8x16_t a, simde_uint8x16x3_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx3q_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(47)));
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    __m128i r_01 = _mm_blendv_epi8(r_0, r_1, _mm_slli_epi32(idx, 3));
+    __m128i r_2 = _mm_shuffle_epi8(t.val[2], idx);
+    __m128i r = _mm_blendv_epi8(r_01, r_2, _mm_slli_epi32(idx, 2));
+    return _mm_blendv_epi8(r, a, idx);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_2 = vec_perm(t.val[2], t.val[2], idx);
+    return vec_sel(a, vec_sel(r_01, r_2, vec_cmpgt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 31)))),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 48))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                                     wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16)))),
+                        wasm_v128_or(wasm_v8x16_swizzle(t.val[2], wasm_i8x16_sub(idx, wasm_i8x16_splat(32))),
+                                     wasm_v128_and(a, wasm_u8x16_gt(idx, wasm_i8x16_splat(47)))));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      t_[3] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]) },
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 48) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx3q_u8
+  #define vqtbx3q_u8(a, t, idx) simde_vqtbx3q_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbx3q_s8(simde_int8x16_t a, simde_int8x16x3_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx3q_s8(a, t, idx);
+  #else
+    simde_uint8x16x3_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbx3q_u8(simde_vreinterpretq_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx3q_s8
+  #define vqtbx3q_s8(a, t, idx) simde_vqtbx3q_s8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vqtbx4q_u8(simde_uint8x16_t a, simde_uint8x16x4_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx4q_u8(a, t, idx);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    idx = _mm_or_si128(idx, _mm_cmpgt_epi8(idx, _mm_set1_epi8(63)));
+    __m128i idx_shl3 = _mm_slli_epi32(idx, 3);
+    __m128i r_0 = _mm_shuffle_epi8(t.val[0], idx);
+    __m128i r_1 = _mm_shuffle_epi8(t.val[1], idx);
+    __m128i r_01 = _mm_blendv_epi8(r_0, r_1, idx_shl3);
+    __m128i r_2 = _mm_shuffle_epi8(t.val[2], idx);
+    __m128i r_3 = _mm_shuffle_epi8(t.val[3], idx);
+    __m128i r_23 = _mm_blendv_epi8(r_2, r_3, idx_shl3);
+    __m128i r = _mm_blendv_epi8(r_01, r_23, _mm_slli_epi32(idx, 2));
+    return _mm_blendv_epi8(r, a, idx);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_01 = vec_perm(t.val[0], t.val[1], idx);
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) r_23 = vec_perm(t.val[2], t.val[3], idx);
+    return vec_sel(a, vec_sel(r_01, r_23, vec_cmpgt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 31)))),
+                   vec_cmplt(idx, vec_splats(HEDLEY_STATIC_CAST(unsigned char, 64))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_v128_or(wasm_v128_or(wasm_v8x16_swizzle(t.val[0], idx),
+                                                  wasm_v8x16_swizzle(t.val[1], wasm_i8x16_sub(idx, wasm_i8x16_splat(16)))),
+                                     wasm_v128_or(wasm_v8x16_swizzle(t.val[2], wasm_i8x16_sub(idx, wasm_i8x16_splat(32))),
+                                                  wasm_v8x16_swizzle(t.val[3], wasm_i8x16_sub(idx, wasm_i8x16_splat(48))))),
+                        wasm_v128_and(a, wasm_u8x16_gt(idx, wasm_i8x16_splat(63))));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      t_[4] = { simde_uint8x16_to_private(t.val[0]), simde_uint8x16_to_private(t.val[1]), simde_uint8x16_to_private(t.val[2]), simde_uint8x16_to_private(t.val[3]) },
+      idx_ = simde_uint8x16_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (idx_.values[i] < 64) ? t_[idx_.values[i] / 16].values[idx_.values[i] & 15] : a_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx4q_u8
+  #define vqtbx4q_u8(a, t, idx) simde_vqtbx4q_u8((a), (t), (idx))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vqtbx4q_s8(simde_int8x16_t a, simde_int8x16x4_t t, simde_uint8x16_t idx) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vqtbx4q_s8(a, t, idx);
+  #else
+    simde_uint8x16x4_t t_;
+    simde_memcpy(&t_, &t, sizeof(t_));
+    return simde_vreinterpretq_s8_u8(simde_vqtbx4q_u8(simde_vreinterpretq_u8_s8(a), t_, idx));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vqtbx4q_s8
+  #define vqtbx4q_s8(a, t, idx) simde_vqtbx4q_s8((a), (t), (idx))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_QTBX_H) */

--- a/2.0/simde/arm/neon/rbit.h
+++ b/2.0/simde/arm/neon/rbit.h
@@ -1,0 +1,147 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_RBIT_H)
+#define SIMDE_ARM_NEON_RBIT_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrbit_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vrbit_u8(a);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    __m64 mask;
+    mask = _mm_set1_pi8(0x55);
+    a = _mm_or_si64(_mm_andnot_si64(mask, _mm_slli_pi16(a, 1)), _mm_and_si64(mask, _mm_srli_pi16(a, 1)));
+    mask = _mm_set1_pi8(0x33);
+    a = _mm_or_si64(_mm_andnot_si64(mask, _mm_slli_pi16(a, 2)), _mm_and_si64(mask, _mm_srli_pi16(a, 2)));
+    mask = _mm_set1_pi8(0x0F);
+    a = _mm_or_si64(_mm_andnot_si64(mask, _mm_slli_pi16(a, 4)), _mm_and_si64(mask, _mm_srli_pi16(a, 4)));
+    return a;
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, (((a_.values[i] * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101)) >> 32);
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vrbit_u8
+  #define vrbit_u8(a) simde_vrbit_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrbit_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vrbit_s8(a);
+  #else
+    return simde_vreinterpret_s8_u8(simde_vrbit_u8(simde_vreinterpret_u8_s8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vrbit_s8
+  #define vrbit_s8(a) simde_vrbit_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrbitq_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vrbitq_u8(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    __m128i mask;
+    mask = _mm_set1_epi8(0x55);
+    a = _mm_or_si128(_mm_andnot_si128(mask, _mm_slli_epi16(a, 1)), _mm_and_si128(mask, _mm_srli_epi16(a, 1)));
+    mask = _mm_set1_epi8(0x33);
+    a = _mm_or_si128(_mm_andnot_si128(mask, _mm_slli_epi16(a, 2)), _mm_and_si128(mask, _mm_srli_epi16(a, 2)));
+    mask = _mm_set1_epi8(0x0F);
+    a = _mm_or_si128(_mm_andnot_si128(mask, _mm_slli_epi16(a, 4)), _mm_and_si128(mask, _mm_srli_epi16(a, 4)));
+    return a;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) shift;
+    shift = vec_splat_u8(1);
+    a = vec_sel(vec_sl(a, shift), vec_sr(a, shift), vec_splats(HEDLEY_STATIC_CAST(unsigned char, 0x55)));
+    shift = vec_splat_u8(2);
+    a = vec_sel(vec_sl(a, shift), vec_sr(a, shift), vec_splats(HEDLEY_STATIC_CAST(unsigned char, 0x33)));
+    shift = vec_splat_u8(4);
+    a = vec_or(vec_sl(a, shift), vec_sr(a, shift));
+    return a;
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    a = wasm_v128_bitselect(wasm_u8x16_shr(a, 1), wasm_i8x16_shl(a, 1), wasm_i8x16_splat(0x55));
+    a = wasm_v128_bitselect(wasm_u8x16_shr(a, 2), wasm_i8x16_shl(a, 2), wasm_i8x16_splat(0x33));
+    a = wasm_v128_or(wasm_u8x16_shr(a, 4), wasm_i8x16_shl(a, 4));
+    return a;
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, (((a_.values[i] * UINT64_C(0x80200802)) & UINT64_C(0x0884422110)) * UINT64_C(0x0101010101)) >> 32);
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vrbitq_u8
+  #define vrbitq_u8(a) simde_vrbitq_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrbitq_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vrbitq_s8(a);
+  #else
+    return simde_vreinterpretq_s8_u8(simde_vrbitq_u8(simde_vreinterpretq_u8_s8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vrbitq_s8
+  #define vrbitq_s8(a) simde_vrbitq_s8(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_RBIT_H) */

--- a/2.0/simde/arm/neon/reinterpret.h
+++ b/2.0/simde/arm/neon/reinterpret.h
@@ -1,0 +1,3101 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+
+#if !defined(SIMDE_ARM_NEON_REINTERPRET_H)
+#define SIMDE_ARM_NEON_REINTERPRET_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_s16(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_s16
+  #define vreinterpret_s8_s16(a) simde_vreinterpret_s8_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_s32(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_s32
+  #define vreinterpret_s8_s32(a) simde_vreinterpret_s8_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_s64(a);
+  #else
+    simde_int8x8_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_s64
+  #define vreinterpret_s8_s64(a) simde_vreinterpret_s8_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_u8(a);
+  #else
+    simde_int8x8_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_u8
+  #define vreinterpret_s8_u8(a) simde_vreinterpret_s8_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_u16(a);
+  #else
+    simde_int8x8_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_u16
+  #define vreinterpret_s8_u16(a) simde_vreinterpret_s8_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_u32(a);
+  #else
+    simde_int8x8_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_u32
+  #define vreinterpret_s8_u32(a) simde_vreinterpret_s8_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_u64(a);
+  #else
+    simde_int8x8_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_u64
+  #define vreinterpret_s8_u64(a) simde_vreinterpret_s8_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s8_f32(a);
+  #else
+    simde_int8x8_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_f32
+  #define vreinterpret_s8_f32(a) simde_vreinterpret_s8_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vreinterpret_s8_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_s8_f64(a);
+  #else
+    simde_int8x8_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s8_f64
+  #define vreinterpret_s8_f64(a) simde_vreinterpret_s8_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_s16(a);
+  #else
+    simde_int8x16_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_s16
+  #define vreinterpretq_s8_s16(a) simde_vreinterpretq_s8_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_s32(a);
+  #else
+    simde_int8x16_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_s32
+  #define vreinterpretq_s8_s32(a) simde_vreinterpretq_s8_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_s64(a);
+  #else
+    simde_int8x16_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_s64
+  #define vreinterpretq_s8_s64(a) simde_vreinterpretq_s8_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_u8(a);
+  #else
+    simde_int8x16_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_u8
+  #define vreinterpretq_s8_u8(a) simde_vreinterpretq_s8_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_u16(a);
+  #else
+    simde_int8x16_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_u16
+  #define vreinterpretq_s8_u16(a) simde_vreinterpretq_s8_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_u32(a);
+  #else
+    simde_int8x16_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_u32
+  #define vreinterpretq_s8_u32(a) simde_vreinterpretq_s8_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_u64(a);
+  #else
+    simde_int8x16_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_u64
+  #define vreinterpretq_s8_u64(a) simde_vreinterpretq_s8_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s8_f32(a);
+  #else
+    simde_int8x16_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_f32
+  #define vreinterpretq_s8_f32(a) simde_vreinterpretq_s8_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vreinterpretq_s8_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s8_f64(a);
+  #else
+    simde_int8x16_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s8_f64
+  #define vreinterpretq_s8_f64(a) simde_vreinterpretq_s8_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_s8(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_s8
+  #define vreinterpret_s16_s8(a) simde_vreinterpret_s16_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_s32(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_s32
+  #define vreinterpret_s16_s32(a) simde_vreinterpret_s16_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_s64(a);
+  #else
+    simde_int16x4_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_s64
+  #define vreinterpret_s16_s64(a) simde_vreinterpret_s16_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_u8(a);
+  #else
+    simde_int16x4_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_u8
+  #define vreinterpret_s16_u8(a) simde_vreinterpret_s16_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_u16(a);
+  #else
+    simde_int16x4_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_u16
+  #define vreinterpret_s16_u16(a) simde_vreinterpret_s16_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_u32(a);
+  #else
+    simde_int16x4_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_u32
+  #define vreinterpret_s16_u32(a) simde_vreinterpret_s16_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_u64(a);
+  #else
+    simde_int16x4_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_u64
+  #define vreinterpret_s16_u64(a) simde_vreinterpret_s16_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s16_f32(a);
+  #else
+    simde_int16x4_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_f32
+  #define vreinterpret_s16_f32(a) simde_vreinterpret_s16_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vreinterpret_s16_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_s16_f64(a);
+  #else
+    simde_int16x4_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s16_f64
+  #define vreinterpret_s16_f64(a) simde_vreinterpret_s16_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_s8(a);
+  #else
+    simde_int16x8_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_s8
+  #define vreinterpretq_s16_s8(a) simde_vreinterpretq_s16_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_s32(a);
+  #else
+    simde_int16x8_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_s32
+  #define vreinterpretq_s16_s32(a) simde_vreinterpretq_s16_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_s64(a);
+  #else
+    simde_int16x8_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_s64
+  #define vreinterpretq_s16_s64(a) simde_vreinterpretq_s16_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_u8(a);
+  #else
+    simde_int16x8_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_u8
+  #define vreinterpretq_s16_u8(a) simde_vreinterpretq_s16_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_u16(a);
+  #else
+    simde_int16x8_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_u16
+  #define vreinterpretq_s16_u16(a) simde_vreinterpretq_s16_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_u32(a);
+  #else
+    simde_int16x8_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_u32
+  #define vreinterpretq_s16_u32(a) simde_vreinterpretq_s16_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_u64(a);
+  #else
+    simde_int16x8_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_u64
+  #define vreinterpretq_s16_u64(a) simde_vreinterpretq_s16_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s16_f32(a);
+  #else
+    simde_int16x8_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_f32
+  #define vreinterpretq_s16_f32(a) simde_vreinterpretq_s16_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vreinterpretq_s16_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s16_f64(a);
+  #else
+    simde_int16x8_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s16_f64
+  #define vreinterpretq_s16_f64(a) simde_vreinterpretq_s16_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_s8(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_s8
+  #define vreinterpret_s32_s8(a) simde_vreinterpret_s32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_s16(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_s16
+  #define vreinterpret_s32_s16(a) simde_vreinterpret_s32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_s64(a);
+  #else
+    simde_int32x2_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_s64
+  #define vreinterpret_s32_s64(a) simde_vreinterpret_s32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_u8(a);
+  #else
+    simde_int32x2_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_u8
+  #define vreinterpret_s32_u8(a) simde_vreinterpret_s32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_u16(a);
+  #else
+    simde_int32x2_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_u16
+  #define vreinterpret_s32_u16(a) simde_vreinterpret_s32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_u32(a);
+  #else
+    simde_int32x2_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_u32
+  #define vreinterpret_s32_u32(a) simde_vreinterpret_s32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_u64(a);
+  #else
+    simde_int32x2_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_u64
+  #define vreinterpret_s32_u64(a) simde_vreinterpret_s32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s32_f32(a);
+  #else
+    simde_int32x2_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_f32
+  #define vreinterpret_s32_f32(a) simde_vreinterpret_s32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vreinterpret_s32_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_s32_f64(a);
+  #else
+    simde_int32x2_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s32_f64
+  #define vreinterpret_s32_f64(a) simde_vreinterpret_s32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_s8(a);
+  #else
+    simde_int32x4_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_s8
+  #define vreinterpretq_s32_s8(a) simde_vreinterpretq_s32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_s16(a);
+  #else
+    simde_int32x4_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_s16
+  #define vreinterpretq_s32_s16(a) simde_vreinterpretq_s32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_s64(a);
+  #else
+    simde_int32x4_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_s64
+  #define vreinterpretq_s32_s64(a) simde_vreinterpretq_s32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_u8(a);
+  #else
+    simde_int32x4_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_u8
+  #define vreinterpretq_s32_u8(a) simde_vreinterpretq_s32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_u16(a);
+  #else
+    simde_int32x4_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_u16
+  #define vreinterpretq_s32_u16(a) simde_vreinterpretq_s32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_u32(a);
+  #else
+    simde_int32x4_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_u32
+  #define vreinterpretq_s32_u32(a) simde_vreinterpretq_s32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_u64(a);
+  #else
+    simde_int32x4_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_u64
+  #define vreinterpretq_s32_u64(a) simde_vreinterpretq_s32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s32_f32(a);
+  #else
+    simde_int32x4_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_f32
+  #define vreinterpretq_s32_f32(a) simde_vreinterpretq_s32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vreinterpretq_s32_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s32_f64(a);
+  #else
+    simde_int32x4_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s32_f64
+  #define vreinterpretq_s32_f64(a) simde_vreinterpretq_s32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_s8(a);
+  #else
+    simde_int64x1_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_s8
+  #define vreinterpret_s64_s8(a) simde_vreinterpret_s64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_s16(a);
+  #else
+    simde_int64x1_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_s16
+  #define vreinterpret_s64_s16(a) simde_vreinterpret_s64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_s32(a);
+  #else
+    simde_int64x1_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_s32
+  #define vreinterpret_s64_s32(a) simde_vreinterpret_s64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_u8(a);
+  #else
+    simde_int64x1_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_u8
+  #define vreinterpret_s64_u8(a) simde_vreinterpret_s64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_u16(a);
+  #else
+    simde_int64x1_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_u16
+  #define vreinterpret_s64_u16(a) simde_vreinterpret_s64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_u32(a);
+  #else
+    simde_int64x1_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_u32
+  #define vreinterpret_s64_u32(a) simde_vreinterpret_s64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_u64(a);
+  #else
+    simde_int64x1_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_u64
+  #define vreinterpret_s64_u64(a) simde_vreinterpret_s64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_s64_f32(a);
+  #else
+    simde_int64x1_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_f32
+  #define vreinterpret_s64_f32(a) simde_vreinterpret_s64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vreinterpret_s64_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_s64_f64(a);
+  #else
+    simde_int64x1_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_s64_f64
+  #define vreinterpret_s64_f64(a) simde_vreinterpret_s64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_s8(a);
+  #else
+    simde_int64x2_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_s8
+  #define vreinterpretq_s64_s8(a) simde_vreinterpretq_s64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_s16(a);
+  #else
+    simde_int64x2_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_s16
+  #define vreinterpretq_s64_s16(a) simde_vreinterpretq_s64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_s32(a);
+  #else
+    simde_int64x2_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_s32
+  #define vreinterpretq_s64_s32(a) simde_vreinterpretq_s64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_u8(a);
+  #else
+    simde_int64x2_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_u8
+  #define vreinterpretq_s64_u8(a) simde_vreinterpretq_s64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_u16(a);
+  #else
+    simde_int64x2_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_u16
+  #define vreinterpretq_s64_u16(a) simde_vreinterpretq_s64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_u32(a);
+  #else
+    simde_int64x2_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_u32
+  #define vreinterpretq_s64_u32(a) simde_vreinterpretq_s64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_u64(a);
+  #else
+    simde_int64x2_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_u64
+  #define vreinterpretq_s64_u64(a) simde_vreinterpretq_s64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_f32(a);
+  #else
+    simde_int64x2_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_f32
+  #define vreinterpretq_s64_f32(a) simde_vreinterpretq_s64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vreinterpretq_s64_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s64_f64(a);
+  #else
+    simde_int64x2_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_s64_f64
+  #define vreinterpretq_s64_f64(a) simde_vreinterpretq_s64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_s8(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_s8
+  #define vreinterpret_u8_s8(a) simde_vreinterpret_u8_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_s16(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_s16
+  #define vreinterpret_u8_s16(a) simde_vreinterpret_u8_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_s32(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_s32
+  #define vreinterpret_u8_s32(a) simde_vreinterpret_u8_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_s64(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_s64
+  #define vreinterpret_u8_s64(a) simde_vreinterpret_u8_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_u16(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_u16
+  #define vreinterpret_u8_u16(a) simde_vreinterpret_u8_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_u32(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_u32
+  #define vreinterpret_u8_u32(a) simde_vreinterpret_u8_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_u64(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_u64
+  #define vreinterpret_u8_u64(a) simde_vreinterpret_u8_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u8_f32(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_f32
+  #define vreinterpret_u8_f32(a) simde_vreinterpret_u8_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vreinterpret_u8_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_u8_f64(a);
+  #else
+    simde_uint8x8_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u8_f64
+  #define vreinterpret_u8_f64(a) simde_vreinterpret_u8_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_s8(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_s8
+  #define vreinterpretq_u8_s8(a) simde_vreinterpretq_u8_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_s16(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_s16
+  #define vreinterpretq_u8_s16(a) simde_vreinterpretq_u8_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_s32(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_s32
+  #define vreinterpretq_u8_s32(a) simde_vreinterpretq_u8_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_s64(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_s64
+  #define vreinterpretq_u8_s64(a) simde_vreinterpretq_u8_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_u16(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_u16
+  #define vreinterpretq_u8_u16(a) simde_vreinterpretq_u8_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_u32(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_u32
+  #define vreinterpretq_u8_u32(a) simde_vreinterpretq_u8_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_u64(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_u64
+  #define vreinterpretq_u8_u64(a) simde_vreinterpretq_u8_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u8_f32(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_f32
+  #define vreinterpretq_u8_f32(a) simde_vreinterpretq_u8_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vreinterpretq_u8_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_u8_f64(a);
+  #else
+    simde_uint8x16_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u8_f64
+  #define vreinterpretq_u8_f64(a) simde_vreinterpretq_u8_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_s8(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_s8
+  #define vreinterpret_u16_s8(a) simde_vreinterpret_u16_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_s16(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_s16
+  #define vreinterpret_u16_s16(a) simde_vreinterpret_u16_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_s32(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_s32
+  #define vreinterpret_u16_s32(a) simde_vreinterpret_u16_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_s64(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_s64
+  #define vreinterpret_u16_s64(a) simde_vreinterpret_u16_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_u8(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_u8
+  #define vreinterpret_u16_u8(a) simde_vreinterpret_u16_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_u32(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_u32
+  #define vreinterpret_u16_u32(a) simde_vreinterpret_u16_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_u64(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_u64
+  #define vreinterpret_u16_u64(a) simde_vreinterpret_u16_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u16_f32(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_f32
+  #define vreinterpret_u16_f32(a) simde_vreinterpret_u16_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vreinterpret_u16_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_u16_f64(a);
+  #else
+    simde_uint16x4_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u16_f64
+  #define vreinterpret_u16_f64(a) simde_vreinterpret_u16_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_s8(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_s8
+  #define vreinterpretq_u16_s8(a) simde_vreinterpretq_u16_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_s16(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_s16
+  #define vreinterpretq_u16_s16(a) simde_vreinterpretq_u16_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_s32(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_s32
+  #define vreinterpretq_u16_s32(a) simde_vreinterpretq_u16_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_s64(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_s64
+  #define vreinterpretq_u16_s64(a) simde_vreinterpretq_u16_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_u8(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_u8
+  #define vreinterpretq_u16_u8(a) simde_vreinterpretq_u16_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_u32(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_u32
+  #define vreinterpretq_u16_u32(a) simde_vreinterpretq_u16_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_u64(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_u64
+  #define vreinterpretq_u16_u64(a) simde_vreinterpretq_u16_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u16_f32(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_f32
+  #define vreinterpretq_u16_f32(a) simde_vreinterpretq_u16_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vreinterpretq_u16_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_u16_f64(a);
+  #else
+    simde_uint16x8_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u16_f64
+  #define vreinterpretq_u16_f64(a) simde_vreinterpretq_u16_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_s8(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_s8
+  #define vreinterpret_u32_s8(a) simde_vreinterpret_u32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_s16(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_s16
+  #define vreinterpret_u32_s16(a) simde_vreinterpret_u32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_s32(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_s32
+  #define vreinterpret_u32_s32(a) simde_vreinterpret_u32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_s64(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_s64
+  #define vreinterpret_u32_s64(a) simde_vreinterpret_u32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_u8(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_u8
+  #define vreinterpret_u32_u8(a) simde_vreinterpret_u32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_u16(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_u16
+  #define vreinterpret_u32_u16(a) simde_vreinterpret_u32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_u64(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_u64
+  #define vreinterpret_u32_u64(a) simde_vreinterpret_u32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u32_f32(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_f32
+  #define vreinterpret_u32_f32(a) simde_vreinterpret_u32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vreinterpret_u32_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_u32_f64(a);
+  #else
+    simde_uint32x2_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u32_f64
+  #define vreinterpret_u32_f64(a) simde_vreinterpret_u32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_s8(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_s8
+  #define vreinterpretq_u32_s8(a) simde_vreinterpretq_u32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_s16(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_s16
+  #define vreinterpretq_u32_s16(a) simde_vreinterpretq_u32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_s32(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_s32
+  #define vreinterpretq_u32_s32(a) simde_vreinterpretq_u32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_s64(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_s64
+  #define vreinterpretq_u32_s64(a) simde_vreinterpretq_u32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_u8(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_u8
+  #define vreinterpretq_u32_u8(a) simde_vreinterpretq_u32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_u16(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_u16
+  #define vreinterpretq_u32_u16(a) simde_vreinterpretq_u32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_u64(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_u64
+  #define vreinterpretq_u32_u64(a) simde_vreinterpretq_u32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u32_f32(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_f32
+  #define vreinterpretq_u32_f32(a) simde_vreinterpretq_u32_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vreinterpretq_u32_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_u32_f64(a);
+  #else
+    simde_uint32x4_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u32_f64
+  #define vreinterpretq_u32_f64(a) simde_vreinterpretq_u32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_s8(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_s8
+  #define vreinterpret_u64_s8(a) simde_vreinterpret_u64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_s16(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_s16
+  #define vreinterpret_u64_s16(a) simde_vreinterpret_u64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_s32(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_s32
+  #define vreinterpret_u64_s32(a) simde_vreinterpret_u64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_s64(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_s64
+  #define vreinterpret_u64_s64(a) simde_vreinterpret_u64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_u8(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_u8
+  #define vreinterpret_u64_u8(a) simde_vreinterpret_u64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_u16(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_u16
+  #define vreinterpret_u64_u16(a) simde_vreinterpret_u64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_u32(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_u32
+  #define vreinterpret_u64_u32(a) simde_vreinterpret_u64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_u64_f32(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_f32
+  #define vreinterpret_u64_f32(a) simde_vreinterpret_u64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vreinterpret_u64_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_u64_f64(a);
+  #else
+    simde_uint64x1_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_u64_f64
+  #define vreinterpret_u64_f64(a) simde_vreinterpret_u64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_s8(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_s8
+  #define vreinterpretq_u64_s8(a) simde_vreinterpretq_u64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_s16(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_s16
+  #define vreinterpretq_u64_s16(a) simde_vreinterpretq_u64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_s32(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_s32
+  #define vreinterpretq_u64_s32(a) simde_vreinterpretq_u64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_s64(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_s64
+  #define vreinterpretq_u64_s64(a) simde_vreinterpretq_u64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_u8(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_u8
+  #define vreinterpretq_u64_u8(a) simde_vreinterpretq_u64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_u16(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_u16
+  #define vreinterpretq_u64_u16(a) simde_vreinterpretq_u64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_u32(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_u32
+  #define vreinterpretq_u64_u32(a) simde_vreinterpretq_u64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_u64_f32(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_f32
+  #define vreinterpretq_u64_f32(a) simde_vreinterpretq_u64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vreinterpretq_u64_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_u64_f64(a);
+  #else
+    simde_uint64x2_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_u64_f64
+  #define vreinterpretq_u64_f64(a) simde_vreinterpretq_u64_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_s8(a);
+  #else
+    simde_float32x2_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_s8
+  #define vreinterpret_f32_s8(a) simde_vreinterpret_f32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_s16(a);
+  #else
+    simde_float32x2_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_s16
+  #define vreinterpret_f32_s16(a) simde_vreinterpret_f32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_s32(a);
+  #else
+    simde_float32x2_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_s32
+  #define vreinterpret_f32_s32(a) simde_vreinterpret_f32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_s64(a);
+  #else
+    simde_float32x2_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_s64
+  #define vreinterpret_f32_s64(a) simde_vreinterpret_f32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_u8(a);
+  #else
+    simde_float32x2_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_u8
+  #define vreinterpret_f32_u8(a) simde_vreinterpret_f32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_u16(a);
+  #else
+    simde_float32x2_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_u16
+  #define vreinterpret_f32_u16(a) simde_vreinterpret_f32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_u32(a);
+  #else
+    simde_float32x2_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_u32
+  #define vreinterpret_f32_u32(a) simde_vreinterpret_f32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpret_f32_u64(a);
+  #else
+    simde_float32x2_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_u64
+  #define vreinterpret_f32_u64(a) simde_vreinterpret_f32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vreinterpret_f32_f64(simde_float64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f32_f64(a);
+  #else
+    simde_float32x2_private r_;
+    simde_float64x1_private a_ = simde_float64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f32_f64
+  #define vreinterpret_f32_f64(a) simde_vreinterpret_f32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_s8(a);
+  #else
+    simde_float32x4_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_s8
+  #define vreinterpretq_f32_s8(a) simde_vreinterpretq_f32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_s16(a);
+  #else
+    simde_float32x4_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_s16
+  #define vreinterpretq_f32_s16(a) simde_vreinterpretq_f32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_s32(a);
+  #else
+    simde_float32x4_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_s32
+  #define vreinterpretq_f32_s32(a) simde_vreinterpretq_f32_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_s64(a);
+  #else
+    simde_float32x4_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_s64
+  #define vreinterpretq_f32_s64(a) simde_vreinterpretq_f32_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_u8(a);
+  #else
+    simde_float32x4_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_u8
+  #define vreinterpretq_f32_u8(a) simde_vreinterpretq_f32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_u16(a);
+  #else
+    simde_float32x4_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_u16
+  #define vreinterpretq_f32_u16(a) simde_vreinterpretq_f32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_u32(a);
+  #else
+    simde_float32x4_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_u32
+  #define vreinterpretq_f32_u32(a) simde_vreinterpretq_f32_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_f32_u64(a);
+  #else
+    simde_float32x4_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_u64
+  #define vreinterpretq_f32_u64(a) simde_vreinterpretq_f32_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vreinterpretq_f32_f64(simde_float64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f32_f64(a);
+  #else
+    simde_float32x4_private r_;
+    simde_float64x2_private a_ = simde_float64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f32_f64
+  #define vreinterpretq_f32_f64(a) simde_vreinterpretq_f32_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_s8(a);
+  #else
+    simde_float64x1_private r_;
+    simde_int8x8_private a_ = simde_int8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_s8
+  #define vreinterpret_f64_s8(a) simde_vreinterpret_f64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_s16(a);
+  #else
+    simde_float64x1_private r_;
+    simde_int16x4_private a_ = simde_int16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_s16
+  #define vreinterpret_f64_s16(a) simde_vreinterpret_f64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_s32(a);
+  #else
+    simde_float64x1_private r_;
+    simde_int32x2_private a_ = simde_int32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_s32
+  #define vreinterpret_f64_s32(a) simde_vreinterpret_f64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_s64(simde_int64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_s64(a);
+  #else
+    simde_float64x1_private r_;
+    simde_int64x1_private a_ = simde_int64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_s64
+  #define vreinterpret_f64_s64(a) simde_vreinterpret_f64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_u8(a);
+  #else
+    simde_float64x1_private r_;
+    simde_uint8x8_private a_ = simde_uint8x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_u8
+  #define vreinterpret_f64_u8(a) simde_vreinterpret_f64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_u16(a);
+  #else
+    simde_float64x1_private r_;
+    simde_uint16x4_private a_ = simde_uint16x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_u16
+  #define vreinterpret_f64_u16(a) simde_vreinterpret_f64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_u32(a);
+  #else
+    simde_float64x1_private r_;
+    simde_uint32x2_private a_ = simde_uint32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_u32
+  #define vreinterpret_f64_u32(a) simde_vreinterpret_f64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_u64(simde_uint64x1_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_u64(a);
+  #else
+    simde_float64x1_private r_;
+    simde_uint64x1_private a_ = simde_uint64x1_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_u64
+  #define vreinterpret_f64_u64(a) simde_vreinterpret_f64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vreinterpret_f64_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpret_f64_f32(a);
+  #else
+    simde_float64x1_private r_;
+    simde_float32x2_private a_ = simde_float32x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpret_f64_f32
+  #define vreinterpret_f64_f32(a) simde_vreinterpret_f64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s8(a);
+  #else
+    simde_float64x2_private r_;
+    simde_int8x16_private a_ = simde_int8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_s8
+  #define vreinterpretq_f64_s8(a) simde_vreinterpretq_f64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s16(a);
+  #else
+    simde_float64x2_private r_;
+    simde_int16x8_private a_ = simde_int16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_s16
+  #define vreinterpretq_f64_s16(a) simde_vreinterpretq_f64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s32(a);
+  #else
+    simde_float64x2_private r_;
+    simde_int32x4_private a_ = simde_int32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_s32
+  #define vreinterpretq_f64_s32(a) simde_vreinterpretq_f64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_s64(simde_int64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s64(a);
+  #else
+    simde_float64x2_private r_;
+    simde_int64x2_private a_ = simde_int64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_s64
+  #define vreinterpretq_f64_s64(a) simde_vreinterpretq_f64_s64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_u8(a);
+  #else
+    simde_float64x2_private r_;
+    simde_uint8x16_private a_ = simde_uint8x16_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_u8
+  #define vreinterpretq_f64_u8(a) simde_vreinterpretq_f64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_u16(a);
+  #else
+    simde_float64x2_private r_;
+    simde_uint16x8_private a_ = simde_uint16x8_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_u16
+  #define vreinterpretq_f64_u16(a) simde_vreinterpretq_f64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_u32(a);
+  #else
+    simde_float64x2_private r_;
+    simde_uint32x4_private a_ = simde_uint32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_u32
+  #define vreinterpretq_f64_u32(a) simde_vreinterpretq_f64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_u64(simde_uint64x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_u64(a);
+  #else
+    simde_float64x2_private r_;
+    simde_uint64x2_private a_ = simde_uint64x2_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_u64
+  #define vreinterpretq_f64_u64(a) simde_vreinterpretq_f64_u64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vreinterpretq_f64_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_f32(a);
+  #else
+    simde_float64x2_private r_;
+    simde_float32x4_private a_ = simde_float32x4_to_private(a);
+    simde_memcpy(&r_, &a_, sizeof(r_));
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vreinterpretq_f64_f32
+  #define vreinterpretq_f64_f32(a) simde_vreinterpretq_f64_f32(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif

--- a/2.0/simde/arm/neon/rev16.h
+++ b/2.0/simde/arm/neon/rev16.h
@@ -1,0 +1,137 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_REV16_H)
+#define SIMDE_ARM_NEON_REV16_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrev16_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev16_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi8(a, _mm_set_pi8(6, 7, 4, 5, 2, 3, 0, 1));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, a_.values, 1, 0, 3, 2, 5, 4, 7, 6);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev16_s8
+  #define vrev16_s8(a) simde_vrev16_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrev16_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev16_u8(a);
+  #else
+    return simde_vreinterpret_u8_s8(simde_vrev16_s8(simde_vreinterpret_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev16_u8
+  #define vrev16_u8(a) simde_vrev16_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrev16q_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev16q_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, _mm_set_epi8(14, 15, 12, 13, 10, 11, 8, 9, 6, 7, 4, 5, 2, 3, 0, 1));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_revb(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+                                                                    a)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 1, 0, 3, 2, 5, 4, 7, 6, 9, 8, 11, 10, 13, 12, 15, 14);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev16q_s8
+  #define vrev16q_s8(a) simde_vrev16q_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrev16q_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev16q_u8(a);
+  #else
+    return simde_vreinterpretq_u8_s8(simde_vrev16q_s8(simde_vreinterpretq_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev16q_u8
+  #define vrev16q_u8(a) simde_vrev16q_u8(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_REV16_H) */

--- a/2.0/simde/arm/neon/rev32.h
+++ b/2.0/simde/arm/neon/rev32.h
@@ -1,0 +1,235 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_REV32_H)
+#define SIMDE_ARM_NEON_REV32_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrev32_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi8(a, _mm_set_pi8(4, 5, 6, 7, 0, 1, 2, 3));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, a_.values, 3, 2, 1, 0, 7, 6, 5, 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 3];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32_s8
+  #define vrev32_s8(a) simde_vrev32_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vrev32_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32_s16(a);
+  #elif defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi16(a, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, a_.values, 1, 0, 3, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32_s16
+  #define vrev32_s16(a) simde_vrev32_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrev32_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32_u8(a);
+  #else
+    return simde_vreinterpret_u8_s8(simde_vrev32_s8(simde_vreinterpret_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32_u8
+  #define vrev32_u8(a) simde_vrev32_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vrev32_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32_u16(a);
+  #else
+    return simde_vreinterpret_u16_s16(simde_vrev32_s16(simde_vreinterpret_s16_u16(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32_u16
+  #define vrev32_u16(a) simde_vrev32_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrev32q_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32q_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, _mm_set_epi8(12, 13, 14, 15, 8, 9, 10, 11,
+                                             4,  5,  6,  7, 0, 1,  2,  3));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_revb(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+                                                                    a)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 3, 2, 1, 0, 7, 6, 5, 4, 11, 10, 9, 8, 15, 14, 13, 12);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 3];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32q_s8
+  #define vrev32q_s8(a) simde_vrev32q_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vrev32q_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32q_s16(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, _mm_set_epi8(13, 12, 15, 14, 9, 8, 11, 10,
+                                             5,  4,  7,  6, 1, 0,  3,  2));
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_shufflehi_epi16(_mm_shufflelo_epi16(a,
+                               (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0)),
+                               (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 1, 0, 3, 2, 5, 4, 7, 6);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32q_s16
+  #define vrev32q_s16(a) simde_vrev32q_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrev32q_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32q_u8(a);
+  #else
+    return simde_vreinterpretq_u8_s8(simde_vrev32q_s8(simde_vreinterpretq_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32q_u8
+  #define vrev32q_u8(a) simde_vrev32q_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vrev32q_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev32q_u16(a);
+  #else
+    return simde_vreinterpretq_u16_s16(simde_vrev32q_s16(simde_vreinterpretq_s16_u16(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev32q_u16
+  #define vrev32q_u16(a) simde_vrev32q_u16(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_REV32_H) */

--- a/2.0/simde/arm/neon/rev64.h
+++ b/2.0/simde/arm/neon/rev64.h
@@ -1,0 +1,358 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+/* N.B. CM: vrev64_f16 and vrev64q_f16 are omitted as
+ * SIMDe has no 16-bit floating point support. */
+
+#if !defined(SIMDE_ARM_NEON_REV64_H)
+#define SIMDE_ARM_NEON_REV64_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrev64_s8(simde_int8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi8(a, _mm_set_pi8(0, 1, 2, 3, 4, 5, 6, 7));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, a_.values, 7, 6, 5, 4, 3, 2, 1, 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 7];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_s8
+  #define vrev64_s8(a) simde_vrev64_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vrev64_s16(simde_int16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_s16(a);
+  #elif defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi16(a, (0 << 6) | (1 << 4) | (2 << 2) | (3 << 0));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, a_.values, 3, 2, 1, 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 3];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_s16
+  #define vrev64_s16(a) simde_vrev64_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vrev64_s32(simde_int32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_s32(a);
+  #elif defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi16(a, (1 << 6) | (0 << 4) | (3 << 2) | (2 << 0));
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, a_.values, 1, 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_s32
+  #define vrev64_s32(a) simde_vrev64_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrev64_u8(simde_uint8x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_u8(a);
+  #else
+    return simde_vreinterpret_u8_s8(simde_vrev64_s8(simde_vreinterpret_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_u8
+  #define vrev64_u8(a) simde_vrev64_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vrev64_u16(simde_uint16x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_u16(a);
+  #else
+    return simde_vreinterpret_u16_s16(simde_vrev64_s16(simde_vreinterpret_s16_u16(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_u16
+  #define vrev64_u16(a) simde_vrev64_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vrev64_u32(simde_uint32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_u32(a);
+  #else
+    return simde_vreinterpret_u32_s32(simde_vrev64_s32(simde_vreinterpret_s32_u32(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_u32
+  #define vrev64_u32(a) simde_vrev64_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vrev64_f32(simde_float32x2_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64_f32(a);
+  #else
+    return simde_vreinterpret_f32_s32(simde_vrev64_s32(simde_vreinterpret_s32_f32(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64_f32
+  #define vrev64_f32(a) simde_vrev64_f32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrev64q_s8(simde_int8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_s8(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, _mm_set_epi8(8, 9, 10, 11, 12, 13, 14, 15,
+                                            0, 1,  2,  3,  4,  5,  6,  7));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_revb(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
+                                                                    a)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, a_.values, 7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12, 11, 10, 9, 8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 7];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_s8
+  #define vrev64q_s8(a) simde_vrev64q_s8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vrev64q_s16(simde_int16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_s16(a);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, _mm_set_epi8(9, 8, 11, 10, 13, 12, 15, 14,
+                                            1, 0,  3,  2,  5,  4,  7,  6));
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_shufflehi_epi16(_mm_shufflelo_epi16(a,
+                               (0 << 6) | (1 << 4) | (2 << 2) | (3 << 0)),
+                               (0 << 6) | (1 << 4) | (2 << 2) | (3 << 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 6, 7, 4, 5, 2, 3, 0, 1, 14, 15, 12, 13, 10, 11, 8, 9);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, a_.values, 3, 2, 1, 0, 7, 6, 5, 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 3];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_s16
+  #define vrev64q_s16(a) simde_vrev64q_s16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vrev64q_s32(simde_int32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_s32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_shuffle_epi32(a, (2 << 6) | (3 << 4) | (0 << 2) | (1 << 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int),
+                                   vec_reve(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long),
+                                                                    vec_reve(a))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, a, 4, 5, 6, 7, 0, 1, 2, 3, 12, 13, 14, 15, 8, 9, 10, 11);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, a_.values, 1, 0, 3, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i ^ 1];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_s32
+  #define vrev64q_s32(a) simde_vrev64q_s32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrev64q_u8(simde_uint8x16_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_u8(a);
+  #else
+    return simde_vreinterpretq_u8_s8(simde_vrev64q_s8(simde_vreinterpretq_s8_u8(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_u8
+  #define vrev64q_u8(a) simde_vrev64q_u8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vrev64q_u16(simde_uint16x8_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_u16(a);
+  #else
+    return simde_vreinterpretq_u16_s16(simde_vrev64q_s16(simde_vreinterpretq_s16_u16(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_u16
+  #define vrev64q_u16(a) simde_vrev64q_u16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vrev64q_u32(simde_uint32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_u32(a);
+  #else
+    return simde_vreinterpretq_u32_s32(simde_vrev64q_s32(simde_vreinterpretq_s32_u32(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_u32
+  #define vrev64q_u32(a) simde_vrev64q_u32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vrev64q_f32(simde_float32x4_t a) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrev64q_f32(a);
+  #else
+    return simde_vreinterpretq_f32_s32(simde_vrev64q_s32(simde_vreinterpretq_s32_f32(a)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrev64q_f32
+  #define vrev64q_f32(a) simde_vrev64q_f32(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_REV64_H) */

--- a/2.0/simde/arm/neon/rhadd.h
+++ b/2.0/simde/arm/neon/rhadd.h
@@ -1,0 +1,406 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_RHADD_H)
+#define SIMDE_ARM_NEON_RHADD_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrhadd_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int8_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int8_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int8_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int8_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int8_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int8_t, 1)));
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_s8
+  #define vrhadd_s8(a, b) simde_vrhadd_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vrhadd_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi16(_m_pand(_m_por(a, b), _mm_set1_pi16(HEDLEY_STATIC_CAST(int16_t, 1))),
+                        _mm_add_pi16(_m_psrawi(a, 1), _m_psrawi(b, 1)));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int16_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int16_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int16_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int16_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int16_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int16_t, 1)));
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_s16
+  #define vrhadd_s16(a, b) simde_vrhadd_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vrhadd_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi32(_m_pand(_m_por(a, b), _mm_set1_pi32(HEDLEY_STATIC_CAST(int32_t, 1))),
+                        _mm_add_pi32(_m_psradi(a, 1), _m_psradi(b, 1)));
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int32_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int32_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int32_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int32_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int32_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int32_t, 1)));
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_s32
+  #define vrhadd_s32(a, b) simde_vrhadd_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrhadd_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint8_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint8_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint8_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint8_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint8_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint8_t, 1)));
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_u8
+  #define vrhadd_u8(a, b) simde_vrhadd_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vrhadd_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi16(_m_pand(_m_por(a, b), _mm_set1_pi16(HEDLEY_STATIC_CAST(int16_t, 1))),
+                        _mm_add_pi16(_mm_srli_pi16(a, 1), _mm_srli_pi16(b, 1)));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint16_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint16_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint16_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint16_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint16_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint16_t, 1)));
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_u16
+  #define vrhadd_u16(a, b) simde_vrhadd_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vrhadd_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhadd_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi32(_m_pand(_m_por(a, b), _mm_set1_pi32(HEDLEY_STATIC_CAST(int32_t, 1))),
+                        _mm_add_pi32(_mm_srli_pi32(a, 1), _mm_srli_pi32(b, 1)));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint32_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint32_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint32_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint32_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint32_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint32_t, 1)));
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhadd_u32
+  #define vrhadd_u32(a, b) simde_vrhadd_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrhaddq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_s8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_add(wasm_i8x16_add(wasm_i8x16_shr(a, 1), wasm_i8x16_shr(b, 1)), wasm_v128_and(wasm_v128_or(a, b), wasm_i8x16_splat(1)));
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int8_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int8_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int8_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int8_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int8_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int8_t, 1)));
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_s8
+  #define vrhaddq_s8(a, b) simde_vrhaddq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vrhaddq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi16(_mm_and_si128(_mm_or_si128(a, b), _mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, 1))),
+                        _mm_add_epi16(_mm_srai_epi16(a, 1), _mm_srai_epi16(b, 1)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_add(wasm_i16x8_add(wasm_i16x8_shr(a, 1), wasm_i16x8_shr(b, 1)), wasm_v128_and(wasm_v128_or(a, b), wasm_i16x8_splat(1)));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int16_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int16_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int16_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int16_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int16_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int16_t, 1)));
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_s16
+  #define vrhaddq_s16(a, b) simde_vrhaddq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vrhaddq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi32(_mm_and_si128(_mm_or_si128(a, b), _mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, 1))),
+                        _mm_add_epi32(_mm_srai_epi32(a, 1), _mm_srai_epi32(b, 1)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_add(wasm_i32x4_add(wasm_i32x4_shr(a, 1), wasm_i32x4_shr(b, 1)), wasm_v128_and(wasm_v128_or(a, b), wasm_i32x4_splat(1)));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(int32_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(int32_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(int32_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(int32_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(int32_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(int32_t, 1)));
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_s32
+  #define vrhaddq_s32(a, b) simde_vrhaddq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrhaddq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_u8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u8x16_avgr(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint8_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint8_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint8_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint8_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint8_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint8_t, 1)));
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_u8
+  #define vrhaddq_u8(a, b) simde_vrhaddq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vrhaddq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_u16x8_avgr(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint16_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint16_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint16_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint16_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint16_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint16_t, 1)));
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_u16
+  #define vrhaddq_u16(a, b) simde_vrhaddq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vrhaddq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrhaddq_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_add(wasm_i32x4_add(wasm_u32x4_shr(a, 1), wasm_u32x4_shr(b, 1)), wasm_v128_and(wasm_v128_or(a, b), wasm_i32x4_splat(1)));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = (((a_.values >> HEDLEY_STATIC_CAST(uint32_t, 1)) + (b_.values >> HEDLEY_STATIC_CAST(uint32_t, 1))) + ((a_.values | b_.values) & HEDLEY_STATIC_CAST(uint32_t, 1)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = (((a_.values[i] >> HEDLEY_STATIC_CAST(uint32_t, 1)) + (b_.values[i] >> HEDLEY_STATIC_CAST(uint32_t, 1))) + ((a_.values[i] | b_.values[i]) & HEDLEY_STATIC_CAST(uint32_t, 1)));
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrhaddq_u32
+  #define vrhaddq_u32(a, b) simde_vrhaddq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_RHADD_H) */

--- a/2.0/simde/arm/neon/rshl.h
+++ b/2.0/simde/arm/neon/rshl.h
@@ -1,0 +1,903 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_RSHL_H)
+#define SIMDE_ARM_NEON_RSHL_H
+
+#include "types.h"
+
+/* Notes from the implementer (Christopher Moore aka rosbif)
+ *
+ * I have tried to exactly reproduce the documented behaviour of the
+ * ARM NEON rshl and rshlq intrinsics.
+ * This is complicated for the following reasons:-
+ *
+ * a) Negative shift counts shift right.
+ *
+ * b) Only the low byte of the shift count is used but the shift count
+ * is not limited to 8-bit values (-128 to 127).
+ *
+ * c) Overflow must be avoided when rounding, together with sign change
+ * warning/errors in the C versions.
+ *
+ * d) Intel SIMD is not nearly as complete as NEON and AltiVec.
+ * There were no intrisics with a vector shift count before AVX2 which
+ * only has 32 and 64-bit logical ones and only a 32-bit arithmetic
+ * one. The others need AVX512. There are no 8-bit shift intrinsics at
+ * all, even with a scalar shift count. It is surprising to use AVX2
+ * and even AVX512 to implement a 64-bit vector operation.
+ *
+ * e) Many shift implementations, and the C standard, do not treat a
+ * shift count >= the object's size in bits as one would expect.
+ * (Personally I feel that > is silly but == can be useful.)
+ *
+ * Note that even the C17/18 standard does not define the behaviour of
+ * a right shift of a negative value.
+ * However Evan and I agree that all compilers likely to be used
+ * implement this as an arithmetic right shift with sign extension.
+ * If this is not the case it could be replaced by a logical right shift
+ * if negative values are complemented before and after the shift.
+ *
+ * Some of the SIMD translations may be slower than the portable code,
+ * particularly those for vectors with only one or two elements.
+ * But I had fun writing them ;-)
+ *
+ */
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrshl_s8 (const simde_int8x8_t a, const simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_s8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi16(zero, zero);
+    __m128i a128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(b));
+    __m128i a128_shr = _mm_srav_epi16(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi16(a128, b128),
+                                   _mm_srai_epi16(_mm_sub_epi16(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi16(zero, b128));
+     return _mm_movepi64_pi64(_mm_cvtepi16_epi8(r128));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi32(zero, zero);
+    __m256i a256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(a));
+    __m256i b256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(b));
+    __m256i a256_shr = _mm256_srav_epi32(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srai_epi32(_mm256_sub_epi32(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi32(zero, b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi32(0x0C080400));
+    return _mm_set_pi32(_mm256_extract_epi32(r256, 4), _mm256_extract_epi32(r256, 0));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t,
+                                        (abs(b_.values[i]) >= 8) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+   }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_s8
+  #define vrshl_s8(a, b) simde_vrshl_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vrshl_s16 (const simde_int16x4_t a, const simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_s16(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i a128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(b));
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i a128_shr = _mm_srav_epi32(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srai_epi32(_mm_sub_epi32(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi32(zero, b128));
+    return _mm_movepi64_pi64(_mm_shuffle_epi8(r128, _mm_set1_epi64x(0x0D0C090805040100)));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t,
+                                        (abs(b_.values[i]) >= 16) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_s16
+  #define vrshl_s16(a, b) simde_vrshl_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vrshl_s32 (const simde_int32x2_t a, const simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_s32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i a128_shr = _mm_srav_epi32(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srai_epi32(_mm_sub_epi32(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi32(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int32_t,
+                                        (abs(b_.values[i]) >= 32) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_s32
+  #define vrshl_s32(a, b) simde_vrshl_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vrshl_s64 (const simde_int64x1_t a, const simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_s64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi64(zero, zero);
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi64(_mm_slli_epi64(b128, 56), 56);
+    __m128i a128_shr = _mm_srav_epi64(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128),
+                                   _mm_srai_epi64(_mm_sub_epi64(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi64(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ones = _mm_set1_epi64x(1);
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    __m128i maska = _mm_cmpgt_epi64(zero, a128);
+    __m128i b128_abs = _mm_and_si128(_mm_abs_epi8(b128), _mm_set1_epi64x(0xFF));
+    __m128i a128_rnd = _mm_and_si128(_mm_srlv_epi64(a128, _mm_sub_epi64(b128_abs, ones)), ones);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128_abs),
+                                   _mm_add_epi64(_mm_xor_si128(_mm_srlv_epi64(_mm_xor_si128(a128, maska), b128_abs), maska), a128_rnd),
+                                   _mm_cmpgt_epi64(zero, _mm_slli_epi64(b128, 56)));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int64_t,
+                                        (llabs(b_.values[i]) >= 64) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (INT64_C(1) << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_s64
+  #define vrshl_s64(a, b) simde_vrshl_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrshl_u8 (const simde_uint8x8_t a, const simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_u8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi16(zero, zero);
+    __m128i a128 = _mm_cvtepu8_epi16(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(b));
+    __m128i a128_shr = _mm_srlv_epi16(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi16(a128, b128),
+                                   _mm_srli_epi16(_mm_sub_epi16(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi16(zero, b128));
+     return _mm_movepi64_pi64(_mm_cvtepi16_epi8(r128));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi32(zero, zero);
+    __m256i a256 = _mm256_cvtepu8_epi32(_mm_movpi64_epi64(a));
+    __m256i b256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(b));
+    __m256i a256_shr = _mm256_srlv_epi32(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srli_epi32(_mm256_sub_epi32(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi32(zero, b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi32(0x0C080400));
+    return _mm_set_pi32(_mm256_extract_epi32(r256, 4), _mm256_extract_epi32(r256, 0));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a);
+    simde_int8x8_private b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t,
+                                        (b_.values[i] >=  8) ? 0 :
+                                        (b_.values[i] >=  0) ? (a_.values[i] << b_.values[i]) :
+                                        (b_.values[i] >= -8) ? (((b_.values[i] == -8) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+                                        0);
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_u8
+  #define vrshl_u8(a, b) simde_vrshl_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vrshl_u16 (const simde_uint16x4_t a, const simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_u16(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i a128 = _mm_cvtepu16_epi32(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(b));
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i a128_shr = _mm_srlv_epi32(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srli_epi32(_mm_sub_epi32(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi32(zero, b128));
+    return _mm_movepi64_pi64(_mm_shuffle_epi8(r128, _mm_set1_epi64x(0x0D0C090805040100)));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a);
+    simde_int16x4_private b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t,
+                                        (b_.values[i] >=  16) ? 0 :
+                                        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+                                        (b_.values[i] >= -16) ? (((b_.values[i] == -16) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+                                        0);
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_u16
+  #define vrshl_u16(a, b) simde_vrshl_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vrshl_u32 (const simde_uint32x2_t a, const simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_u32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i a128_shr = _mm_srlv_epi32(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srli_epi32(_mm_sub_epi32(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi32(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a);
+    simde_int32x2_private b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=  32) ? 0 :
+        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+        (b_.values[i] >= -32) ? (((b_.values[i] == -32) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+        0;
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_u32
+  #define vrshl_u32(a, b) simde_vrshl_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vrshl_u64 (const simde_uint64x1_t a, const simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshl_u64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi64(zero, zero);
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi64(_mm_slli_epi64(b128, 56), 56);
+    __m128i a128_shr = _mm_srlv_epi64(a128, _mm_xor_si128(b128, ff));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128),
+                                   _mm_srli_epi64(_mm_sub_epi64(a128_shr, ff), 1),
+                                   _mm_cmpgt_epi64(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    const __m128i ones = _mm_set1_epi64x(1);
+    const __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    __m128i b128_abs = _mm_and_si128(_mm_abs_epi8(b128), _mm_set1_epi64x(0xFF));
+    __m128i a128_shr = _mm_srlv_epi64(a128, _mm_sub_epi64(b128_abs, ones));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128_abs),
+                                   _mm_srli_epi64(_mm_add_epi64(a128_shr, ones), 1),
+                                   _mm_cmpgt_epi64(_mm_setzero_si128(), _mm_slli_epi64(b128, 56)));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a);
+    simde_int64x1_private b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=  64) ? 0 :
+        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+        (b_.values[i] >= -64) ? (((b_.values[i] == -64) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+        0;
+    }
+
+  return simde_uint64x1_from_private(r_);
+#endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshl_u64
+  #define vrshl_u64(a, b) simde_vrshl_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrshlq_s8 (const simde_int8x16_t a, const simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_s8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi16(zero, zero);
+    __m256i a256 = _mm256_cvtepi8_epi16(a);
+    __m256i b256 = _mm256_cvtepi8_epi16(b);
+    __m256i a256_shr = _mm256_srav_epi16(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi16(a256, b256),
+                                      _mm256_srai_epi16(_mm256_sub_epi16(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi16(zero, b256));
+    return _mm256_cvtepi16_epi8(r256);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed char) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed char,    0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned char,    1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned char,    8));
+    SIMDE_POWER_ALTIVEC_VECTOR(signed char) a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) b_abs;
+
+    b_abs = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_abs(b));
+    a_shr = vec_sra(a, vec_sub(b_abs, ones));
+    return vec_and(vec_sel(vec_sl(a, b_abs),
+                           vec_add(vec_sra(a_shr, ones), vec_and(a_shr, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), ones))),
+                           vec_cmplt(b, zero)),
+                   vec_cmplt(b_abs, max));
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t,
+                                        (abs(b_.values[i]) >= 8) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_s8
+  #define vrshlq_s8(a, b) simde_vrshlq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vrshlq_s16 (const simde_int16x8_t a, const simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_s16(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi16(zero, zero);
+    __m128i b_ = _mm_srai_epi16(_mm_slli_epi16(b, 8), 8);
+    __m128i a_shr = _mm_srav_epi16(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi16(a, b_),
+                           _mm_srai_epi16(_mm_sub_epi16(a_shr, ff), 1),
+                           _mm_cmpgt_epi16(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi32(zero, zero);
+    __m256i a256 = _mm256_cvtepi16_epi32(a);
+    __m256i b256 = _mm256_cvtepi16_epi32(b);
+    b256 = _mm256_srai_epi32(_mm256_slli_epi32(b256, 24), 24);
+    __m256i a256_shr = _mm256_srav_epi32(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srai_epi32(_mm256_sub_epi32(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi32(zero, b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
+    return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed short) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed short,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned short,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 16 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned short,     16));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned short,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(signed short) a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) b_abs;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    a_shr = vec_sra(a, vec_sub(b_abs, ones));
+    return vec_and(vec_sel(vec_sl(a, b_abs),
+                           vec_add(vec_sra(a_shr, ones), vec_and(a_shr, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), ones))),
+                           vec_cmplt(vec_sl(b, shift), zero)),
+                   vec_cmplt(b_abs, max));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t,
+                                        (abs(b_.values[i]) >= 16) ? 0 :
+                                        (b_.values[i] >= 0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_s16
+  #define vrshlq_s16(a, b) simde_vrshlq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vrshlq_s32 (const simde_int32x4_t a, const simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_s32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i b_ = _mm_srai_epi32(_mm_slli_epi32(b, 24), 24);
+    __m128i a_shr = _mm_srav_epi32(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
+                           _mm_srai_epi32(_mm_sub_epi32(a_shr, ff), 1),
+                           _mm_cmpgt_epi32(zero, b_));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed int) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed int,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned int,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 32 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned int,     32));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned int,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(signed int) a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) b_abs;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    a_shr = vec_sra(a, vec_sub(b_abs, ones));
+    return vec_and(vec_sel(vec_sl(a, b_abs),
+                           vec_add(vec_sra(a_shr, ones), vec_and(a_shr, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), ones))),
+                           vec_cmplt(vec_sl(b, shift), zero)),
+                   vec_cmplt(b_abs, max));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int32_t,
+                                        (abs(b_.values[i]) >= 32) ? 0 :
+                                        (b_.values[i] >=  0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (1 << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_s32
+  #define vrshlq_s32(a, b) simde_vrshlq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vrshlq_s64 (const simde_int64x2_t a, const simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_s64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i b_ = _mm_srai_epi64(_mm_slli_epi64(b, 56), 56);
+    __m128i a_shr = _mm_srav_epi64(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_),
+                           _mm_srai_epi64(_mm_sub_epi64(a_shr, ff), 1),
+                           _mm_cmpgt_epi64(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ones = _mm_set1_epi64x(1);
+    __m128i maska = _mm_cmpgt_epi64(zero, a);
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b), _mm_set1_epi64x(0xFF));
+    __m128i a_rnd = _mm_and_si128(_mm_srlv_epi64(a, _mm_sub_epi64(b_abs, ones)), ones);
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
+                           _mm_add_epi64(_mm_xor_si128(_mm_srlv_epi64(_mm_xor_si128(a, maska), b_abs), maska), a_rnd),
+                           _mm_cmpgt_epi64(zero, _mm_slli_epi64(b, 56)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed long long) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed long long,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 64 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,     64));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(signed long long) a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) b_abs;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    a_shr = vec_sra(a, vec_sub(b_abs, ones));
+
+    HEDLEY_DIAGNOSTIC_PUSH
+    #if defined(SIMDE_BUG_CLANG_46770)
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+    #endif
+    return vec_and(vec_sel(vec_sl(a, b_abs),
+                           vec_add(vec_sra(a_shr, ones), vec_and(a_shr, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), ones))),
+                           vec_cmplt(vec_sl(b, shift), zero)),
+                   vec_cmplt(b_abs, max));
+    HEDLEY_DIAGNOSTIC_POP
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int64_t,
+                                        (llabs(b_.values[i]) >= 64) ? 0 :
+                                        (b_.values[i] >=  0) ? (a_.values[i] << b_.values[i]) :
+                                        ((a_.values[i] + (INT64_C(1) << (-b_.values[i] - 1))) >> -b_.values[i]));
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_s64
+  #define vrshlq_s64(a, b) simde_vrshlq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrshlq_u8 (const simde_uint8x16_t a, const simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_u8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi32(zero, zero);
+    __m256i a256 = _mm256_cvtepu8_epi16(a);
+    __m256i b256 = _mm256_cvtepi8_epi16(b);
+    __m256i a256_shr = _mm256_srlv_epi16(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi16(a256, b256),
+                                      _mm256_srli_epi16(_mm256_sub_epi16(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi16(zero, b256));
+    return _mm256_cvtepi16_epi8(r256);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+   const SIMDE_POWER_ALTIVEC_VECTOR(  signed char) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed char,    0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned char,    1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned char,    8));
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) b_abs, b_abs_dec, a_shr;
+
+    b_abs = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_abs(b));
+    b_abs_dec = vec_sub(b_abs, ones);
+    a_shr = vec_and(vec_sr(a, b_abs_dec), vec_cmplt(b_abs_dec, max));
+    return vec_sel(vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, max)),
+                   vec_sr(vec_add(a_shr, ones), ones),
+                   vec_cmplt(b, zero));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+    simde_int8x16_private b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t,
+                                        (b_.values[i] >=  8) ? 0 :
+                                        (b_.values[i] >=  0) ? (a_.values[i] << b_.values[i]) :
+                                        (b_.values[i] >= -8) ? (((b_.values[i] == -8) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+                                        0);
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_u8
+  #define vrshlq_u8(a, b) simde_vrshlq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vrshlq_u16 (const simde_uint16x8_t a, const simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_u16(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi16(zero, zero);
+    __m128i b_ = _mm_srai_epi16(_mm_slli_epi16(b, 8), 8);
+    __m128i a_shr = _mm_srlv_epi16(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi16(a, b_),
+                           _mm_srli_epi16(_mm_sub_epi16(a_shr, ff), 1),
+                           _mm_cmpgt_epi16(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i ff   = _mm256_cmpeq_epi32(zero, zero);
+    __m256i a256 = _mm256_cvtepu16_epi32(a);
+    __m256i b256 = _mm256_cvtepi16_epi32(b);
+    b256 = _mm256_srai_epi32(_mm256_slli_epi32(b256, 24), 24);
+    __m256i a256_shr = _mm256_srlv_epi32(a256, _mm256_xor_si256(b256, ff));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srli_epi32(_mm256_sub_epi32(a256_shr, ff), 1),
+                                      _mm256_cmpgt_epi32(zero, b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
+    return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed short) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed short,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned short,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned short, 16 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned short,     16));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned short,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) b_abs, b_abs_dec, a_shr;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    b_abs_dec = vec_sub(b_abs, ones);
+    a_shr = vec_and(vec_sr(a, b_abs_dec), vec_cmplt(b_abs_dec, max));
+    return vec_sel(vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, max)),
+                   vec_sr(vec_add(a_shr, ones), ones),
+                   vec_cmplt(vec_sl(b, shift), zero));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+    simde_int16x8_private b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t,
+                                        (b_.values[i] >=  16) ? 0 :
+                                        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+                                        (b_.values[i] >= -16) ? (((b_.values[i] == -16) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+                                        0);
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_u16
+  #define vrshlq_u16(a, b) simde_vrshlq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vrshlq_u32 (const simde_uint32x4_t a, const simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_u32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi32(zero, zero);
+    __m128i b_ = _mm_srai_epi32(_mm_slli_epi32(b, 24), 24);
+    __m128i a_shr = _mm_srlv_epi32(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
+                           _mm_srli_epi32(_mm_sub_epi32(a_shr, ff), 1),
+                           _mm_cmpgt_epi32(zero, b_));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed int) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed int,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned int,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 32 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned int,     32));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned int,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) b_abs, b_abs_dec, a_shr;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    b_abs_dec = vec_sub(b_abs, ones);
+    a_shr = vec_and(vec_sr(a, b_abs_dec), vec_cmplt(b_abs_dec, max));
+    return vec_sel(vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, max)),
+                   vec_sr(vec_add(a_shr, ones), ones),
+                   vec_cmplt(vec_sl(b, shift), zero));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+    simde_int32x4_private b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=  32) ? 0 :
+        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+        (b_.values[i] >= -32) ? (((b_.values[i] == -32) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+        0;
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_u32
+  #define vrshlq_u32(a, b) simde_vrshlq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vrshlq_u64 (const simde_uint64x2_t a, const simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vrshlq_u64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    const __m128i zero = _mm_setzero_si128();
+    const __m128i ff   = _mm_cmpeq_epi64(zero, zero);
+    __m128i b_ = _mm_srai_epi64(_mm_slli_epi64(b, 56), 56);
+    __m128i a_shr = _mm_srlv_epi64(a, _mm_xor_si128(b_, ff));
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_),
+                           _mm_srli_epi64(_mm_sub_epi64(a_shr, ff), 1),
+                           _mm_cmpgt_epi64(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i ones = _mm_set1_epi64x(1);
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b), _mm_set1_epi64x(0xFF));
+    __m128i a_shr = _mm_srlv_epi64(a, _mm_sub_epi64(b_abs, ones));
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
+                           _mm_srli_epi64(_mm_add_epi64(a_shr, ones), 1),
+                           _mm_cmpgt_epi64(_mm_setzero_si128(), _mm_slli_epi64(b, 56)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(  signed long long) zero  = vec_splats(HEDLEY_STATIC_CAST(  signed long long,      0));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) ones  = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,      1));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) shift = vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 64 - 8));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) max   = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,     64));
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) ff    = vec_splats(HEDLEY_STATIC_CAST(unsigned long long,   0xFF));
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) b_abs, b_abs_dec, a_shr;
+
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    ff);
+    b_abs_dec = vec_sub(b_abs, ones);
+    a_shr = vec_and(vec_sr(a, b_abs_dec), vec_cmplt(b_abs_dec, max));
+    HEDLEY_DIAGNOSTIC_PUSH
+    #if defined(SIMDE_BUG_CLANG_46770)
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+    #endif
+    return vec_sel(vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, max)),
+                   vec_sr(vec_add(a_shr, ones), ones),
+                   vec_cmplt(vec_sl(b, shift), zero));
+    HEDLEY_DIAGNOSTIC_POP
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a);
+    simde_int64x2_private b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=  64) ? 0 :
+        (b_.values[i] >=   0) ? (a_.values[i] << b_.values[i]) :
+        (b_.values[i] >= -64) ? (((b_.values[i] == -64) ? 0 : (a_.values[i] >> -b_.values[i])) + ((a_.values[i] >> (-b_.values[i] - 1)) & 1)) :
+        0;
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshlq_u64
+  #define vrshlq_u64(a, b) simde_vrshlq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_RSHL_H) */

--- a/2.0/simde/arm/neon/rshr_n.h
+++ b/2.0/simde/arm/neon/rshr_n.h
@@ -1,0 +1,471 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_RSHR_N_H)
+#define SIMDE_ARM_NEON_RSHR_N_H
+
+#include "combine.h"
+#include "dup_n.h"
+#include "get_low.h"
+#include "reinterpret.h"
+#include "shr_n.h"
+#include "sub.h"
+#include "tst.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vrshrq_n_s8 (const simde_int8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_int8x16_private
+    r_,
+    a_ = simde_int8x16_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(int8_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_int8x16_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_s8(a, n) vrshrq_n_s8((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_s8(a, n) simde_vsubq_s8(simde_vshrq_n_s8((a), (n)), simde_vreinterpretq_s8_u8( \
+    simde_vtstq_u8(simde_vreinterpretq_u8_s8(a), \
+                   simde_vdupq_n_u8(HEDLEY_STATIC_CAST(uint8_t, 1 << ((n) - 1))))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_s8
+  #define vrshrq_n_s8(a, n) simde_vrshrq_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vrshrq_n_s16 (const simde_int16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_int16x8_private
+    r_,
+    a_ = simde_int16x8_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(int16_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_int16x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_s16(a, n) vrshrq_n_s16((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_s16(a, n) simde_vsubq_s16(simde_vshrq_n_s16((a), (n)), simde_vreinterpretq_s16_u16( \
+    simde_vtstq_u16(simde_vreinterpretq_u16_s16(a),                              \
+                    simde_vdupq_n_u16(HEDLEY_STATIC_CAST(uint16_t, 1 << ((n) - 1))))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_s16
+  #define vrshrq_n_s16(a, n) simde_vrshrq_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vrshrq_n_s32 (const simde_int32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_int32x4_private
+    r_,
+    a_ = simde_int32x4_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = (a_.values[i] >> ((n == 32) ? 31 : n)) + ((a_.values[i] & HEDLEY_STATIC_CAST(int32_t, UINT32_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_int32x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_s32(a, n) vrshrq_n_s32((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_s32(a, n) simde_vsubq_s32(simde_vshrq_n_s32((a), (n)), \
+    simde_vreinterpretq_s32_u32(simde_vtstq_u32(simde_vreinterpretq_u32_s32(a), \
+      simde_vdupq_n_u32(UINT32_C(1) << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_s32
+  #define vrshrq_n_s32(a, n) simde_vrshrq_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vrshrq_n_s64 (const simde_int64x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_int64x2_private
+    r_,
+    a_ = simde_int64x2_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = (a_.values[i] >> ((n == 64) ? 63 : n)) + ((a_.values[i] & HEDLEY_STATIC_CAST(int64_t, UINT64_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_int64x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_s64(a, n) vrshrq_n_s64((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_s64(a, n) simde_vsubq_s64(simde_vshrq_n_s64((a), (n)), \
+    simde_vreinterpretq_s64_u64(simde_vtstq_u64(simde_vreinterpretq_u64_s64(a), \
+      simde_vdupq_n_u64(UINT64_C(1) << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_s64
+  #define vrshrq_n_s64(a, n) simde_vrshrq_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vrshrq_n_u8 (const simde_uint8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_uint8x16_private
+    r_,
+    a_ = simde_uint8x16_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_uint8x16_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_u8(a, n) vrshrq_n_u8((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_u8(a, n) simde_vsubq_u8(simde_vshrq_n_u8((a), (n)), \
+    simde_vtstq_u8((a), simde_vdupq_n_u8(HEDLEY_STATIC_CAST(uint8_t, 1 << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_u8
+  #define vrshrq_n_u8(a, n) simde_vrshrq_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vrshrq_n_u16 (const simde_uint16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_uint16x8_private
+    r_,
+    a_ = simde_uint16x8_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_uint16x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_u16(a, n) vrshrq_n_u16((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_u16(a, n) simde_vsubq_u16(simde_vshrq_n_u16((a), (n)), \
+    simde_vtstq_u16((a), simde_vdupq_n_u16(HEDLEY_STATIC_CAST(uint16_t, 1 << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_u16
+  #define vrshrq_n_u16(a, n) simde_vrshrq_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vrshrq_n_u32 (const simde_uint32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_uint32x4_private
+    r_,
+    a_ = simde_uint32x4_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = ((n == 32) ? 0 : (a_.values[i] >> n)) + ((a_.values[i] & (UINT32_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_uint32x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_u32(a, n) vrshrq_n_u32((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_u32(a, n) simde_vsubq_u32(simde_vshrq_n_u32((a), (n)), \
+    simde_vtstq_u32((a), simde_vdupq_n_u32(UINT32_C(1) << ((n) - 1))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_u32
+  #define vrshrq_n_u32(a, n) simde_vrshrq_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vrshrq_n_u64 (const simde_uint64x2_t a, const int n)
+  SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_uint64x2_private
+    r_,
+    a_ = simde_uint64x2_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = ((n == 64) ? 0 : (a_.values[i] >> n)) + ((a_.values[i] & (UINT64_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_uint64x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshrq_n_u64(a, n) vrshrq_n_u64((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshrq_n_u64(a, n) simde_vsubq_u64(simde_vshrq_n_u64((a), (n)), \
+    simde_vtstq_u64((a), simde_vdupq_n_u64(UINT64_C(1) << ((n) - 1))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshrq_n_u64
+  #define vrshrq_n_u64(a, n) simde_vrshrq_n_u64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vrshr_n_s8 (const simde_int8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_int8x8_private
+    r_,
+    a_ = simde_int8x8_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(int8_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_int8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_s8(a, n) vrshr_n_s8((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_s8(a, n) simde_vsub_s8(simde_vshr_n_s8((a), (n)), simde_vreinterpret_s8_u8( \
+    simde_vtst_u8(simde_vreinterpret_u8_s8(a),                              \
+                  simde_vdup_n_u8(HEDLEY_STATIC_CAST(uint8_t, 1 << ((n) - 1))))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_s8
+  #define vrshr_n_s8(a, n) simde_vrshr_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vrshr_n_s16 (const simde_int16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_int16x4_private
+    r_,
+    a_ = simde_int16x4_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(int16_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_int16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_s16(a, n) vrshr_n_s16((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_s16(a, n) simde_vsub_s16(simde_vshr_n_s16((a), (n)), simde_vreinterpret_s16_u16( \
+    simde_vtst_u16(simde_vreinterpret_u16_s16(a), \
+                   simde_vdup_n_u16(HEDLEY_STATIC_CAST(uint16_t, 1 << ((n) - 1))))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_s16
+  #define vrshr_n_s16(a, n) simde_vrshr_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vrshr_n_s32 (const simde_int32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_int32x2_private
+    r_,
+    a_ = simde_int32x2_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = (a_.values[i] >> ((n == 32) ? 31 : n)) + ((a_.values[i] & HEDLEY_STATIC_CAST(int32_t, UINT32_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_int32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_s32(a, n) vrshr_n_s32((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_s32(a, n) simde_vsub_s32(simde_vshr_n_s32((a), (n)), \
+    simde_vreinterpret_s32_u32(simde_vtst_u32(simde_vreinterpret_u32_s32(a), \
+      simde_vdup_n_u32(UINT32_C(1) << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_s32
+  #define vrshr_n_s32(a, n) simde_vrshr_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vrshr_n_s64 (const simde_int64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_int64x1_private
+    r_,
+    a_ = simde_int64x1_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = (a_.values[i] >> ((n == 64) ? 63 : n)) + ((a_.values[i] & HEDLEY_STATIC_CAST(int64_t, UINT64_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_int64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_s64(a, n) vrshr_n_s64((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_s64(a, n) simde_vsub_s64(simde_vshr_n_s64((a), (n)), \
+    simde_vreinterpret_s64_u64(simde_vtst_u64(simde_vreinterpret_u64_s64(a), \
+      simde_vdup_n_u64(UINT64_C(1) << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_s64
+  #define vrshr_n_s64(a, n) simde_vrshr_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vrshr_n_u8 (const simde_uint8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_uint8x8_private
+    r_,
+    a_ = simde_uint8x8_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_uint8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_u8(a, n) vrshr_n_u8((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_u8(a, n) simde_vsub_u8(simde_vshr_n_u8((a), (n)), \
+    simde_vtst_u8((a), simde_vdup_n_u8(HEDLEY_STATIC_CAST(uint8_t, 1 << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_u8
+  #define vrshr_n_u8(a, n) simde_vrshr_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vrshr_n_u16 (const simde_uint16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_uint16x4_private
+    r_,
+    a_ = simde_uint16x4_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.values[i] + (1 << (n - 1))) >> n);
+  }
+
+  return simde_uint16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_u16(a, n) vrshr_n_u16((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_u16(a, n) simde_vsub_u16(simde_vshr_n_u16((a), (n)), \
+    simde_vtst_u16((a), simde_vdup_n_u16(HEDLEY_STATIC_CAST(uint16_t, 1 << ((n) - 1)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_u16
+  #define vrshr_n_u16(a, n) simde_vrshr_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vrshr_n_u32 (const simde_uint32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_uint32x2_private
+    r_,
+    a_ = simde_uint32x2_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = ((n == 32) ? 0 : (a_.values[i] >> n))  + ((a_.values[i] & (UINT32_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_uint32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_u32(a, n) vrshr_n_u32((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_u32(a, n) simde_vsub_u32(simde_vshr_n_u32((a), (n)), \
+    simde_vtst_u32((a), simde_vdup_n_u32(UINT32_C(1) << ((n) - 1))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_u32
+  #define vrshr_n_u32(a, n) simde_vrshr_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vrshr_n_u64 (const simde_uint64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_uint64x1_private
+    r_,
+    a_ = simde_uint64x1_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+    r_.values[i] = ((n == 64) ? 0 : (a_.values[i] >> n))  + ((a_.values[i] & (UINT64_C(1) << (n - 1))) != 0);
+  }
+
+  return simde_uint64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrshr_n_u64(a, n) vrshr_n_u64((a), (n))
+#elif SIMDE_NATURAL_VECTOR_SIZE > 0
+  #define simde_vrshr_n_u64(a, n) simde_vsub_u64(simde_vshr_n_u64((a), (n)), \
+    simde_vtst_u64((a), simde_vdup_n_u64(UINT64_C(1) << ((n) - 1))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrshr_n_u64
+  #define vrshr_n_u64(a, n) simde_vrshr_n_u64((a), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_RSHR_N_H) */

--- a/2.0/simde/arm/neon/rsra_n.h
+++ b/2.0/simde/arm/neon/rsra_n.h
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_RSRA_N_H)
+#define SIMDE_ARM_NEON_RSRA_N_H
+
+#include "add.h"
+#include "combine.h"
+#include "get_low.h"
+#include "rshr_n.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+/* Remark: For these instructions
+ *    1 <= n     <= data element size in bits
+ * so 0 <= n - 1 <  data element size in bits
+ */
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_s8(a, b, n) vrsraq_n_s8((a), (b), (n))
+#else
+  #define simde_vrsraq_n_s8(a, b, n) simde_vaddq_s8((a), simde_vrshrq_n_s8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_s8
+  #define vrsraq_n_s8(a, b, n) simde_vrsraq_n_s8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_s16(a, b, n) vrsraq_n_s16((a), (b), (n))
+#else
+  #define simde_vrsraq_n_s16(a, b, n) simde_vaddq_s16((a), simde_vrshrq_n_s16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_s16
+  #define vrsraq_n_s16(a, b, n) simde_vrsraq_n_s16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_s32(a, b, n) vrsraq_n_s32((a), (b), (n))
+#else
+  #define simde_vrsraq_n_s32(a, b, n) simde_vaddq_s32((a), simde_vrshrq_n_s32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_s32
+  #define vrsraq_n_s32(a, b, n) simde_vrsraq_n_s32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_s64(a, b, n) vrsraq_n_s64((a), (b), (n))
+#else
+  #define simde_vrsraq_n_s64(a, b, n) simde_vaddq_s64((a), simde_vrshrq_n_s64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_s64
+  #define vrsraq_n_s64(a, b, n) simde_vrsraq_n_s64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_u8(a, b, n) vrsraq_n_u8((a), (b), (n))
+#else
+  #define simde_vrsraq_n_u8(a, b, n) simde_vaddq_u8((a), simde_vrshrq_n_u8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_u8
+  #define vrsraq_n_u8(a, b, n) simde_vrsraq_n_u8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_u16(a, b, n) vrsraq_n_u16((a), (b), (n))
+#else
+  #define simde_vrsraq_n_u16(a, b, n) simde_vaddq_u16((a), simde_vrshrq_n_u16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_u16
+  #define vrsraq_n_u16(a, b, n) simde_vrsraq_n_u16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_u32(a, b, n) vrsraq_n_u32((a), (b), (n))
+#else
+  #define simde_vrsraq_n_u32(a, b, n) simde_vaddq_u32((a), simde_vrshrq_n_u32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_u32
+  #define vrsraq_n_u32(a, b, n) simde_vrsraq_n_u32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsraq_n_u64(a, b, n) vrsraq_n_u64((a), (b), (n))
+#else
+  #define simde_vrsraq_n_u64(a, b, n) simde_vaddq_u64((a), simde_vrshrq_n_u64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsraq_n_u64
+  #define vrsraq_n_u64(a, b, n) simde_vrsraq_n_u64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_s8(a, b, n) vrsra_n_s8((a), (b), (n))
+#else
+  #define simde_vrsra_n_s8(a, b, n) simde_vadd_s8((a), simde_vrshr_n_s8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_s8
+  #define vrsra_n_s8(a, b, n) simde_vrsra_n_s8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_s16(a, b, n) vrsra_n_s16((a), (b), (n))
+#else
+  #define simde_vrsra_n_s16(a, b, n) simde_vadd_s16((a), simde_vrshr_n_s16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_s16
+  #define vrsra_n_s16(a, b, n) simde_vrsra_n_s16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_s32(a, b, n) vrsra_n_s32((a), (b), (n))
+#else
+  #define simde_vrsra_n_s32(a, b, n) simde_vadd_s32((a), simde_vrshr_n_s32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_s32
+  #define vrsra_n_s32(a, b, n) simde_vrsra_n_s32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_s64(a, b, n) vrsra_n_s64((a), (b), (n))
+#else
+  #define simde_vrsra_n_s64(a, b, n) simde_vadd_s64((a), simde_vrshr_n_s64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_s64
+  #define vrsra_n_s64(a, b, n) simde_vrsra_n_s64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_u8(a, b, n) vrsra_n_u8((a), (b), (n))
+#else
+  #define simde_vrsra_n_u8(a, b, n) simde_vadd_u8((a), simde_vrshr_n_u8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_u8
+  #define vrsra_n_u8(a, b, n) simde_vrsra_n_u8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_u16(a, b, n) vrsra_n_u16((a), (b), (n))
+#else
+  #define simde_vrsra_n_u16(a, b, n) simde_vadd_u16((a), simde_vrshr_n_u16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_u16
+  #define vrsra_n_u16(a, b, n) simde_vrsra_n_u16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_u32(a, b, n) vrsra_n_u32((a), (b), (n))
+#else
+  #define simde_vrsra_n_u32(a, b, n) simde_vadd_u32((a), simde_vrshr_n_u32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_u32
+  #define vrsra_n_u32(a, b, n) simde_vrsra_n_u32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vrsra_n_u64(a, b, n) vrsra_n_u64((a), (b), (n))
+#else
+  #define simde_vrsra_n_u64(a, b, n) simde_vadd_u64((a), simde_vrshr_n_u64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vrsra_n_u64
+  #define vrsra_n_u64(a, b, n) simde_vrsra_n_u64((a), (b), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_RSRA_N_H) */

--- a/2.0/simde/arm/neon/set_lane.h
+++ b/2.0/simde/arm/neon/set_lane.h
@@ -1,0 +1,422 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_SET_LANE_H)
+#define SIMDE_ARM_NEON_SET_LANE_H
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vset_lane_f32(simde_float32_t a, simde_float32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_float32x2_t r;
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_CONSTIFY_2_(vset_lane_f32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_float32x2_private v_ = simde_float32x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_float32x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_f32
+  #define vset_lane_f32(a, b, c) simde_vset_lane_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vset_lane_f64(simde_float64_t a, simde_float64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  simde_float64x1_t r;
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    (void) lane;
+    r = vset_lane_f64(a, v, 0);
+  #else
+    simde_float64x1_private v_ = simde_float64x1_to_private(v);
+    v_.values[lane] = a;
+    r = simde_float64x1_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_f64
+  #define vset_lane_f64(a, b, c) simde_vset_lane_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vset_lane_s8(int8_t a, simde_int8x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  simde_int8x8_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vset_lane_s8, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int8x8_private v_ = simde_int8x8_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int8x8_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_s8
+  #define vset_lane_s8(a, b, c) simde_vset_lane_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vset_lane_s16(int16_t a, simde_int16x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_int16x4_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vset_lane_s16, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int16x4_private v_ = simde_int16x4_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int16x4_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_s16
+  #define vset_lane_s16(a, b, c) simde_vset_lane_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vset_lane_s32(int32_t a, simde_int32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_int32x2_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vset_lane_s32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int32x2_private v_ = simde_int32x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int32x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_s32
+  #define vset_lane_s32(a, b, c) simde_vset_lane_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vset_lane_s64(int64_t a, simde_int64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  simde_int64x1_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    r = vset_lane_s64(a, v, 0);
+  #else
+    simde_int64x1_private v_ = simde_int64x1_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int64x1_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_s64
+  #define vset_lane_s64(a, b, c) simde_vset_lane_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vset_lane_u8(uint8_t a, simde_uint8x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  simde_uint8x8_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vset_lane_u8, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint8x8_private v_ = simde_uint8x8_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint8x8_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_u8
+  #define vset_lane_u8(a, b, c) simde_vset_lane_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vset_lane_u16(uint16_t a, simde_uint16x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_uint16x4_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vset_lane_u16, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint16x4_private v_ = simde_uint16x4_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint16x4_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_u16
+  #define vset_lane_u16(a, b, c) simde_vset_lane_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vset_lane_u32(uint32_t a, simde_uint32x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_uint32x2_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vset_lane_u32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint32x2_private v_ = simde_uint32x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint32x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_u32
+  #define vset_lane_u32(a, b, c) simde_vset_lane_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vset_lane_u64(uint64_t a, simde_uint64x1_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  simde_uint64x1_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    r = vset_lane_u64(a, v, 0);
+  #else
+    simde_uint64x1_private v_ = simde_uint64x1_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint64x1_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vset_lane_u64
+  #define vset_lane_u64(a, b, c) simde_vset_lane_u64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vsetq_lane_f32(simde_float32_t a, simde_float32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_float32x4_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vsetq_lane_f32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_float32x4_private v_ = simde_float32x4_to_private(v);
+    v_.values[lane] = a;
+    r = simde_float32x4_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_f32
+  #define vsetq_lane_f32(a, b, c) simde_vsetq_lane_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vsetq_lane_f64(simde_float64_t a, simde_float64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_float64x2_t r;
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_CONSTIFY_2_(vsetq_lane_f64, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_float64x2_private v_ = simde_float64x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_float64x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_f64
+  #define vsetq_lane_f64(a, b, c) simde_vsetq_lane_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vsetq_lane_s8(int8_t a, simde_int8x16_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  simde_int8x16_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_(vsetq_lane_s8, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int8x16_private v_ = simde_int8x16_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int8x16_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_s8
+  #define vsetq_lane_s8(a, b, c) simde_vsetq_lane_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vsetq_lane_s16(int16_t a, simde_int16x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  simde_int16x8_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vsetq_lane_s16, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int16x8_private v_ = simde_int16x8_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int16x8_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_s16
+  #define vsetq_lane_s16(a, b, c) simde_vsetq_lane_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vsetq_lane_s32(int32_t a, simde_int32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_int32x4_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vsetq_lane_s32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int32x4_private v_ = simde_int32x4_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int32x4_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_s32
+  #define vsetq_lane_s32(a, b, c) simde_vsetq_lane_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vsetq_lane_s64(int64_t a, simde_int64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_int64x2_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vsetq_lane_s64, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_int64x2_private v_ = simde_int64x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_int64x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_s64
+  #define vsetq_lane_s64(a, b, c) simde_vsetq_lane_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vsetq_lane_u8(uint8_t a, simde_uint8x16_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  simde_uint8x16_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_(vsetq_lane_u8, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint8x16_private v_ = simde_uint8x16_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint8x16_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_u8
+  #define vsetq_lane_u8(a, b, c) simde_vsetq_lane_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vsetq_lane_u16(uint16_t a, simde_uint16x8_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  simde_uint16x8_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_(vsetq_lane_u16, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint16x8_private v_ = simde_uint16x8_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint16x8_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_u16
+  #define vsetq_lane_u16(a, b, c) simde_vsetq_lane_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vsetq_lane_u32(uint32_t a, simde_uint32x4_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  simde_uint32x4_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_(vsetq_lane_u32, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint32x4_private v_ = simde_uint32x4_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint32x4_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_u32
+  #define vsetq_lane_u32(a, b, c) simde_vsetq_lane_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vsetq_lane_u64(uint64_t a, simde_uint64x2_t v, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  simde_uint64x2_t r;
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_(vsetq_lane_u64, r, (HEDLEY_UNREACHABLE(), v), lane, a, v);
+  #else
+    simde_uint64x2_private v_ = simde_uint64x2_to_private(v);
+    v_.values[lane] = a;
+    r = simde_uint64x2_from_private(v_);
+  #endif
+  return r;
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsetq_lane_u64
+  #define vsetq_lane_u64(a, b, c) simde_vsetq_lane_u64((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SET_LANE_H) */

--- a/2.0/simde/arm/neon/shl.h
+++ b/2.0/simde/arm/neon/shl.h
@@ -1,0 +1,805 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_SHL_H)
+#define SIMDE_ARM_NEON_SHL_H
+
+#include "types.h"
+
+/* Notes from the implementer (Christopher Moore aka rosbif)
+ *
+ * I have tried to exactly reproduce the documented behaviour of the
+ * ARM NEON shl and shlq intrinsics.
+ * This is complicated for the following reasons:-
+ *
+ * a) Negative shift counts shift right.
+ *
+ * b) Only the low byte of the shift count is used but the shift count
+ * is not limited to 8-bit values (-128 to 127).
+ *
+ * c) Intel SIMD is not nearly as complete as NEON and AltiVec.
+ * There were no intrisics with a vector shift count before AVX2 which
+ * only has 32 and 64-bit logical ones and only a 32-bit arithmetic
+ * one. The others need AVX512. There are no 8-bit shift intrinsics at
+ * all, even with a scalar shift count. It is surprising to use AVX2
+ * and even AVX512 to implement a 64-bit vector operation.
+ *
+ * d) Many shift implementations, and the C standard, do not treat a
+ * shift count >= the object's size in bits as one would expect.
+ * (Personally I feel that > is silly but == can be useful.)
+ *
+ * Maybe it would be useful for SIMDe to have a flag enabling a fast
+ * implementation where the result is only guaranteed for shift counts
+ * conforming to the C standard.
+ *
+ * Note that even the C17/18 standard does not define the behaviour of
+ * a right shift of a negative value.
+ * However Evan and I agree that all compilers likely to be used
+ * implement this as an arithmetic right shift with sign extension.
+ * If this is not the case it could be replaced by a logical right shift
+ * if negative values are complemented before and after the shift.
+ *
+ * Some of the SIMD translations may be slower than the portable code,
+ * particularly those for vectors with only one or two elements.
+ * But I had fun writing them ;-)
+ *
+ */
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vshl_s8 (const simde_int8x8_t a, const simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_s8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(b));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi16(a128, b128),
+                                   _mm_srav_epi16(a128, _mm_abs_epi16(b128)),
+                                   _mm_cmpgt_epi16(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(_mm_cvtepi16_epi8(r128));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m256i a256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(a));
+    __m256i b256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(b));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srav_epi32(a256, _mm256_abs_epi32(b256)),
+                                      _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi32(0x0C080400));
+    return _mm_set_pi32(_mm256_extract_epi32(r256, 4), _mm256_extract_epi32(r256, 0));
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t,
+        (b_.values[i] >=  0) ?
+        (b_.values[i] >=  8) ?                   0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -8) ? (a_.values[i] >> 7) : (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_s8
+  #define vshl_s8(a, b) simde_vshl_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vshl_s16 (const simde_int16x4_t a, const simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_s16(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(b));
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srav_epi32(a128, _mm_abs_epi32(b128)),
+                                   _mm_cmpgt_epi32(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(_mm_shuffle_epi8(r128, _mm_set1_epi64x(0x0D0C090805040100)));
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t,
+        (b_.values[i] >=   0) ?
+        (b_.values[i] >=  16) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -16) ? (a_.values[i] >> 15) : (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_s16
+  #define vshl_s16(a, b) simde_vshl_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vshl_s32 (const simde_int32x2_t a, const simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_s32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srav_epi32(a128, _mm_abs_epi32(b128)),
+                                   _mm_cmpgt_epi32(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=   0) ?
+        (b_.values[i] >=  32) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -32) ? (a_.values[i] >> 31) : (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_s32
+  #define vshl_s32(a, b) simde_vshl_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vshl_s64 (const simde_int64x1_t a, const simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_s64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi64(_mm_slli_epi64(b128, 56), 56);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128),
+                                   _mm_srav_epi64(a128, _mm_sub_epi64(zero, b128)),
+                                   _mm_cmpgt_epi64(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    __m128i maska = _mm_cmpgt_epi64(zero, a128);
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b128), _mm_set1_epi64x(0xFF));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b_abs),
+                                   _mm_xor_si128(_mm_srlv_epi64(_mm_xor_si128(a128, maska), b_abs), maska),
+                                   _mm_cmpgt_epi64(zero, _mm_slli_epi64(b128, 56)));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=   0) ?
+        (b_.values[i] >=  64) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -64) ? (a_.values[i] >> 63) : (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_s64
+  #define vshl_s64(a, b) simde_vshl_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vshl_u8 (const simde_uint8x8_t a, const simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_u8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_cvtepu8_epi16(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi8_epi16(_mm_movpi64_epi64(b));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi16(a128, b128),
+                                   _mm_srlv_epi16(a128, _mm_abs_epi16(b128)),
+                                   _mm_cmpgt_epi16(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(_mm_cvtepi16_epi8(r128));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m256i a256 = _mm256_cvtepu8_epi32(_mm_movpi64_epi64(a));
+    __m256i b256 = _mm256_cvtepi8_epi32(_mm_movpi64_epi64(b));
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srlv_epi32(a256, _mm256_abs_epi32(b256)),
+                                      _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi32(0x0C080400));
+    return _mm_set_pi32(_mm256_extract_epi32(r256, 4), _mm256_extract_epi32(r256, 0));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a);
+    simde_int8x8_private b_ = simde_int8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t,
+        (abs(b_.values[i]) >= 8) ? 0 :
+            (b_.values[i]  >= 0) ? (a_.values[i] <<  b_.values[i]) :
+                                   (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_u8
+  #define vshl_u8(a, b) simde_vshl_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vshl_u16 (const simde_uint16x4_t a, const simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_u16(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_cvtepu16_epi32(_mm_movpi64_epi64(a));
+    __m128i b128 = _mm_cvtepi16_epi32(_mm_movpi64_epi64(b));
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srlv_epi32(a128, _mm_abs_epi32(b128)),
+                                   _mm_cmpgt_epi32(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(_mm_shuffle_epi8(r128, _mm_set1_epi64x(0x0D0C090805040100)));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a);
+    simde_int16x4_private b_ = simde_int16x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t,
+        (abs(b_.values[i]) >= 16) ? 0 :
+            (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                    (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_u16
+  #define vshl_u16(a, b) simde_vshl_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vshl_u32 (const simde_uint32x2_t a, const simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_u32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi32(_mm_slli_epi32(b128, 24), 24);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi32(a128, b128),
+                                   _mm_srlv_epi32(a128, _mm_abs_epi32(b128)),
+                                   _mm_cmpgt_epi32(_mm_setzero_si128(), b128));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a);
+    simde_int32x2_private b_ = simde_int32x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (abs(b_.values[i]) >= 32) ? 0 :
+            (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                    (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_u32
+  #define vshl_u32(a, b) simde_vshl_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vshl_u64 (const simde_uint64x1_t a, const simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshl_u64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    b128 = _mm_srai_epi64(_mm_slli_epi64(b128, 56), 56);
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b128),
+                                   _mm_srlv_epi64(a128, _mm_sub_epi64(zero, b128)),
+                                   _mm_cmpgt_epi64(zero, b128));
+    return _mm_movepi64_pi64(r128);
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_movpi64_epi64(a);
+    __m128i b128 = _mm_movpi64_epi64(b);
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b128), _mm_set1_epi64x(0xFF));
+    __m128i r128 = _mm_blendv_epi8(_mm_sllv_epi64(a128, b_abs),
+                                   _mm_srlv_epi64(a128, b_abs),
+                                   _mm_cmpgt_epi64(_mm_setzero_si128(), _mm_slli_epi64(b128, 56)));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a);
+    simde_int64x1_private b_ = simde_int64x1_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (llabs(b_.values[i]) >= 64) ? 0 :
+              (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                      (a_.values[i] >> -b_.values[i]);
+    }
+
+  return simde_uint64x1_from_private(r_);
+#endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_u64
+  #define vshl_u64(a, b) simde_vshl_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vshlq_s8 (const simde_int8x16_t a, const simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_s8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m256i a256 = _mm256_cvtepi8_epi16(a);
+    __m256i b256 = _mm256_cvtepi8_epi16(b);
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi16(a256, b256),
+                                      _mm256_srav_epi16(a256, _mm256_abs_epi16(b256)),
+                                      _mm256_cmpgt_epi16(_mm256_setzero_si256(), b256));
+    return _mm256_cvtepi16_epi8(r256);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(signed char) a_shl, a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) b_abs, b_max;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool char) b_mask;
+    b_abs = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_abs(b));
+    b_max = vec_splat_u8(7);
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
+    #else
+      a_shl = vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, vec_splat_u8(8)));
+    #endif
+    a_shr = vec_sra(a, vec_min(b_abs, b_max));
+    b_mask = vec_cmplt(b, vec_splat_s8(0));
+    return vec_sel(a_shl, a_shr, b_mask);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t,
+        (b_.values[i] >=  0) ?
+        (b_.values[i] >=  8) ?                   0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -8) ? (a_.values[i] >> 7) : (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_s8
+  #define vshlq_s8(a, b) simde_vshlq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vshlq_s16 (const simde_int16x8_t a, const simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_s16(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128i b_ = _mm_srai_epi16(_mm_slli_epi16(b, 8), 8);
+    return _mm_blendv_epi8(_mm_sllv_epi16(a, b_),
+                           _mm_srav_epi16(a, _mm_abs_epi16(b_)),
+                           _mm_cmpgt_epi16(_mm_setzero_si128(), b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    __m256i a256 = _mm256_cvtepi16_epi32(a);
+    __m256i b256 = _mm256_cvtepi16_epi32(b);
+    b256 = _mm256_srai_epi32(_mm256_slli_epi32(b256, 24), 24);
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srav_epi32(a256, _mm256_abs_epi32(b256)),
+                                      _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
+    return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(signed short) a_shl, a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) b_abs, b_max;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool short) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0xFF)));
+    b_max = vec_splat_u16(15);
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
+    #else
+      a_shl = vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned short, 16))));
+    #endif
+    a_shr = vec_sra(a, vec_min(b_abs, b_max));
+    b_mask = vec_cmplt(vec_sl(b, vec_splat_u16(8)), vec_splat_s16(0));
+    return vec_sel(a_shl, a_shr, b_mask);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t,
+          (b_.values[i] >=   0) ?
+          (b_.values[i] >=  16) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+          (b_.values[i] <= -16) ? (a_.values[i] >> 15) : (a_.values[i] >> -b_.values[i]));
+      }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_s16
+  #define vshlq_s16(a, b) simde_vshlq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vshlq_s32 (const simde_int32x4_t a, const simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_s32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    __m128i b_ = _mm_srai_epi32(_mm_slli_epi32(b, 24), 24);
+    return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
+                           _mm_srav_epi32(a, _mm_abs_epi32(b_)),
+                           _mm_cmpgt_epi32(_mm_setzero_si128(), b_));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(signed int) a_shl, a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) b_abs, b_max;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool int) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned int, 0xFF)));
+    b_max = vec_splats(HEDLEY_STATIC_CAST(unsigned int, 31));
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
+    #else
+    a_shl = vec_and(vec_sl(a, b_abs), vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 32))));
+      #endif
+    a_shr = vec_sra(a, vec_min(b_abs, b_max));
+    b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 24))),
+                       vec_splat_s32(0));
+    return vec_sel(a_shl, a_shr, b_mask);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=   0) ?
+        (b_.values[i] >=  32) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -32) ? (a_.values[i] >> 31) : (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_s32
+  #define vshlq_s32(a, b) simde_vshlq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vshlq_s64 (const simde_int64x2_t a, const simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_s64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i b_ = _mm_srai_epi64(_mm_slli_epi64(b, 56), 56);
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_),
+                           _mm_srav_epi64(a, _mm_sub_epi64(zero, b_)),
+                           _mm_cmpgt_epi64(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i maska = _mm_cmpgt_epi64(zero, a);
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b), _mm_set1_epi64x(0xFF));
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
+                           _mm_xor_si128(_mm_srlv_epi64(_mm_xor_si128(a, maska), b_abs), maska),
+                           _mm_cmpgt_epi64(zero, _mm_slli_epi64(b, 56)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(signed long long) a_shl, a_shr;
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) b_abs, b_max;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool long long) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 0xFF)));
+    b_max = vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 63));
+    a_shl = vec_and(vec_sl(a, b_abs), vec_cmple(b_abs, b_max));
+    a_shr = vec_sra(a, vec_min(b_abs, b_max));
+    b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 56))),
+                       vec_splats(HEDLEY_STATIC_CAST(signed long long, 0)));
+    HEDLEY_DIAGNOSTIC_PUSH
+    #if defined(SIMDE_BUG_CLANG_46770)
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+    #endif
+    return vec_sel(a_shl, a_shr, b_mask);
+    HEDLEY_DIAGNOSTIC_POP
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] =
+        (b_.values[i] >=   0) ?
+        (b_.values[i] >=  64) ?                    0 : (a_.values[i] <<  b_.values[i]) :
+        (b_.values[i] <= -64) ? (a_.values[i] >> 63) : (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_s64
+  #define vshlq_s64(a, b) simde_vshlq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vshlq_u8 (const simde_uint8x16_t a, const simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_u8(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m256i a256 = _mm256_cvtepu8_epi16(a);
+    __m256i b256 = _mm256_cvtepi8_epi16(b);
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi16(a256, b256),
+                                      _mm256_srlv_epi16(a256, _mm256_abs_epi16(b256)),
+                                      _mm256_cmpgt_epi16(_mm256_setzero_si256(), b256));
+    return _mm256_cvtepi16_epi8(r256);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) b_abs;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool char) b_mask;
+    b_abs = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), vec_abs(b));
+    b_mask = vec_cmplt(b, vec_splat_s8(0));
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
+                   vec_cmplt(b_abs, vec_splat_u8(8)));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+    simde_int8x16_private b_ = simde_int8x16_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t,
+        (abs(b_.values[i]) >= 8) ? 0 :
+            (b_.values[i]  >= 0) ? (a_.values[i] <<  b_.values[i]) :
+                                   (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_u8
+  #define vshlq_u8(a, b) simde_vshlq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vshlq_u16 (const simde_uint16x8_t a, const simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_u16(a, b);
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128i b_ = _mm_srai_epi16(_mm_slli_epi16(b, 8), 8);
+    return _mm_blendv_epi8(_mm_sllv_epi16(a, b_),
+                           _mm_srlv_epi16(a, _mm_abs_epi16(b_)),
+                           _mm_cmpgt_epi16(_mm_setzero_si128(), b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    __m256i a256 = _mm256_cvtepu16_epi32(a);
+    __m256i b256 = _mm256_cvtepi16_epi32(b);
+    b256 = _mm256_srai_epi32(_mm256_slli_epi32(b256, 24), 24);
+    __m256i r256 = _mm256_blendv_epi8(_mm256_sllv_epi32(a256, b256),
+                                      _mm256_srlv_epi32(a256, _mm256_abs_epi32(b256)),
+                                      _mm256_cmpgt_epi32(_mm256_setzero_si256(), b256));
+    r256 = _mm256_shuffle_epi8(r256, _mm256_set1_epi64x(0x0D0C090805040100));
+    return _mm_set_epi64x(_mm256_extract_epi64(r256, 2), _mm256_extract_epi64(r256, 0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) b_abs;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool short) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned short),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned short, 0xFF)));
+    b_mask = vec_cmplt(vec_sl(b, vec_splat_u16(8)), vec_splat_s16(0));
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
+                     vec_cmple(b_abs, vec_splat_u16(15)));
+    #else
+      return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
+                     vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned short, 16))));
+    #endif
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+    simde_int16x8_private b_ = simde_int16x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t,
+        (abs(b_.values[i]) >= 16) ? 0 :
+            (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                    (a_.values[i] >> -b_.values[i]));
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_u16
+  #define vshlq_u16(a, b) simde_vshlq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vshlq_u32 (const simde_uint32x4_t a, const simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_u32(a, b);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    __m128i b_ = _mm_srai_epi32(_mm_slli_epi32(b, 24), 24);
+    return _mm_blendv_epi8(_mm_sllv_epi32(a, b_),
+                           _mm_srlv_epi32(a, _mm_abs_epi32(b_)),
+                           _mm_cmpgt_epi32(_mm_setzero_si128(), b_));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) b_abs;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool int) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned int, 0xFF)));
+    b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 24))), vec_splat_s32(0));
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
+                   vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned int, 32))));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+    simde_int32x4_private b_ = simde_int32x4_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = (abs(b_.values[i]) >= 32) ? 0 :
+                         (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                                 (a_.values[i] >> -b_.values[i]);
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_u32
+  #define vshlq_u32(a, b) simde_vshlq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vshlq_u64 (const simde_uint64x2_t a, const simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vshlq_u64(a, b);
+  #elif defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    __m128i zero = _mm_setzero_si128();
+    __m128i b_ = _mm_srai_epi64(_mm_slli_epi64(b, 56), 56);
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_),
+                           _mm_srlv_epi64(a, _mm_sub_epi64(zero, b_)),
+                           _mm_cmpgt_epi64(zero, b_));
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    __m128i b_abs = _mm_and_si128(_mm_abs_epi8(b), _mm_set1_epi64x(0xFF));
+    return _mm_blendv_epi8(_mm_sllv_epi64(a, b_abs),
+                           _mm_srlv_epi64(a, b_abs),
+                           _mm_cmpgt_epi64(_mm_setzero_si128(), _mm_slli_epi64(b, 56)));
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) b_abs;
+    SIMDE_POWER_ALTIVEC_VECTOR(bool long long) b_mask;
+    b_abs = vec_and(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long),
+                                            vec_abs(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), b))),
+                    vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 0xFF)));
+    b_mask = vec_cmplt(vec_sl(b, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 56))),
+                       vec_splats(HEDLEY_STATIC_CAST(signed long long, 0)));
+    HEDLEY_DIAGNOSTIC_PUSH
+    #if defined(SIMDE_BUG_CLANG_46770)
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+    #endif
+    return vec_and(vec_sel(vec_sl(a, b_abs), vec_sr(a, b_abs), b_mask),
+                   vec_cmplt(b_abs, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 64))));
+    HEDLEY_DIAGNOSTIC_POP
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a);
+    simde_int64x2_private b_ = simde_int64x2_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      b_.values[i] = HEDLEY_STATIC_CAST(int8_t, b_.values[i]);
+      r_.values[i] = (llabs(b_.values[i]) >= 64) ? 0 :
+                           (b_.values[i]  >=  0) ? (a_.values[i] <<  b_.values[i]) :
+                                                   (a_.values[i] >> -b_.values[i]);
+      }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_u64
+  #define vshlq_u64(a, b) simde_vshlq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SHL_H) */

--- a/2.0/simde/arm/neon/shl_n.h
+++ b/2.0/simde/arm/neon/shl_n.h
@@ -1,0 +1,554 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_SHL_N_H)
+#define SIMDE_ARM_NEON_SHL_N_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vshl_n_s8 (const simde_int8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  simde_int8x8_private
+    r_,
+    a_ = simde_int8x8_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << HEDLEY_STATIC_CAST(int8_t, n);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_int8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_s8(a, n) vshl_n_s8((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_s8(a, n) \
+    _mm_andnot_si64(_mm_set1_pi8((1 << n) - 1), _mm_slli_si64((a), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_s8
+  #define vshl_n_s8(a, n) simde_vshl_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vshl_n_s16 (const simde_int16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  simde_int16x4_private
+    r_,
+    a_ = simde_int16x4_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << HEDLEY_STATIC_CAST(int16_t, n);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_int16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_s16(a, n) vshl_n_s16((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_s16(a, n) _mm_slli_pi16((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_s16
+  #define vshl_n_s16(a, n) simde_vshl_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vshl_n_s32 (const simde_int32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 31) {
+  simde_int32x2_private
+    r_,
+    a_ = simde_int32x2_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << n;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_int32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_s32(a, n) vshl_n_s32((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_s32(a, n) _mm_slli_pi32((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_s32
+  #define vshl_n_s32(a, n) simde_vshl_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vshl_n_s64 (const simde_int64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 63) {
+  simde_int64x1_private
+    r_,
+    a_ = simde_int64x1_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << n;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int64_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_int64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_s64(a, n) vshl_n_s64((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_s64(a, n) _mm_slli_si64((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_s64
+  #define vshl_n_s64(a, n) simde_vshl_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vshl_n_u8 (const simde_uint8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  simde_uint8x8_private
+    r_,
+    a_ = simde_uint8x8_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << HEDLEY_STATIC_CAST(uint8_t, n);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_uint8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_u8(a, n) vshl_n_u8((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_u8(a, n) \
+    _mm_andnot_si64(_mm_set1_pi8((1 << n) - 1), _mm_slli_si64((a), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_u8
+  #define vshl_n_u8(a, n) simde_vshl_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vshl_n_u16 (const simde_uint16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  simde_uint16x4_private
+    r_,
+    a_ = simde_uint16x4_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << HEDLEY_STATIC_CAST(uint16_t, n);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_uint16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_u16(a, n) vshl_n_u16((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_u16(a, n) _mm_slli_pi16((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_u16
+  #define vshl_n_u16(a, n) simde_vshl_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vshl_n_u32 (const simde_uint32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 31) {
+  simde_uint32x2_private
+    r_,
+    a_ = simde_uint32x2_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << n;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_uint32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_u32(a, n) vshl_n_u32((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_u32(a, n) _mm_slli_pi32((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_u32
+  #define vshl_n_u32(a, n) simde_vshl_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vshl_n_u64 (const simde_uint64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 63) {
+  simde_uint64x1_private
+    r_,
+    a_ = simde_uint64x1_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values << n;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(uint64_t, a_.values[i] << n);
+    }
+  #endif
+
+  return simde_uint64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshl_n_u64(a, n) vshl_n_u64((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshl_n_u64(a, n) _mm_slli_si64((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshl_n_u64
+  #define vshl_n_u64(a, n) simde_vshl_n_u64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vshlq_n_s8 (const simde_int8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, (1 << n) - 1)), _mm_slli_epi64(a, n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_shl(a, n);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << HEDLEY_STATIC_CAST(int8_t, n);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int8_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_s8(a, n) vshlq_n_s8((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_s8(a, n) vec_sl((a), vec_splats(SIMDE_CHECKED_STATIC_CAST(unsigned char, int, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_s8
+  #define vshlq_n_s8(a, n) simde_vshlq_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vshlq_n_s16 (const simde_int16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi16((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_shl((a), (n));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << HEDLEY_STATIC_CAST(int16_t, n);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_s16(a, n) vshlq_n_s16((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_s16(a, n) vec_sl((a), vec_splats(SIMDE_CHECKED_STATIC_CAST(unsigned short, int, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_s16
+  #define vshlq_n_s16(a, n) simde_vshlq_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vshlq_n_s32 (const simde_int32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 31) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi32((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_shl((a), (n));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int32_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_s32(a, n) vshlq_n_s32((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_s32(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_s32
+  #define vshlq_n_s32(a, n) simde_vshlq_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vshlq_n_s64 (const simde_int64x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 63) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi64((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_shl((a), (n));
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int64_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_s64(a, n) vshlq_n_s64((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_vshlq_n_s64(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_s64
+  #define vshlq_n_s64(a, n) simde_vshlq_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vshlq_n_u8 (const simde_uint8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 7) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, (1 << n) - 1)), _mm_slli_epi64((a), (n)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_shl((a), (n));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << HEDLEY_STATIC_CAST(uint8_t, n);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint8_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_u8(a, n) vshlq_n_u8((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_u8(a, n) vec_sl((a), vec_splat_u8(n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_u8
+  #define vshlq_n_u8(a, n) simde_vshlq_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vshlq_n_u16 (const simde_uint16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 15) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi16((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_shl((a), (n));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << HEDLEY_STATIC_CAST(uint16_t, n);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint16_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_u16(a, n) vshlq_n_u16((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_u16(a, n) vec_sl((a), vec_splat_u16(n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_u16
+  #define vshlq_n_u16(a, n) simde_vshlq_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vshlq_n_u32 (const simde_uint32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 31) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi32((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_shl((a), (n));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint32_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_u32(a, n) vshlq_n_u32((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshlq_n_u32(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_u32
+  #define vshlq_n_u32(a, n) simde_vshlq_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vshlq_n_u64 (const simde_uint64x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 0, 63) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_slli_epi64((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_shl((a), (n));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values << n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(uint64_t, a_.values[i] << n);
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshlq_n_u64(a, n) vshlq_n_u64((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_vshlq_n_u64(a, n) vec_sl((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshlq_n_u64
+  #define vshlq_n_u64(a, n) simde_vshlq_n_u64((a), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SHL_N_H) */

--- a/2.0/simde/arm/neon/shr_n.h
+++ b/2.0/simde/arm/neon/shr_n.h
@@ -1,0 +1,604 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_SHR_N_H)
+#define SIMDE_ARM_NEON_SHR_N_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vshr_n_s8 (const simde_int8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_int8x8_private
+    r_,
+    a_ = simde_int8x8_to_private(a);
+  int32_t n_ = (n == 8) ? 7 : n;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values >> n_;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int8_t, a_.values[i] >> n_);
+    }
+  #endif
+
+  return simde_int8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_s8(a, n) vshr_n_s8((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_s8(a, n) \
+    _mm_or_si64(_mm_andnot_si64(_mm_set1_pi16(0x00FF), _mm_srai_pi16((a), (n))), \
+                _mm_and_si64(_mm_set1_pi16(0x00FF), _mm_srai_pi16(_mm_slli_pi16((a), 8), 8 + (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_s8
+  #define vshr_n_s8(a, n) simde_vshr_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vshr_n_s16 (const simde_int16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_int16x4_private
+    r_,
+    a_ = simde_int16x4_to_private(a);
+  int32_t n_ = (n == 16) ? 15 : n;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values >> n_;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i] >> n_);
+    }
+  #endif
+
+  return simde_int16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_s16(a, n) vshr_n_s16((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_s16(a, n) _mm_srai_pi16((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_s16
+  #define vshr_n_s16(a, n) simde_vshr_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vshr_n_s32 (const simde_int32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_int32x2_private
+    r_,
+    a_ = simde_int32x2_to_private(a);
+  int32_t n_ = (n == 32) ? 31 : n;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values >> n_;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i] >> n_;
+    }
+  #endif
+
+  return simde_int32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_s32(a, n) vshr_n_s32((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_s32(a, n) _mm_srai_pi32((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_s32
+  #define vshr_n_s32(a, n) simde_vshr_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vshr_n_s64 (const simde_int64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_int64x1_private
+    r_,
+    a_ = simde_int64x1_to_private(a);
+  int32_t n_ = (n == 64) ? 63 : n;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.values = a_.values >> n_;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = a_.values[i] >> n_;
+    }
+  #endif
+
+  return simde_int64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_s64(a, n) vshr_n_s64((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_s64
+  #define vshr_n_s64(a, n) simde_vshr_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vshr_n_u8 (const simde_uint8x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  simde_uint8x8_private
+    r_,
+    a_ = simde_uint8x8_to_private(a);
+
+  if (n == 8) {
+    simde_memset(&r_, 0, sizeof(r_));
+  } else {
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n;
+      }
+    #endif
+  }
+
+  return simde_uint8x8_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_u8(a, n) vshr_n_u8((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_u8(a, n) \
+    _mm_and_si64(_mm_srli_si64((a), (n)), _mm_set1_pi8((1 << (8 - (n))) - 1))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_u8
+  #define vshr_n_u8(a, n) simde_vshr_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vshr_n_u16 (const simde_uint16x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  simde_uint16x4_private
+    r_,
+    a_ = simde_uint16x4_to_private(a);
+
+  if (n == 16) {
+    simde_memset(&r_, 0, sizeof(r_));
+  } else {
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n;
+      }
+    #endif
+  }
+
+  return simde_uint16x4_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_u16(a, n) vshr_n_u16((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_u16(a, n) _mm_srli_pi16((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_u16
+  #define vshr_n_u16(a, n) simde_vshr_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vshr_n_u32 (const simde_uint32x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  simde_uint32x2_private
+    r_,
+    a_ = simde_uint32x2_to_private(a);
+
+  if (n == 32) {
+    simde_memset(&r_, 0, sizeof(r_));
+  } else {
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n;
+      }
+    #endif
+  }
+
+  return simde_uint32x2_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_u32(a, n) vshr_n_u32((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_u32(a, n) _mm_srli_pi32((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_u32
+  #define vshr_n_u32(a, n) simde_vshr_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vshr_n_u64 (const simde_uint64x1_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  simde_uint64x1_private
+    r_,
+    a_ = simde_uint64x1_to_private(a);
+
+  if (n == 64) {
+    simde_memset(&r_, 0, sizeof(r_));
+  } else {
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n;
+      }
+    #endif
+  }
+
+  return simde_uint64x1_from_private(r_);
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshr_n_u64(a, n) vshr_n_u64((a), (n))
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #define simde_vshr_n_u64(a, n) _mm_srli_si64((a), (n))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshr_n_u64
+  #define vshr_n_u64(a, n) simde_vshr_n_u64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vshrq_n_s8 (const simde_int8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return
+      _mm_blendv_epi8(_mm_srai_epi16((a), (n)),
+                      _mm_srai_epi16(_mm_slli_epi16((a), 8), 8 + (n)),
+                      _mm_set1_epi16(0x00FF));
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return
+      _mm_or_si128(_mm_andnot_si128(_mm_set1_epi16(0x00FF), _mm_srai_epi16((a), (n))),
+                  _mm_and_si128(_mm_set1_epi16(0x00FF), _mm_srai_epi16(_mm_slli_epi16((a), 8), 8 + (n))));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_shr((a), ((n) == 8) ? 7 : (n));
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a);
+    int32_t n_ = (n == 8) ? 7 : n;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n_;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int8_t, a_.values[i] >> n_);
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_s8(a, n) vshrq_n_s8((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_s8(a, n) vec_sra((a), vec_splat_u8(((n) == 8) ? 7 : (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_s8
+  #define vshrq_n_s8(a, n) simde_vshrq_n_s8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vshrq_n_s16 (const simde_int16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srai_epi16((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_shr((a), ((n) == 16) ? 15 : (n));
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a);
+    int32_t n_ = (n == 16) ? 15 : n;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n_;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = HEDLEY_STATIC_CAST(int16_t, a_.values[i] >> n_);
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_s16(a, n) vshrq_n_s16((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_s16(a, n) vec_sra((a), vec_splat_u16(((n) == 16) ? 15 : (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_s16
+  #define vshrq_n_s16(a, n) simde_vshrq_n_s16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vshrq_n_s32 (const simde_int32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srai_epi32((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_shr((a), ((n) == 32) ? 31 : (n));
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a);
+    int32_t n_ = (n == 32) ? 31 : n;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n_;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n_;
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_s32(a, n) vshrq_n_s32((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_s32(a, n) \
+    vec_sra((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, ((n) == 32) ? 31 : (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_s32
+  #define vshrq_n_s32(a, n) simde_vshrq_n_s32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vshrq_n_s64 (const simde_int64x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  #if defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_shr((a), ((n) == 64) ? 63 : (n));
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a);
+    int32_t n_ = (n == 64) ? 63 : n;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = a_.values >> n_;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] >> n_;
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_s64(a, n) vshrq_n_s64((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_vshrq_n_s64(a, n) \
+    vec_sra((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, ((n) == 64) ? 63 : (n))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_s64
+  #define vshrq_n_s64(a, n) simde_vshrq_n_s64((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vshrq_n_u8 (const simde_uint8x16_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 8) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(_mm_srli_epi64((a), (n)), _mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, (1 << (8 - (n))) - 1)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return (((n) == 8) ? wasm_i8x16_splat(0) : wasm_u8x16_shr((a), (n)));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a);
+
+    if (n == 8) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.values = a_.values >> n;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+          r_.values[i] = a_.values[i] >> n;
+        }
+      #endif
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_u8(a, n) vshrq_n_u8((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_u8(a, n) \
+    (((n) == 8) ? vec_splat_u8(0) : vec_sr((a), vec_splat_u8(n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_u8
+  #define vshrq_n_u8(a, n) simde_vshrq_n_u8((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vshrq_n_u16 (const simde_uint16x8_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 16) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srli_epi16((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return (((n) == 16) ? wasm_i16x8_splat(0) : wasm_u16x8_shr((a), (n)));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a);
+
+    if (n == 16) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.values = a_.values >> n;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+          r_.values[i] = a_.values[i] >> n;
+        }
+      #endif
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_u16(a, n) vshrq_n_u16((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_u16(a, n) \
+    (((n) == 16) ? vec_splat_u16(0) : vec_sr((a), vec_splat_u16(n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_u16
+  #define vshrq_n_u16(a, n) simde_vshrq_n_u16((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vshrq_n_u32 (const simde_uint32x4_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 32) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srli_epi32((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return (((n) == 32) ? wasm_i32x4_splat(0) : wasm_u32x4_shr((a), (n)));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a);
+
+    if (n == 32) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.values = a_.values >> n;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+          r_.values[i] = a_.values[i] >> n;
+        }
+      #endif
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_u32(a, n) vshrq_n_u32((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_vshrq_n_u32(a, n) \
+    (((n) == 32) ? vec_splat_u32(0) : vec_sr((a), vec_splats(HEDLEY_STATIC_CAST(unsigned int, (n)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_u32
+  #define vshrq_n_u32(a, n) simde_vshrq_n_u32((a), (n))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vshrq_n_u64 (const simde_uint64x2_t a, const int n)
+    SIMDE_REQUIRE_CONSTANT_RANGE(n, 1, 64) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srli_epi64((a), (n));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return (((n) == 64) ? wasm_i64x2_splat(0) : wasm_u64x2_shr((a), (n)));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a);
+
+    if (n == 64) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.values = a_.values >> n;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+          r_.values[i] = a_.values[i] >> n;
+        }
+      #endif
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vshrq_n_u64(a, n) vshrq_n_u64((a), (n))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_vshrq_n_u64(a, n) \
+    (((n) == 64) ? vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 0)) : vec_sr((a), vec_splats(HEDLEY_STATIC_CAST(unsigned long long, (n)))))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vshrq_n_u64
+  #define vshrq_n_u64(a, n) simde_vshrq_n_u64((a), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SHR_N_H) */

--- a/2.0/simde/arm/neon/sra_n.h
+++ b/2.0/simde/arm/neon/sra_n.h
@@ -1,0 +1,202 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_SRA_N_H)
+#define SIMDE_ARM_NEON_SRA_N_H
+
+#include "add.h"
+#include "shr_n.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_s8(a, b, n) vsra_n_s8((a), (b), (n))
+#else
+  #define simde_vsra_n_s8(a, b, n) simde_vadd_s8((a), simde_vshr_n_s8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_s8
+  #define vsra_n_s8(a, b, n) simde_vsra_n_s8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_s16(a, b, n) vsra_n_s16((a), (b), (n))
+#else
+  #define simde_vsra_n_s16(a, b, n) simde_vadd_s16((a), simde_vshr_n_s16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_s16
+  #define vsra_n_s16(a, b, n) simde_vsra_n_s16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_s32(a, b, n) vsra_n_s32((a), (b), (n))
+#else
+  #define simde_vsra_n_s32(a, b, n) simde_vadd_s32((a), simde_vshr_n_s32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_s32
+  #define vsra_n_s32(a, b, n) simde_vsra_n_s32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_s64(a, b, n) vsra_n_s64((a), (b), (n))
+#else
+  #define simde_vsra_n_s64(a, b, n) simde_vadd_s64((a), simde_vshr_n_s64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_s64
+  #define vsra_n_s64(a, b, n) simde_vsra_n_s64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_u8(a, b, n) vsra_n_u8((a), (b), (n))
+#else
+  #define simde_vsra_n_u8(a, b, n) simde_vadd_u8((a), simde_vshr_n_u8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_u8
+  #define vsra_n_u8(a, b, n) simde_vsra_n_u8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_u16(a, b, n) vsra_n_u16((a), (b), (n))
+#else
+  #define simde_vsra_n_u16(a, b, n) simde_vadd_u16((a), simde_vshr_n_u16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_u16
+  #define vsra_n_u16(a, b, n) simde_vsra_n_u16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_u32(a, b, n) vsra_n_u32((a), (b), (n))
+#else
+  #define simde_vsra_n_u32(a, b, n) simde_vadd_u32((a), simde_vshr_n_u32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_u32
+  #define vsra_n_u32(a, b, n) simde_vsra_n_u32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsra_n_u64(a, b, n) vsra_n_u64((a), (b), (n))
+#else
+  #define simde_vsra_n_u64(a, b, n) simde_vadd_u64((a), simde_vshr_n_u64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsra_n_u64
+  #define vsra_n_u64(a, b, n) simde_vsra_n_u64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_s8(a, b, n) vsraq_n_s8((a), (b), (n))
+#else
+  #define simde_vsraq_n_s8(a, b, n) simde_vaddq_s8((a), simde_vshrq_n_s8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_s8
+  #define vsraq_n_s8(a, b, n) simde_vsraq_n_s8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_s16(a, b, n) vsraq_n_s16((a), (b), (n))
+#else
+  #define simde_vsraq_n_s16(a, b, n) simde_vaddq_s16((a), simde_vshrq_n_s16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_s16
+  #define vsraq_n_s16(a, b, n) simde_vsraq_n_s16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_s32(a, b, n) vsraq_n_s32((a), (b), (n))
+#else
+  #define simde_vsraq_n_s32(a, b, n) simde_vaddq_s32((a), simde_vshrq_n_s32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_s32
+  #define vsraq_n_s32(a, b, n) simde_vsraq_n_s32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_s64(a, b, n) vsraq_n_s64((a), (b), (n))
+#else
+  #define simde_vsraq_n_s64(a, b, n) simde_vaddq_s64((a), simde_vshrq_n_s64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_s64
+  #define vsraq_n_s64(a, b, n) simde_vsraq_n_s64((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_u8(a, b, n) vsraq_n_u8((a), (b), (n))
+#else
+  #define simde_vsraq_n_u8(a, b, n) simde_vaddq_u8((a), simde_vshrq_n_u8((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_u8
+  #define vsraq_n_u8(a, b, n) simde_vsraq_n_u8((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_u16(a, b, n) vsraq_n_u16((a), (b), (n))
+#else
+  #define simde_vsraq_n_u16(a, b, n) simde_vaddq_u16((a), simde_vshrq_n_u16((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_u16
+  #define vsraq_n_u16(a, b, n) simde_vsraq_n_u16((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_u32(a, b, n) vsraq_n_u32((a), (b), (n))
+#else
+  #define simde_vsraq_n_u32(a, b, n) simde_vaddq_u32((a), simde_vshrq_n_u32((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_u32
+  #define vsraq_n_u32(a, b, n) simde_vsraq_n_u32((a), (b), (n))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_vsraq_n_u64(a, b, n) vsraq_n_u64((a), (b), (n))
+#else
+  #define simde_vsraq_n_u64(a, b, n) simde_vaddq_u64((a), simde_vshrq_n_u64((b), (n)))
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsraq_n_u64
+  #define vsraq_n_u64(a, b, n) simde_vsraq_n_u64((a), (b), (n))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SRA_N_H) */

--- a/2.0/simde/arm/neon/st1.h
+++ b/2.0/simde/arm/neon/st1.h
@@ -1,0 +1,353 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ST1_H)
+#define SIMDE_ARM_NEON_ST1_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float32x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1_f32(ptr, val);
+  #else
+    simde_float32x2_private val_ = simde_float32x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_f32
+  #define vst1_f32(a, b) simde_vst1_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_float64x1_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1_f64(ptr, val);
+  #else
+    simde_float64x1_private val_ = simde_float64x1_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst1_f64
+  #define vst1_f64(a, b) simde_vst1_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int8x8_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_s8(ptr, val);
+  #else
+    simde_int8x8_private val_ = simde_int8x8_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_s8
+  #define vst1_s8(a, b) simde_vst1_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int16x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_s16(ptr, val);
+  #else
+    simde_int16x4_private val_ = simde_int16x4_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_s16
+  #define vst1_s16(a, b) simde_vst1_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int32x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_s32(ptr, val);
+  #else
+    simde_int32x2_private val_ = simde_int32x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_s32
+  #define vst1_s32(a, b) simde_vst1_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_int64x1_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_s64(ptr, val);
+  #else
+    simde_int64x1_private val_ = simde_int64x1_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_s64
+  #define vst1_s64(a, b) simde_vst1_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint8x8_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_u8(ptr, val);
+  #else
+    simde_uint8x8_private val_ = simde_uint8x8_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_u8
+  #define vst1_u8(a, b) simde_vst1_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint16x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_u16(ptr, val);
+  #else
+    simde_uint16x4_private val_ = simde_uint16x4_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_u16
+  #define vst1_u16(a, b) simde_vst1_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint32x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_u32(ptr, val);
+  #else
+    simde_uint32x2_private val_ = simde_uint32x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_u32
+  #define vst1_u32(a, b) simde_vst1_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(1)], simde_uint64x1_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1_u64(ptr, val);
+  #else
+    simde_uint64x1_private val_ = simde_uint64x1_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_u64
+  #define vst1_u64(a, b) simde_vst1_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_f32(simde_float32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_float32x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_f32(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_float32x4_private val_ = simde_float32x4_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_f32
+  #define vst1q_f32(a, b) simde_vst1q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_f64(simde_float64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_float64x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1q_f64(ptr, val);
+  #else
+    simde_float64x2_private val_ = simde_float64x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_f64
+  #define vst1q_f64(a, b) simde_vst1q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_s8(int8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_int8x16_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s8(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_int8x16_private val_ = simde_int8x16_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_s8
+  #define vst1q_s8(a, b) simde_vst1q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_s16(int16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_int16x8_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s16(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_int16x8_private val_ = simde_int16x8_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_s16
+  #define vst1q_s16(a, b) simde_vst1q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_s32(int32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_int32x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s32(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_int32x4_private val_ = simde_int32x4_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_s32
+  #define vst1q_s32(a, b) simde_vst1q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_s64(int64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_int64x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s64(ptr, val);
+  #else
+    simde_int64x2_private val_ = simde_int64x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_s64
+  #define vst1q_s64(a, b) simde_vst1q_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_u8(uint8_t ptr[HEDLEY_ARRAY_PARAM(16)], simde_uint8x16_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_u8(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_uint8x16_private val_ = simde_uint8x16_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_u8
+  #define vst1q_u8(a, b) simde_vst1q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_u16(uint16_t ptr[HEDLEY_ARRAY_PARAM(8)], simde_uint16x8_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_u16(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_uint16x8_private val_ = simde_uint16x8_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_u16
+  #define vst1q_u16(a, b) simde_vst1q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_u32(uint32_t ptr[HEDLEY_ARRAY_PARAM(4)], simde_uint32x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_u32(ptr, val);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && 0
+    vec_st(val, 0, ptr);
+  #else
+    simde_uint32x4_private val_ = simde_uint32x4_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_u32
+  #define vst1q_u32(a, b) simde_vst1q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_u64(uint64_t ptr[HEDLEY_ARRAY_PARAM(2)], simde_uint64x2_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_u64(ptr, val);
+  #else
+    simde_uint64x2_private val_ = simde_uint64x2_to_private(val);
+    simde_memcpy(ptr, &val_, sizeof(val_));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_u64
+  #define vst1q_u64(a, b) simde_vst1q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ST1_H) */

--- a/2.0/simde/arm/neon/st1_lane.h
+++ b/2.0/simde/arm/neon/st1_lane.h
@@ -1,0 +1,363 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ST1_LANE_H)
+#define SIMDE_ARM_NEON_ST1_LANE_H
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_f32(simde_float32_t *ptr, simde_float32x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1_lane_f32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_float32x2_private val_ = simde_float32x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_f32
+  #define vst1_lane_f32(a, b, c) simde_vst1_lane_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_f64(simde_float64_t *ptr, simde_float64x1_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    (void) lane;
+    vst1_lane_f64(ptr, val, 0);
+  #else
+    simde_float64x1_private val_ = simde_float64x1_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_f64
+  #define vst1_lane_f64(a, b, c) simde_vst1_lane_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_s8(int8_t *ptr, simde_int8x8_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_NO_RESULT_(vst1_lane_s8, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int8x8_private val_ = simde_int8x8_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_s8
+  #define vst1_lane_s8(a, b, c) simde_vst1_lane_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_s16(int16_t *ptr, simde_int16x4_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_NO_RESULT_(vst1_lane_s16, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int16x4_private val_ = simde_int16x4_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_s16
+  #define vst1_lane_s16(a, b, c) simde_vst1_lane_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_s32(int32_t *ptr, simde_int32x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1_lane_s32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int32x2_private val_ = simde_int32x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_s32
+  #define vst1_lane_s32(a, b, c) simde_vst1_lane_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_s64(int64_t *ptr, simde_int64x1_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    vst1_lane_s64(ptr, val, 0);
+  #else
+    simde_int64x1_private val_ = simde_int64x1_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_s64
+  #define vst1_lane_s64(a, b, c) simde_vst1_lane_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_u8(uint8_t *ptr, simde_uint8x8_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_NO_RESULT_(vst1_lane_u8, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint8x8_private val_ = simde_uint8x8_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_u8
+  #define vst1_lane_u8(a, b, c) simde_vst1_lane_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_u16(uint16_t *ptr, simde_uint16x4_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_NO_RESULT_(vst1_lane_u16, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint16x4_private val_ = simde_uint16x4_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_u16
+  #define vst1_lane_u16(a, b, c) simde_vst1_lane_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_u32(uint32_t *ptr, simde_uint32x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1_lane_u32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint32x2_private val_ = simde_uint32x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_u32
+  #define vst1_lane_u32(a, b, c) simde_vst1_lane_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1_lane_u64(uint64_t *ptr, simde_uint64x1_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 0) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    (void) lane;
+    vst1_lane_u64(ptr, val, 0);
+  #else
+    simde_uint64x1_private val_ = simde_uint64x1_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1_lane_u64
+  #define vst1_lane_u64(a, b, c) simde_vst1_lane_u64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_f32(simde_float32_t *ptr, simde_float32x4_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_NO_RESULT_(vst1q_lane_f32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_float32x4_private val_ = simde_float32x4_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_f32
+  #define vst1q_lane_f32(a, b, c) simde_vst1q_lane_f32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_f64(simde_float64_t *ptr, simde_float64x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1q_lane_f64, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_float64x2_private val_ = simde_float64x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_f64
+  #define vst1q_lane_f64(a, b, c) simde_vst1q_lane_f64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_s8(int8_t *ptr, simde_int8x16_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_NO_RESULT_(vst1q_lane_s8, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int8x16_private val_ = simde_int8x16_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_s8
+  #define vst1q_lane_s8(a, b, c) simde_vst1q_lane_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_s16(int16_t *ptr, simde_int16x8_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_NO_RESULT_(vst1q_lane_s16, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int16x8_private val_ = simde_int16x8_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_s16
+  #define vst1q_lane_s16(a, b, c) simde_vst1q_lane_s16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_s32(int32_t *ptr, simde_int32x4_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_NO_RESULT_(vst1q_lane_s32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int32x4_private val_ = simde_int32x4_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_s32
+  #define vst1q_lane_s32(a, b, c) simde_vst1q_lane_s32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_s64(int64_t *ptr, simde_int64x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1q_lane_s64, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_int64x2_private val_ = simde_int64x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_s64
+  #define vst1q_lane_s64(a, b, c) simde_vst1q_lane_s64((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_u8(uint8_t *ptr, simde_uint8x16_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 15) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_16_NO_RESULT_(vst1q_lane_u8, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint8x16_private val_ = simde_uint8x16_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_u8
+  #define vst1q_lane_u8(a, b, c) simde_vst1q_lane_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_u16(uint16_t *ptr, simde_uint16x8_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 7) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_8_NO_RESULT_(vst1q_lane_u16, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint16x8_private val_ = simde_uint16x8_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_u16
+  #define vst1q_lane_u16(a, b, c) simde_vst1q_lane_u16((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_u32(uint32_t *ptr, simde_uint32x4_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 3) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_4_NO_RESULT_(vst1q_lane_u32, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint32x4_private val_ = simde_uint32x4_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_u32
+  #define vst1q_lane_u32(a, b, c) simde_vst1q_lane_u32((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst1q_lane_u64(uint64_t *ptr, simde_uint64x2_t val, const int lane)
+    SIMDE_REQUIRE_CONSTANT_RANGE(lane, 0, 1) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_CONSTIFY_2_NO_RESULT_(vst1q_lane_u64, HEDLEY_UNREACHABLE(), lane, ptr, val);
+  #else
+    simde_uint64x2_private val_ = simde_uint64x2_to_private(val);
+    *ptr = val_.values[lane];
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst1q_lane_u64
+  #define vst1q_lane_u64(a, b, c) simde_vst1q_lane_u64((a), (b), (c))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ST1_LANE_H) */
+

--- a/2.0/simde/arm/neon/st3.h
+++ b/2.0/simde/arm/neon/st3.h
@@ -1,0 +1,426 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ST3_H)
+#define SIMDE_ARM_NEON_ST3_H
+
+#include "types.h"
+#include "st1.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_f32(simde_float32_t *ptr, simde_float32x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_f32(ptr, val);
+  #else
+    simde_float32_t buf[6];
+    simde_float32x2_private a_[3] = { simde_float32x2_to_private(val.val[0]), simde_float32x2_to_private(val.val[1]), simde_float32x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_f32
+  #define vst3_f32(a, b) simde_vst3_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_f64(simde_float64_t *ptr, simde_float64x1x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst3_f64(ptr, val);
+  #else
+    simde_float64_t buf[3];
+    simde_float64x1_private a_[3] = { simde_float64x1_to_private(val.val[0]), simde_float64x1_to_private(val.val[1]), simde_float64x1_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3_f64
+  #define vst3_f64(a, b) simde_vst3_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_s8(int8_t *ptr, simde_int8x8x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_s8(ptr, val);
+  #else
+    int8_t buf[24];
+    simde_int8x8_private a_[3] = { simde_int8x8_to_private(val.val[0]), simde_int8x8_to_private(val.val[1]), simde_int8x8_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_s8
+  #define vst3_s8(a, b) simde_vst3_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_s16(int16_t *ptr, simde_int16x4x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_s16(ptr, val);
+  #else
+    int16_t buf[12];
+    simde_int16x4_private a_[3] = { simde_int16x4_to_private(val.val[0]), simde_int16x4_to_private(val.val[1]), simde_int16x4_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_s16
+  #define vst3_s16(a, b) simde_vst3_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_s32(int32_t *ptr, simde_int32x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_s32(ptr, val);
+  #else
+    int32_t buf[6];
+    simde_int32x2_private a_[3] = { simde_int32x2_to_private(val.val[0]), simde_int32x2_to_private(val.val[1]), simde_int32x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_s32
+  #define vst3_s32(a, b) simde_vst3_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_s64(int64_t *ptr, simde_int64x1x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_s64(ptr, val);
+  #else
+    int64_t buf[3];
+    simde_int64x1_private a_[3] = { simde_int64x1_to_private(val.val[0]), simde_int64x1_to_private(val.val[1]), simde_int64x1_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3_s64
+  #define vst3_s64(a, b) simde_vst3_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_u8(uint8_t *ptr, simde_uint8x8x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_u8(ptr, val);
+  #else
+    uint8_t buf[24];
+    simde_uint8x8_private a_[3] = { simde_uint8x8_to_private(val.val[0]), simde_uint8x8_to_private(val.val[1]), simde_uint8x8_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_u8
+  #define vst3_u8(a, b) simde_vst3_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_u16(uint16_t *ptr, simde_uint16x4x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_u16(ptr, val);
+  #else
+    uint16_t buf[12];
+    simde_uint16x4_private a_[3] = { simde_uint16x4_to_private(val.val[0]), simde_uint16x4_to_private(val.val[1]), simde_uint16x4_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_u16
+  #define vst3_u16(a, b) simde_vst3_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_u32(uint32_t *ptr, simde_uint32x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_u32(ptr, val);
+  #else
+    uint32_t buf[6];
+    simde_uint32x2_private a_[3] = { simde_uint32x2_to_private(val.val[0]), simde_uint32x2_to_private(val.val[1]), simde_uint32x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3_u32
+  #define vst3_u32(a, b) simde_vst3_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3_u64(uint64_t *ptr, simde_uint64x1x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3_u64(ptr, val);
+  #else
+    uint64_t buf[3];
+    simde_uint64x1_private a_[3] = { simde_uint64x1_to_private(val.val[0]), simde_uint64x1_to_private(val.val[1]), simde_uint64x1_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3_u64
+  #define vst3_u64(a, b) simde_vst3_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_f32(simde_float32_t *ptr, simde_float32x4x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_f32(ptr, val);
+  #else
+    simde_float32_t buf[12];
+    simde_float32x4_private a_[3] = { simde_float32x4_to_private(val.val[0]), simde_float32x4_to_private(val.val[1]), simde_float32x4_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_f32
+  #define vst3q_f32(a, b) simde_vst3q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_f64(simde_float64_t *ptr, simde_float64x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst3q_f64(ptr, val);
+  #else
+    simde_float64_t buf[6];
+    simde_float64x2_private a_[3] = { simde_float64x2_to_private(val.val[0]), simde_float64x2_to_private(val.val[1]), simde_float64x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_f64
+  #define vst3q_f64(a, b) simde_vst3q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_s8(int8_t *ptr, simde_int8x16x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_s8(ptr, val);
+  #else
+    int8_t buf[48];
+    simde_int8x16_private a_[3] = { simde_int8x16_to_private(val.val[0]), simde_int8x16_to_private(val.val[1]), simde_int8x16_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_s8
+  #define vst3q_s8(a, b) simde_vst3q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_s16(int16_t *ptr, simde_int16x8x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_s16(ptr, val);
+  #else
+    int16_t buf[24];
+    simde_int16x8_private a_[3] = { simde_int16x8_to_private(val.val[0]), simde_int16x8_to_private(val.val[1]), simde_int16x8_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_s16
+  #define vst3q_s16(a, b) simde_vst3q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_s32(int32_t *ptr, simde_int32x4x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_s32(ptr, val);
+  #else
+    int32_t buf[12];
+    simde_int32x4_private a_[3] = { simde_int32x4_to_private(val.val[0]), simde_int32x4_to_private(val.val[1]), simde_int32x4_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_s32
+  #define vst3q_s32(a, b) simde_vst3q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_s64(int64_t *ptr, simde_int64x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst3q_s64(ptr, val);
+  #else
+    int64_t buf[6];
+    simde_int64x2_private a_[3] = { simde_int64x2_to_private(val.val[0]), simde_int64x2_to_private(val.val[1]), simde_int64x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_s64
+  #define vst3q_s64(a, b) simde_vst3q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_u8(uint8_t *ptr, simde_uint8x16x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_u8(ptr, val);
+  #else
+    uint8_t buf[48];
+    simde_uint8x16_private a_[3] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]), simde_uint8x16_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_u8
+  #define vst3q_u8(a, b) simde_vst3q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_u16(uint16_t *ptr, simde_uint16x8x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_u16(ptr, val);
+  #else
+    uint16_t buf[24];
+    simde_uint16x8_private a_[3] = { simde_uint16x8_to_private(val.val[0]), simde_uint16x8_to_private(val.val[1]), simde_uint16x8_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_u16
+  #define vst3q_u16(a, b) simde_vst3q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_u32(uint32_t *ptr, simde_uint32x4x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst3q_u32(ptr, val);
+  #else
+    uint32_t buf[12];
+    simde_uint32x4_private a_[3] = { simde_uint32x4_to_private(val.val[0]), simde_uint32x4_to_private(val.val[1]), simde_uint32x4_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_u32
+  #define vst3q_u32(a, b) simde_vst3q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst3q_u64(uint64_t *ptr, simde_uint64x2x3_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst3q_u64(ptr, val);
+  #else
+    uint64_t buf[6];
+    simde_uint64x2_private a_[3] = { simde_uint64x2_to_private(val.val[0]), simde_uint64x2_to_private(val.val[1]), simde_uint64x2_to_private(val.val[2]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 3 ; i++) {
+      buf[i] = a_[i % 3].values[i / 3];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst3q_u64
+  #define vst3q_u64(a, b) simde_vst3q_u64((a), (b))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ST3_H) */

--- a/2.0/simde/arm/neon/st4.h
+++ b/2.0/simde/arm/neon/st4.h
@@ -1,0 +1,445 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_ST4_H)
+#define SIMDE_ARM_NEON_ST4_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_f32(simde_float32_t *ptr, simde_float32x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_f32(ptr, val);
+  #else
+    simde_float32_t buf[8];
+    simde_float32x2_private a_[4] = { simde_float32x2_to_private(val.val[0]), simde_float32x2_to_private(val.val[1]),
+                                      simde_float32x2_to_private(val.val[2]), simde_float32x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_f32
+  #define vst4_f32(a, b) simde_vst4_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_f64(simde_float64_t *ptr, simde_float64x1x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst4_f64(ptr, val);
+  #else
+    simde_float64_t buf[4];
+    simde_float64x1_private a_[4] = { simde_float64x1_to_private(val.val[0]), simde_float64x1_to_private(val.val[1]),
+                                      simde_float64x1_to_private(val.val[2]), simde_float64x1_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4_f64
+  #define vst4_f64(a, b) simde_vst4_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_s8(int8_t *ptr, simde_int8x8x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_s8(ptr, val);
+  #else
+    int8_t buf[32];
+    simde_int8x8_private a_[4] = { simde_int8x8_to_private(val.val[0]), simde_int8x8_to_private(val.val[1]),
+                                   simde_int8x8_to_private(val.val[2]), simde_int8x8_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_s8
+  #define vst4_s8(a, b) simde_vst4_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_s16(int16_t *ptr, simde_int16x4x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_s16(ptr, val);
+  #else
+    int16_t buf[16];
+    simde_int16x4_private a_[4] = { simde_int16x4_to_private(val.val[0]), simde_int16x4_to_private(val.val[1]),
+                                    simde_int16x4_to_private(val.val[2]), simde_int16x4_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_s16
+  #define vst4_s16(a, b) simde_vst4_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_s32(int32_t *ptr, simde_int32x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_s32(ptr, val);
+  #else
+    int32_t buf[8];
+    simde_int32x2_private a_[4] = { simde_int32x2_to_private(val.val[0]), simde_int32x2_to_private(val.val[1]),
+                                    simde_int32x2_to_private(val.val[2]), simde_int32x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_s32
+  #define vst4_s32(a, b) simde_vst4_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_s64(int64_t *ptr, simde_int64x1x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_s64(ptr, val);
+  #else
+    int64_t buf[4];
+    simde_int64x1_private a_[4] = { simde_int64x1_to_private(val.val[0]), simde_int64x1_to_private(val.val[1]),
+                                    simde_int64x1_to_private(val.val[2]), simde_int64x1_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4_s64
+  #define vst4_s64(a, b) simde_vst4_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_u8(uint8_t *ptr, simde_uint8x8x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_u8(ptr, val);
+  #else
+    uint8_t buf[32];
+    simde_uint8x8_private a_[4] = { simde_uint8x8_to_private(val.val[0]), simde_uint8x8_to_private(val.val[1]),
+                                    simde_uint8x8_to_private(val.val[2]), simde_uint8x8_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_u8
+  #define vst4_u8(a, b) simde_vst4_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_u16(uint16_t *ptr, simde_uint16x4x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_u16(ptr, val);
+  #else
+    uint16_t buf[16];
+    simde_uint16x4_private a_[4] = { simde_uint16x4_to_private(val.val[0]), simde_uint16x4_to_private(val.val[1]),
+                                     simde_uint16x4_to_private(val.val[2]), simde_uint16x4_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_u16
+  #define vst4_u16(a, b) simde_vst4_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_u32(uint32_t *ptr, simde_uint32x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_u32(ptr, val);
+  #else
+    uint32_t buf[8];
+    simde_uint32x2_private a_[4] = { simde_uint32x2_to_private(val.val[0]), simde_uint32x2_to_private(val.val[1]),
+                                     simde_uint32x2_to_private(val.val[2]), simde_uint32x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4_u32
+  #define vst4_u32(a, b) simde_vst4_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4_u64(uint64_t *ptr, simde_uint64x1x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4_u64(ptr, val);
+  #else
+    uint64_t buf[4];
+    simde_uint64x1_private a_[4] = { simde_uint64x1_to_private(val.val[0]), simde_uint64x1_to_private(val.val[1]),
+                                     simde_uint64x1_to_private(val.val[2]), simde_uint64x1_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4_u64
+  #define vst4_u64(a, b) simde_vst4_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_f32(simde_float32_t *ptr, simde_float32x4x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_f32(ptr, val);
+  #else
+    simde_float32_t buf[16];
+    simde_float32x4_private a_[4] = { simde_float32x4_to_private(val.val[0]), simde_float32x4_to_private(val.val[1]),
+                                      simde_float32x4_to_private(val.val[2]), simde_float32x4_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_f32
+  #define vst4q_f32(a, b) simde_vst4q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_f64(simde_float64_t *ptr, simde_float64x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst4q_f64(ptr, val);
+  #else
+    simde_float64_t buf[8];
+    simde_float64x2_private a_[4] = { simde_float64x2_to_private(val.val[0]), simde_float64x2_to_private(val.val[1]),
+                                      simde_float64x2_to_private(val.val[2]), simde_float64x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_f64
+  #define vst4q_f64(a, b) simde_vst4q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_s8(int8_t *ptr, simde_int8x16x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_s8(ptr, val);
+  #else
+    int8_t buf[64];
+    simde_int8x16_private a_[4] = { simde_int8x16_to_private(val.val[0]), simde_int8x16_to_private(val.val[1]),
+                                    simde_int8x16_to_private(val.val[2]), simde_int8x16_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_s8
+  #define vst4q_s8(a, b) simde_vst4q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_s16(int16_t *ptr, simde_int16x8x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_s16(ptr, val);
+  #else
+    int16_t buf[32];
+    simde_int16x8_private a_[4] = { simde_int16x8_to_private(val.val[0]), simde_int16x8_to_private(val.val[1]),
+                                    simde_int16x8_to_private(val.val[2]), simde_int16x8_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_s16
+  #define vst4q_s16(a, b) simde_vst4q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_s32(int32_t *ptr, simde_int32x4x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_s32(ptr, val);
+  #else
+    int32_t buf[16];
+    simde_int32x4_private a_[4] = { simde_int32x4_to_private(val.val[0]), simde_int32x4_to_private(val.val[1]),
+                                    simde_int32x4_to_private(val.val[2]), simde_int32x4_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_s32
+  #define vst4q_s32(a, b) simde_vst4q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_s64(int64_t *ptr, simde_int64x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst4q_s64(ptr, val);
+  #else
+    int64_t buf[8];
+    simde_int64x2_private a_[4] = { simde_int64x2_to_private(val.val[0]), simde_int64x2_to_private(val.val[1]),
+                                    simde_int64x2_to_private(val.val[2]), simde_int64x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_s64
+  #define vst4q_s64(a, b) simde_vst4q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_u8(uint8_t *ptr, simde_uint8x16x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_u8(ptr, val);
+  #else
+    uint8_t buf[64];
+    simde_uint8x16_private a_[4] = { simde_uint8x16_to_private(val.val[0]), simde_uint8x16_to_private(val.val[1]),
+                                     simde_uint8x16_to_private(val.val[2]), simde_uint8x16_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_u8
+  #define vst4q_u8(a, b) simde_vst4q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_u16(uint16_t *ptr, simde_uint16x8x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_u16(ptr, val);
+  #else
+    uint16_t buf[32];
+    simde_uint16x8_private a_[4] = { simde_uint16x8_to_private(val.val[0]), simde_uint16x8_to_private(val.val[1]),
+                                     simde_uint16x8_to_private(val.val[2]), simde_uint16x8_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_u16
+  #define vst4q_u16(a, b) simde_vst4q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_u32(uint32_t *ptr, simde_uint32x4x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst4q_u32(ptr, val);
+  #else
+    uint32_t buf[16];
+    simde_uint32x4_private a_[4] = { simde_uint32x4_to_private(val.val[0]), simde_uint32x4_to_private(val.val[1]),
+                                     simde_uint32x4_to_private(val.val[2]), simde_uint32x4_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_u32
+  #define vst4q_u32(a, b) simde_vst4q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_vst4q_u64(uint64_t *ptr, simde_uint64x2x4_t val) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst4q_u64(ptr, val);
+  #else
+    uint64_t buf[8];
+    simde_uint64x2_private a_[4] = { simde_uint64x2_to_private(val.val[0]), simde_uint64x2_to_private(val.val[1]),
+                                     simde_uint64x2_to_private(val.val[2]), simde_uint64x2_to_private(val.val[3]) };
+    for (size_t i = 0; i < (sizeof(val.val[0]) / sizeof(*ptr)) * 4 ; i++) {
+      buf[i] = a_[i % 4].values[i / 4];
+    }
+    simde_memcpy(ptr, buf, sizeof(buf));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vst4q_u64
+  #define vst4q_u64(a, b) simde_vst4q_u64((a), (b))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ST4_H) */

--- a/2.0/simde/arm/neon/sub.h
+++ b/2.0/simde/arm/neon/sub.h
@@ -1,0 +1,659 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_SUB_H)
+#define SIMDE_ARM_NEON_SUB_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vsub_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_f32
+  #define vsub_f32(a, b) simde_vsub_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x1_t
+simde_vsub_f64(simde_float64x1_t a, simde_float64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vsub_f64(a, b);
+  #else
+    simde_float64x1_private
+      r_,
+      a_ = simde_float64x1_to_private(a),
+      b_ = simde_float64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_float64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vsub_f64
+  #define vsub_f64(a, b) simde_vsub_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vsub_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_s8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_s8
+  #define vsub_s8(a, b) simde_vsub_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vsub_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_s16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_s16
+  #define vsub_s16(a, b) simde_vsub_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vsub_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_s32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_s32
+  #define vsub_s32(a, b) simde_vsub_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x1_t
+simde_vsub_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_s64(a, b);
+  #else
+    simde_int64x1_private
+      r_,
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_s64
+  #define vsub_s64(a, b) simde_vsub_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vsub_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_u8(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_u8
+  #define vsub_u8(a, b) simde_vsub_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vsub_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_u16(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_u16
+  #define vsub_u16(a, b) simde_vsub_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vsub_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_u32(a, b);
+  #elif defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_u32
+  #define vsub_u32(a, b) simde_vsub_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vsub_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsub_u64(a, b);
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsub_u64
+  #define vsub_u64(a, b) simde_vsub_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vsubq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_f32(a, b);
+  #elif defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sub_ps(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(float) a_ , b_, r_;
+    a_ = a;
+    b_ = b;
+    r_ = vec_sub(a_, b_);
+    return r_;
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f32x4_sub(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_f32
+  #define vsubq_f32(a, b) simde_vsubq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vsubq_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vsubq_f64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_pd(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    return vec_sub(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_f64x2_sub(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_f64
+  #define vsubq_f64(a, b) simde_vsubq_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vsubq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_s8(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_sub(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_s8
+  #define vsubq_s8(a, b) simde_vsubq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vsubq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_s16(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_sub(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_s16
+  #define vsubq_s16(a, b) simde_vsubq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vsubq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_s32(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_sub(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_s32
+  #define vsubq_s32(a, b) simde_vsubq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vsubq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_s64(a, b);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_sub(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_sub(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_s64
+  #define vsubq_s64(a, b) simde_vsubq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vsubq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_u8(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_u8
+  #define vsubq_u8(a, b) simde_vsubq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vsubq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_u16(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_u16
+  #define vsubq_u16(a, b) simde_vsubq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vsubq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_u32(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_sub(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_u32
+  #define vsubq_u32(a, b) simde_vsubq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vsubq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubq_u64(a, b);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return vec_sub(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.values = a_.values - b_.values;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = a_.values[i] - b_.values[i];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubq_u64
+  #define vsubq_u64(a, b) simde_vsubq_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SUB_H) */

--- a/2.0/simde/arm/neon/subl.h
+++ b/2.0/simde/arm/neon/subl.h
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_SUBL_H)
+#define SIMDE_ARM_NEON_SUBL_H
+
+#include "sub.h"
+#include "movl.h"
+#include "movl_high.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vsubl_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_s8(a, b);
+  #else
+    return simde_vsubq_s16(simde_vmovl_s8(a), simde_vmovl_s8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_s8
+  #define vsubl_s8(a, b) simde_vsubl_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vsubl_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_s16(a, b);
+  #else
+    return simde_vsubq_s32(simde_vmovl_s16(a), simde_vmovl_s16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_s16
+  #define vsubl_s16(a, b) simde_vsubl_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vsubl_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_s32(a, b);
+  #else
+    return simde_vsubq_s64(simde_vmovl_s32(a), simde_vmovl_s32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_s32
+  #define vsubl_s32(a, b) simde_vsubl_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vsubl_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_u8(a, b);
+  #else
+    return simde_vsubq_u16(simde_vmovl_u8(a), simde_vmovl_u8(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_u8
+  #define vsubl_u8(a, b) simde_vsubl_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vsubl_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_u16(a, b);
+  #else
+    return simde_vsubq_u32(simde_vmovl_u16(a), simde_vmovl_u16(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_u16
+  #define vsubl_u16(a, b) simde_vsubl_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vsubl_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsubl_u32(a, b);
+  #else
+    return simde_vsubq_u64(simde_vmovl_u32(a), simde_vmovl_u32(b));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vsubl_u32
+  #define vsubl_u32(a, b) simde_vsubl_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_SUBL_H) */

--- a/2.0/simde/arm/neon/tbl.h
+++ b/2.0/simde/arm/neon/tbl.h
@@ -1,0 +1,224 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_TBL_H)
+#define SIMDE_ARM_NEON_TBL_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbl1_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl1_u8(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi8(a, _mm_or_si64(b, _mm_cmpgt_pi8(b, _mm_set1_pi8(7))));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (b_.values[i] < 8) ? a_.values[b_.values[i]] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl1_u8
+  #define vtbl1_u8(a, b) simde_vtbl1_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbl1_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl1_s8(a, b);
+  #else
+    return simde_vreinterpret_s8_u8(simde_vtbl1_u8(simde_vreinterpret_u8_s8(a), simde_vreinterpret_u8_s8(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl1_s8
+  #define vtbl1_s8(a, b) simde_vtbl1_s8((a), (b))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbl2_u8(simde_uint8x8x2_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl2_u8(a, b);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_set_epi64(a.val[1], a.val[0]);
+    __m128i b128 = _mm_set1_epi64(b);
+    __m128i r128 = _mm_shuffle_epi8(a128, _mm_or_si128(b128, _mm_cmpgt_epi8(b128, _mm_set1_epi8(15))));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_[2] = { simde_uint8x8_to_private(a.val[0]), simde_uint8x8_to_private(a.val[1]) },
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (b_.values[i] < 16) ? a_[b_.values[i] / 8].values[b_.values[i] & 7] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl2_u8
+  #define vtbl2_u8(a, b) simde_vtbl2_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbl2_s8(simde_int8x8x2_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl2_s8(a, b);
+  #else
+    simde_uint8x8x2_t a_;
+    simde_memcpy(&a_, &a, sizeof(a_));
+    return simde_vreinterpret_s8_u8(simde_vtbl2_u8(a_, simde_vreinterpret_u8_s8(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl2_s8
+  #define vtbl2_s8(a, b) simde_vtbl2_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbl3_u8(simde_uint8x8x3_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl3_u8(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i b128 = _mm_set1_epi64(b);
+    b128 = _mm_or_si128(b128, _mm_cmpgt_epi8(b128, _mm_set1_epi8(23)));
+    __m128i r128_01 = _mm_shuffle_epi8(_mm_set_epi64(a.val[1], a.val[0]), b128);
+    __m128i r128_2  = _mm_shuffle_epi8(_mm_set1_epi64(a.val[2]), b128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_2, _mm_slli_epi32(b128, 3));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_[3] = { simde_uint8x8_to_private(a.val[0]), simde_uint8x8_to_private(a.val[1]), simde_uint8x8_to_private(a.val[2]) },
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (b_.values[i] < 24) ? a_[b_.values[i] / 8].values[b_.values[i] & 7] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl3_u8
+  #define vtbl3_u8(a, b) simde_vtbl3_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbl3_s8(simde_int8x8x3_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl3_s8(a, b);
+  #else
+    simde_uint8x8x3_t a_;
+    simde_memcpy(&a_, &a, sizeof(a_));
+    return simde_vreinterpret_s8_u8(simde_vtbl3_u8(a_, simde_vreinterpret_u8_s8(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl3_s8
+  #define vtbl3_s8(a, b) simde_vtbl3_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbl4_u8(simde_uint8x8x4_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl4_u8(a, b);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i b128 = _mm_set1_epi64(b);
+    b128 = _mm_or_si128(b128, _mm_cmpgt_epi8(b128, _mm_set1_epi8(31)));
+    __m128i r128_01 = _mm_shuffle_epi8(_mm_set_epi64(a.val[1], a.val[0]), b128);
+    __m128i r128_23 = _mm_shuffle_epi8(_mm_set_epi64(a.val[3], a.val[2]), b128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_23, _mm_slli_epi32(b128, 3));
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_[4] = { simde_uint8x8_to_private(a.val[0]), simde_uint8x8_to_private(a.val[1]), simde_uint8x8_to_private(a.val[2]), simde_uint8x8_to_private(a.val[3]) },
+      b_ = simde_uint8x8_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (b_.values[i] < 32) ? a_[b_.values[i] / 8].values[b_.values[i] & 7] : 0;
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl4_u8
+  #define vtbl4_u8(a, b) simde_vtbl4_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbl4_s8(simde_int8x8x4_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbl4_s8(a, b);
+  #else
+    simde_uint8x8x4_t a_;
+    simde_memcpy(&a_, &a, sizeof(a_));
+    return simde_vreinterpret_s8_u8(simde_vtbl4_u8(a_, simde_vreinterpret_u8_s8(b)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbl4_s8
+  #define vtbl4_s8(a, b) simde_vtbl4_s8((a), (b))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TBL_H) */

--- a/2.0/simde/arm/neon/tbx.h
+++ b/2.0/simde/arm/neon/tbx.h
@@ -1,0 +1,247 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_TBX_H)
+#define SIMDE_ARM_NEON_TBX_H
+
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbx1_u8(simde_uint8x8_t a, simde_uint8x8_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx1_u8(a, b, c);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_set1_epi64(a);
+    __m128i b128 = _mm_set1_epi64(b);
+    __m128i c128 = _mm_set1_epi64(c);
+    c128 = _mm_or_si128(c128, _mm_cmpgt_epi8(c128, _mm_set1_epi8(7)));
+    __m128i r128 = _mm_shuffle_epi8(b128, c128);
+    r128 =  _mm_blendv_epi8(r128, a128, c128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b),
+      c_ = simde_uint8x8_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (c_.values[i] < 8) ? b_.values[c_.values[i]] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx1_u8
+  #define vtbx1_u8(a, b, c) simde_vtbx1_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbx1_s8(simde_int8x8_t a, simde_int8x8_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx1_s8(a, b, c);
+  #else
+    return simde_vreinterpret_s8_u8(simde_vtbx1_u8(simde_vreinterpret_u8_s8(a), simde_vreinterpret_u8_s8(b), simde_vreinterpret_u8_s8(c)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx1_s8
+  #define vtbx1_s8(a, b, c) simde_vtbx1_s8((a), (b), (c))
+#endif
+
+#if !defined(SIMDE_BUG_INTEL_857088)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbx2_u8(simde_uint8x8_t a, simde_uint8x8x2_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx2_u8(a, b, c);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_set1_epi64(a);
+    __m128i b128 = _mm_set_epi64(b.val[1], b.val[0]);
+    __m128i c128 = _mm_set1_epi64(c);
+    c128 = _mm_or_si128(c128, _mm_cmpgt_epi8(c128, _mm_set1_epi8(15)));
+    __m128i r128 = _mm_shuffle_epi8(b128, c128);
+    r128 =  _mm_blendv_epi8(r128, a128, c128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_[2] = { simde_uint8x8_to_private(b.val[0]), simde_uint8x8_to_private(b.val[1]) },
+      c_ = simde_uint8x8_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (c_.values[i] < 16) ? b_[c_.values[i] / 8].values[c_.values[i] & 7] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx2_u8
+  #define vtbx2_u8(a, b, c) simde_vtbx2_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbx2_s8(simde_int8x8_t a, simde_int8x8x2_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx2_s8(a, b, c);
+  #else
+    simde_uint8x8x2_t b_;
+    simde_memcpy(&b_, &b, sizeof(b_));
+    return simde_vreinterpret_s8_u8(simde_vtbx2_u8(simde_vreinterpret_u8_s8(a),
+                                                   b_,
+                                                   simde_vreinterpret_u8_s8(c)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx2_s8
+  #define vtbx2_s8(a, b, c) simde_vtbx2_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbx3_u8(simde_uint8x8_t a, simde_uint8x8x3_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx3_u8(a, b, c);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_set1_epi64(a);
+    __m128i c128 = _mm_set1_epi64(c);
+    c128 = _mm_or_si128(c128, _mm_cmpgt_epi8(c128, _mm_set1_epi8(23)));
+    __m128i r128_01 = _mm_shuffle_epi8(_mm_set_epi64(b.val[1], b.val[0]), c128);
+    __m128i r128_2  = _mm_shuffle_epi8(_mm_set1_epi64(b.val[2]), c128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_2, _mm_slli_epi32(c128, 3));
+    r128 =  _mm_blendv_epi8(r128, a128, c128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_[3] = { simde_uint8x8_to_private(b.val[0]), simde_uint8x8_to_private(b.val[1]), simde_uint8x8_to_private(b.val[2]) },
+      c_ = simde_uint8x8_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (c_.values[i] < 24) ? b_[c_.values[i] / 8].values[c_.values[i] & 7] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx3_u8
+  #define vtbx3_u8(a, b, c) simde_vtbx3_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbx3_s8(simde_int8x8_t a, simde_int8x8x3_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx3_s8(a, b, c);
+  #else
+    simde_uint8x8x3_t b_;
+    simde_memcpy(&b_, &b, sizeof(b_));
+    return simde_vreinterpret_s8_u8(simde_vtbx3_u8(simde_vreinterpret_u8_s8(a),
+                                                   b_,
+                                                   simde_vreinterpret_u8_s8(c)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx3_s8
+  #define vtbx3_s8(a, b, c) simde_vtbx3_s8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtbx4_u8(simde_uint8x8_t a, simde_uint8x8x4_t b, simde_uint8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx4_u8(a, b, c);
+  #elif defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    __m128i a128 = _mm_set1_epi64(a);
+    __m128i c128 = _mm_set1_epi64(c);
+    c128 = _mm_or_si128(c128, _mm_cmpgt_epi8(c128, _mm_set1_epi8(31)));
+    __m128i r128_01 = _mm_shuffle_epi8(_mm_set_epi64(b.val[1], b.val[0]), c128);
+    __m128i r128_23 = _mm_shuffle_epi8(_mm_set_epi64(b.val[3], b.val[2]), c128);
+    __m128i r128 = _mm_blendv_epi8(r128_01, r128_23,  _mm_slli_epi32(c128, 3));
+    r128 =  _mm_blendv_epi8(r128, a128, c128);
+    return _mm_movepi64_pi64(r128);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_[4] = { simde_uint8x8_to_private(b.val[0]), simde_uint8x8_to_private(b.val[1]), simde_uint8x8_to_private(b.val[2]), simde_uint8x8_to_private(b.val[3]) },
+      c_ = simde_uint8x8_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+      r_.values[i] = (c_.values[i] < 32) ? b_[c_.values[i] / 8].values[c_.values[i] & 7] : a_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx4_u8
+  #define vtbx4_u8(a, b, c) simde_vtbx4_u8((a), (b), (c))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtbx4_s8(simde_int8x8_t a, simde_int8x8x4_t b, simde_int8x8_t c) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtbx4_s8(a, b, c);
+  #else
+    simde_uint8x8x4_t b_;
+    simde_memcpy(&b_, &b, sizeof(b_));
+    return simde_vreinterpret_s8_u8(simde_vtbx4_u8(simde_vreinterpret_u8_s8(a),
+                                                   b_,
+                                                   simde_vreinterpret_u8_s8(c)));
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtbx4_s8
+  #define vtbx4_s8(a, b, c) simde_vtbx4_s8((a), (b), (c))
+#endif
+
+#endif /* !defined(SIMDE_BUG_INTEL_857088) */
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TBX_H) */

--- a/2.0/simde/arm/neon/trn.h
+++ b/2.0/simde/arm/neon/trn.h
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_TRN_H) && !defined(SIMDE_BUG_INTEL_857088)
+#define SIMDE_ARM_NEON_TRN_H
+
+#include "types.h"
+#include "trn1.h"
+#include "trn2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2x2_t
+simde_vtrn_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_f32(a, b);
+  #else
+    simde_float32x2x2_t r = { { simde_vtrn1_f32(a, b), simde_vtrn2_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_f32
+  #define vtrn_f32(a, b) simde_vtrn_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8x2_t
+simde_vtrn_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_s8(a, b);
+  #else
+    simde_int8x8x2_t r = { { simde_vtrn1_s8(a, b), simde_vtrn2_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_s8
+  #define vtrn_s8(a, b) simde_vtrn_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4x2_t
+simde_vtrn_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_s16(a, b);
+  #else
+    simde_int16x4x2_t r = { { simde_vtrn1_s16(a, b), simde_vtrn2_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_s16
+  #define vtrn_s16(a, b) simde_vtrn_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2x2_t
+simde_vtrn_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_s32(a, b);
+  #else
+    simde_int32x2x2_t r = { { simde_vtrn1_s32(a, b), simde_vtrn2_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_s32
+  #define vtrn_s32(a, b) simde_vtrn_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8x2_t
+simde_vtrn_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_u8(a, b);
+  #else
+    simde_uint8x8x2_t r = { { simde_vtrn1_u8(a, b), simde_vtrn2_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_u8
+  #define vtrn_u8(a, b) simde_vtrn_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4x2_t
+simde_vtrn_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_u16(a, b);
+  #else
+    simde_uint16x4x2_t r = { { simde_vtrn1_u16(a, b), simde_vtrn2_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_u16
+  #define vtrn_u16(a, b) simde_vtrn_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2x2_t
+simde_vtrn_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrn_u32(a, b);
+  #else
+    simde_uint32x2x2_t r = { { simde_vtrn1_u32(a, b), simde_vtrn2_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrn_u32
+  #define vtrn_u32(a, b) simde_vtrn_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4x2_t
+simde_vtrnq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_f32(a, b);
+  #else
+    simde_float32x4x2_t r = { { simde_vtrn1q_f32(a, b), simde_vtrn2q_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_f32
+  #define vtrnq_f32(a, b) simde_vtrnq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16x2_t
+simde_vtrnq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_s8(a, b);
+  #else
+    simde_int8x16x2_t r = { { simde_vtrn1q_s8(a, b), simde_vtrn2q_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_s8
+  #define vtrnq_s8(a, b) simde_vtrnq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8x2_t
+simde_vtrnq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_s16(a, b);
+  #else
+    simde_int16x8x2_t r = { { simde_vtrn1q_s16(a, b), simde_vtrn2q_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_s16
+  #define vtrnq_s16(a, b) simde_vtrnq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4x2_t
+simde_vtrnq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_s32(a, b);
+  #else
+    simde_int32x4x2_t r = { { simde_vtrn1q_s32(a, b), simde_vtrn2q_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_s32
+  #define vtrnq_s32(a, b) simde_vtrnq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16x2_t
+simde_vtrnq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_u8(a, b);
+  #else
+    simde_uint8x16x2_t r = { { simde_vtrn1q_u8(a, b), simde_vtrn2q_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_u8
+  #define vtrnq_u8(a, b) simde_vtrnq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8x2_t
+simde_vtrnq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_u16(a, b);
+  #else
+    simde_uint16x8x2_t r = { { simde_vtrn1q_u16(a, b), simde_vtrn2q_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_u16
+  #define vtrnq_u16(a, b) simde_vtrnq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4x2_t
+simde_vtrnq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtrnq_u32(a, b);
+  #else
+    simde_uint32x4x2_t r = { { simde_vtrn1q_u32(a, b), simde_vtrn2q_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtrnq_u32
+  #define vtrnq_u32(a, b) simde_vtrnq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TRN_H) */

--- a/2.0/simde/arm/neon/trn1.h
+++ b/2.0/simde/arm/neon/trn1.h
@@ -1,0 +1,500 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_TRN1_H)
+#define SIMDE_ARM_NEON_TRN1_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vtrn1_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_f32
+  #define vtrn1_f32(a, b) simde_vtrn1_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtrn1_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_s8
+  #define vtrn1_s8(a, b) simde_vtrn1_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vtrn1_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_s16
+  #define vtrn1_s16(a, b) simde_vtrn1_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vtrn1_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_s32
+  #define vtrn1_s32(a, b) simde_vtrn1_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtrn1_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_u8
+  #define vtrn1_u8(a, b) simde_vtrn1_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vtrn1_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_u16
+  #define vtrn1_u16(a, b) simde_vtrn1_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vtrn1_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1_u32
+  #define vtrn1_u32(a, b) simde_vtrn1_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vtrn1q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_f32(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_f32
+  #define vtrn1q_f32(a, b) simde_vtrn1q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vtrn1q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_f64(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_f64
+  #define vtrn1q_f64(a, b) simde_vtrn1q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vtrn1q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_s8
+  #define vtrn1q_s8(a, b) simde_vtrn1q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vtrn1q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_s16
+  #define vtrn1q_s16(a, b) simde_vtrn1q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vtrn1q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_s32
+  #define vtrn1q_s32(a, b) simde_vtrn1q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vtrn1q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_s64(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_s64
+  #define vtrn1q_s64(a, b) simde_vtrn1q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vtrn1q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_u8(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_u8
+  #define vtrn1q_u8(a, b) simde_vtrn1q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vtrn1q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_u16(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_u16
+  #define vtrn1q_u16(a, b) simde_vtrn1q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vtrn1q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_u32(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_u32
+  #define vtrn1q_u32(a, b) simde_vtrn1q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vtrn1q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn1q_u64(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx];
+      r_.values[idx | 1] = b_.values[idx];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn1q_u64
+  #define vtrn1q_u64(a, b) simde_vtrn1q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TRN1_H) */

--- a/2.0/simde/arm/neon/trn2.h
+++ b/2.0/simde/arm/neon/trn2.h
@@ -1,0 +1,499 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_TRN2_H)
+#define SIMDE_ARM_NEON_TRN2_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vtrn2_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_f32
+  #define vtrn2_f32(a, b) simde_vtrn2_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vtrn2_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_s8
+  #define vtrn2_s8(a, b) simde_vtrn2_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vtrn2_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_s16
+  #define vtrn2_s16(a, b) simde_vtrn2_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vtrn2_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_s32
+  #define vtrn2_s32(a, b) simde_vtrn2_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtrn2_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_u8
+  #define vtrn2_u8(a, b) simde_vtrn2_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vtrn2_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_u16
+  #define vtrn2_u16(a, b) simde_vtrn2_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vtrn2_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2_u32
+  #define vtrn2_u32(a, b) simde_vtrn2_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vtrn2q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_f32(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_f32
+  #define vtrn2q_f32(a, b) simde_vtrn2q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vtrn2q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_f64(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_f64
+  #define vtrn2q_f64(a, b) simde_vtrn2q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vtrn2q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_s8
+  #define vtrn2q_s8(a, b) simde_vtrn2q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vtrn2q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_s16
+  #define vtrn2q_s16(a, b) simde_vtrn2q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vtrn2q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_s32
+  #define vtrn2q_s32(a, b) simde_vtrn2q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vtrn2q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_s64(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_s64
+  #define vtrn2q_s64(a, b) simde_vtrn2q_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vtrn2q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_u8(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_u8
+  #define vtrn2q_u8(a, b) simde_vtrn2q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vtrn2q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_u16(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_u16
+  #define vtrn2q_u16(a, b) simde_vtrn2q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vtrn2q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_u32(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_u32
+  #define vtrn2q_u32(a, b) simde_vtrn2q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vtrn2q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtrn2q_u64(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      const size_t idx = i << 1;
+      r_.values[idx] = a_.values[idx | 1];
+      r_.values[idx | 1] = b_.values[idx | 1];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtrn2q_u64
+  #define vtrn2q_u64(a, b) simde_vtrn2q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TRN2_H) */

--- a/2.0/simde/arm/neon/tst.h
+++ b/2.0/simde/arm/neon/tst.h
@@ -1,0 +1,540 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_ARM_NEON_TST_H)
+#define SIMDE_ARM_NEON_TST_H
+
+#include "and.h"
+#include "ceqz.h"
+#include "cgt.h"
+#include "combine.h"
+#include "dup_n.h"
+#include "get_low.h"
+#include "mvn.h"
+#include "reinterpret.h"
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vtstq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_s8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_ne(wasm_v128_and(a, b), wasm_i8x16_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u8(simde_vceqzq_s8(simde_vandq_s8(a, b)));
+  #else
+    simde_int8x16_private
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+    simde_uint8x16_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_s8
+  #define vtstq_s8(a, b) simde_vtstq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vtstq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_s16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_ne(wasm_v128_and(a, b), wasm_i16x8_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u16(simde_vceqzq_s16(simde_vandq_s16(a, b)));
+  #else
+    simde_int16x8_private
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+    simde_uint16x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_s16
+  #define vtstq_s16(a, b) simde_vtstq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vtstq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_s32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_ne(wasm_v128_and(a, b), wasm_i32x4_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u32(simde_vceqzq_s32(simde_vandq_s32(a, b)));
+  #else
+    simde_int32x4_private
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+    simde_uint32x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_s32
+  #define vtstq_s32(a, b) simde_vtstq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vtstq_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtstq_s64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vceqzq_u64(simde_vceqzq_s64(simde_vandq_s64(a, b)));
+  #else
+    simde_int64x2_private
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+    simde_uint64x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_s64
+  #define vtstq_s64(a, b) simde_vtstq_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vtstq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_u8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i8x16_ne(wasm_v128_and(a, b), wasm_i8x16_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u8(simde_vceqzq_u8(simde_vandq_u8(a, b)));
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_u8
+  #define vtstq_u8(a, b) simde_vtstq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vtstq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i16x8_ne(wasm_v128_and(a, b), wasm_i16x8_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u16(simde_vceqzq_u16(simde_vandq_u16(a, b)));
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_u16
+  #define vtstq_u16(a, b) simde_vtstq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vtstq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtstq_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i32x4_ne(wasm_v128_and(a, b), wasm_i32x4_splat(0));
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvnq_u32(simde_vceqzq_u32(simde_vandq_u32(a, b)));
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_u32
+  #define vtstq_u32(a, b) simde_vtstq_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vtstq_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtstq_u64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vceqzq_u64(simde_vceqzq_u64(simde_vandq_u64(a, b)));
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtstq_u64
+  #define vtstq_u64(a, b) simde_vtstq_u64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtst_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_s8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u8(simde_vceqz_s8(simde_vand_s8(a, b)));
+  #else
+    simde_int8x8_private
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+    simde_uint8x8_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_s8
+  #define vtst_s8(a, b) simde_vtst_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vtst_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_s16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u16(simde_vceqz_s16(simde_vand_s16(a, b)));
+  #else
+    simde_int16x4_private
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+    simde_uint16x4_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_s16
+  #define vtst_s16(a, b) simde_vtst_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vtst_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_s32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u32(simde_vceqz_s32(simde_vand_s32(a, b)));
+  #else
+    simde_int32x2_private
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+    simde_uint32x2_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_s32
+  #define vtst_s32(a, b) simde_vtst_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vtst_s64(simde_int64x1_t a, simde_int64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtst_s64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vceqz_u64(simde_vceqz_s64(simde_vand_s64(a, b)));
+  #else
+    simde_int64x1_private
+      a_ = simde_int64x1_to_private(a),
+      b_ = simde_int64x1_to_private(b);
+    simde_uint64x1_private r_;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtst_s64
+  #define vtst_s64(a, b) simde_vtst_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vtst_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_u8(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u8(simde_vceqz_u8(simde_vand_u8(a, b)));
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT8_MAX : 0;
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_u8
+  #define vtst_u8(a, b) simde_vtst_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vtst_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_u16(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u16(simde_vceqz_u16(simde_vand_u16(a, b)));
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT16_MAX : 0;
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_u16
+  #define vtst_u16(a, b) simde_vtst_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vtst_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vtst_u32(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vmvn_u32(simde_vceqz_u32(simde_vand_u32(a, b)));
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT32_MAX : 0;
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vtst_u32
+  #define vtst_u32(a, b) simde_vtst_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x1_t
+simde_vtst_u64(simde_uint64x1_t a, simde_uint64x1_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vtst_u64(a, b);
+  #elif SIMDE_NATURAL_VECTOR_SIZE > 0
+    return simde_vceqz_u64(simde_vceqz_u64(simde_vand_u64(a, b)));
+  #else
+    simde_uint64x1_private
+      r_,
+      a_ = simde_uint64x1_to_private(a),
+      b_ = simde_uint64x1_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.values = HEDLEY_REINTERPRET_CAST(__typeof__(r_.values), (a_.values & b_.values) != 0);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.values) / sizeof(r_.values[0])) ; i++) {
+        r_.values[i] = ((a_.values[i] & b_.values[i]) != 0) ? UINT64_MAX : 0;
+      }
+    #endif
+
+    return simde_uint64x1_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vtst_u64
+  #define vtst_u64(a, b) simde_vtst_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_TST_H) */

--- a/2.0/simde/arm/neon/types.h
+++ b/2.0/simde/arm/neon/types.h
@@ -1,0 +1,683 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_ARM_NEON_TYPES_H)
+#define SIMDE_ARM_NEON_TYPES_H
+
+#include "../../simde-common.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT)
+  #define SIMDE_ARM_NEON_TYPE_INT_DEFINE_(Element_Type_Name, Element_Count, Alignment) \
+    typedef struct simde_##Element_Type_Name##x##Element_Count##_private { \
+      SIMDE_ALIGN(Alignment) Element_Type_Name##_t values SIMDE_VECTOR(sizeof(Element_Type_Name##_t) * Element_Count); \
+    } simde_##Element_Type_Name##x##Element_Count##_private;
+  #define SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(Element_Size, Element_Count, Alignment) \
+    typedef struct simde_float##Element_Size##x##Element_Count##_private { \
+      SIMDE_ALIGN(Alignment) simde_float##Element_Size values SIMDE_VECTOR(sizeof(simde_float##Element_Size) * Element_Count); \
+    } simde_float##Element_Size##x##Element_Count##_private;
+#else
+  #define SIMDE_ARM_NEON_TYPE_INT_DEFINE_(Element_Type_Name, Element_Count, Alignment) \
+    typedef struct simde_##Element_Type_Name##x##Element_Count##_private { \
+      SIMDE_ALIGN(Alignment) Element_Type_Name##_t values[Element_Count]; \
+    } simde_##Element_Type_Name##x##Element_Count##_private;
+  #define SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(Element_Size, Element_Count, Alignment) \
+    typedef struct simde_float##Element_Size##x##Element_Count##_private { \
+      SIMDE_ALIGN(Alignment) simde_float##Element_Size values[Element_Count]; \
+    } simde_float##Element_Size##x##Element_Count##_private;
+#endif
+
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(     int8, 8,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int16, 4,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int32, 2,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int64, 1,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    uint8, 8,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint16, 4,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint32, 2,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint64, 1,  8)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(     int8, 16, 16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int16, 8,  16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int32, 4,  16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    int64, 2,  16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(    uint8, 16, 16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint16, 8,  16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint32, 4,  16)
+SIMDE_ARM_NEON_TYPE_INT_DEFINE_(   uint64, 2,  16)
+SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(32, 2, 8)
+SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 1, 8)
+SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(32, 4, 16)
+SIMDE_ARM_NEON_TYPE_FLOAT_DEFINE_(64, 2, 16)
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  typedef     float32_t     simde_float32_t;
+
+  typedef      int8x8_t      simde_int8x8_t;
+  typedef     int16x4_t     simde_int16x4_t;
+  typedef     int32x2_t     simde_int32x2_t;
+  typedef     int64x1_t     simde_int64x1_t;
+  typedef     uint8x8_t     simde_uint8x8_t;
+  typedef    uint16x4_t    simde_uint16x4_t;
+  typedef    uint32x2_t    simde_uint32x2_t;
+  typedef    uint64x1_t    simde_uint64x1_t;
+  typedef   float32x2_t   simde_float32x2_t;
+
+  typedef     int8x16_t     simde_int8x16_t;
+  typedef     int16x8_t     simde_int16x8_t;
+  typedef     int32x4_t     simde_int32x4_t;
+  typedef     int64x2_t     simde_int64x2_t;
+  typedef    uint8x16_t    simde_uint8x16_t;
+  typedef    uint16x8_t    simde_uint16x8_t;
+  typedef    uint32x4_t    simde_uint32x4_t;
+  typedef    uint64x2_t    simde_uint64x2_t;
+  typedef   float32x4_t   simde_float32x4_t;
+
+  typedef    int8x8x2_t    simde_int8x8x2_t;
+  typedef   int16x4x2_t   simde_int16x4x2_t;
+  typedef   int32x2x2_t   simde_int32x2x2_t;
+  typedef   int64x1x2_t   simde_int64x1x2_t;
+  typedef   uint8x8x2_t   simde_uint8x8x2_t;
+  typedef  uint16x4x2_t  simde_uint16x4x2_t;
+  typedef  uint32x2x2_t  simde_uint32x2x2_t;
+  typedef  uint64x1x2_t  simde_uint64x1x2_t;
+  typedef float32x2x2_t simde_float32x2x2_t;
+
+  typedef   int8x16x2_t   simde_int8x16x2_t;
+  typedef   int16x8x2_t   simde_int16x8x2_t;
+  typedef   int32x4x2_t   simde_int32x4x2_t;
+  typedef   int64x2x2_t   simde_int64x2x2_t;
+  typedef  uint8x16x2_t  simde_uint8x16x2_t;
+  typedef  uint16x8x2_t  simde_uint16x8x2_t;
+  typedef  uint32x4x2_t  simde_uint32x4x2_t;
+  typedef  uint64x2x2_t  simde_uint64x2x2_t;
+  typedef float32x4x2_t simde_float32x4x2_t;
+
+  typedef    int8x8x3_t    simde_int8x8x3_t;
+  typedef   int16x4x3_t   simde_int16x4x3_t;
+  typedef   int32x2x3_t   simde_int32x2x3_t;
+  typedef   int64x1x3_t   simde_int64x1x3_t;
+  typedef   uint8x8x3_t   simde_uint8x8x3_t;
+  typedef  uint16x4x3_t  simde_uint16x4x3_t;
+  typedef  uint32x2x3_t  simde_uint32x2x3_t;
+  typedef  uint64x1x3_t  simde_uint64x1x3_t;
+  typedef float32x2x3_t simde_float32x2x3_t;
+
+  typedef   int8x16x3_t   simde_int8x16x3_t;
+  typedef   int16x8x3_t   simde_int16x8x3_t;
+  typedef   int32x4x3_t   simde_int32x4x3_t;
+  typedef   int64x2x3_t   simde_int64x2x3_t;
+  typedef  uint8x16x3_t  simde_uint8x16x3_t;
+  typedef  uint16x8x3_t  simde_uint16x8x3_t;
+  typedef  uint32x4x3_t  simde_uint32x4x3_t;
+  typedef  uint64x2x3_t  simde_uint64x2x3_t;
+  typedef float32x4x3_t simde_float32x4x3_t;
+
+  typedef    int8x8x4_t    simde_int8x8x4_t;
+  typedef   int16x4x4_t   simde_int16x4x4_t;
+  typedef   int32x2x4_t   simde_int32x2x4_t;
+  typedef   int64x1x4_t   simde_int64x1x4_t;
+  typedef   uint8x8x4_t   simde_uint8x8x4_t;
+  typedef  uint16x4x4_t  simde_uint16x4x4_t;
+  typedef  uint32x2x4_t  simde_uint32x2x4_t;
+  typedef  uint64x1x4_t  simde_uint64x1x4_t;
+  typedef float32x2x4_t simde_float32x2x4_t;
+
+  typedef   int8x16x4_t   simde_int8x16x4_t;
+  typedef   int16x8x4_t   simde_int16x8x4_t;
+  typedef   int32x4x4_t   simde_int32x4x4_t;
+  typedef   int64x2x4_t   simde_int64x2x4_t;
+  typedef  uint8x16x4_t  simde_uint8x16x4_t;
+  typedef  uint16x8x4_t  simde_uint16x8x4_t;
+  typedef  uint32x4x4_t  simde_uint32x4x4_t;
+  typedef  uint64x2x4_t  simde_uint64x2x4_t;
+  typedef float32x4x4_t simde_float32x4x4_t;
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    typedef     float64_t     simde_float64_t;
+    typedef   float64x1_t   simde_float64x1_t;
+    typedef   float64x2_t   simde_float64x2_t;
+    typedef float64x1x2_t simde_float64x1x2_t;
+    typedef float64x2x2_t simde_float64x2x2_t;
+    typedef float64x1x3_t simde_float64x1x3_t;
+    typedef float64x2x3_t simde_float64x2x3_t;
+    typedef float64x1x4_t simde_float64x1x4_t;
+    typedef float64x2x4_t simde_float64x2x4_t;
+  #else
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN
+  #endif
+#elif defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VXN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN
+
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    typedef __m64    simde_int8x8_t;
+    typedef __m64   simde_int16x4_t;
+    typedef __m64   simde_int32x2_t;
+    typedef __m64   simde_int64x1_t;
+    typedef __m64   simde_uint8x8_t;
+    typedef __m64  simde_uint16x4_t;
+    typedef __m64  simde_uint32x2_t;
+    typedef __m64  simde_uint64x1_t;
+    typedef __m64 simde_float32x2_t;
+    typedef __m64 simde_float64x1_t;
+  #else
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I8X8
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I16X4
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I32X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I64X1
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U8X8
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U16X4
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U32X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U64X1
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F32X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1
+  #endif
+
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    typedef __m128 simde_float32x4_t;
+  #else
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F32X4
+  #endif
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    typedef  __m128i  simde_int8x16_t;
+    typedef  __m128i  simde_int16x8_t;
+    typedef  __m128i  simde_int32x4_t;
+    typedef  __m128i  simde_int64x2_t;
+    typedef __m128i  simde_uint8x16_t;
+    typedef __m128i  simde_uint16x8_t;
+    typedef __m128i  simde_uint32x4_t;
+    typedef __m128i  simde_uint64x2_t;
+    typedef __m128d simde_float64x2_t;
+  #else
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I8X16
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I16X8
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I32X4
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I64X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U8X16
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U16X8
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U32X4
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U64X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2
+  #endif
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VXN
+
+  typedef v128_t   simde_int8x16_t;
+  typedef v128_t   simde_int16x8_t;
+  typedef v128_t   simde_int32x4_t;
+  typedef v128_t   simde_int64x2_t;
+  typedef v128_t  simde_uint8x16_t;
+  typedef v128_t  simde_uint16x8_t;
+  typedef v128_t  simde_uint32x4_t;
+  typedef v128_t  simde_uint64x2_t;
+  typedef v128_t simde_float32x4_t;
+  typedef v128_t simde_float64x2_t;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VXN
+
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(signed char)          simde_int8x16_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(signed short)         simde_int16x8_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(signed int)           simde_int32x4_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)       simde_uint8x16_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)      simde_uint16x8_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)        simde_uint32x4_t;
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(float)              simde_float32x4_t;
+
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    typedef SIMDE_POWER_ALTIVEC_VECTOR(signed long long)       simde_int64x2_t;
+    typedef SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long)     simde_uint64x2_t;
+    typedef SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double) simde_float64x2_t;
+  #else
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_I64X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_U64X2
+    #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2
+  #endif
+#else
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F32
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_64BIT
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_128BIT
+
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_VXN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN
+  #define SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I8X8) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_int8x8_private simde_int8x8_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I16X4) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_int16x4_private simde_int16x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I32X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_int32x2_private simde_int32x2_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I64X1) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_int64x1_private simde_int64x1_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U8X8) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_uint8x8_private simde_uint8x8_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U16X4) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_uint16x4_private simde_uint16x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U32X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_uint32x2_private simde_uint32x2_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U64X1) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_uint64x1_private simde_uint64x1_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F32X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_float32x2_private simde_float32x2_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X1) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_64BIT)
+  typedef simde_float64x1_private simde_float64x1_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I8X16) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_int8x16_private simde_int8x16_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I16X8) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_int16x8_private simde_int16x8_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I32X4) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_int32x4_private simde_int32x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_I64X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_int64x2_private simde_int64x2_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U8X16) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_uint8x16_private simde_uint8x16_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U16X8) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_uint16x8_private simde_uint16x8_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U32X4) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_uint32x4_private simde_uint32x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_U64X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_uint64x2_private simde_uint64x2_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F32X4) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_float32x4_private simde_float32x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X2) || defined(SIMDE_ARM_NEON_NEED_PORTABLE_128BIT)
+  typedef simde_float64x2_private simde_float64x2_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F32)
+  typedef simde_float32 simde_float32_t;
+#endif
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64)
+  typedef simde_float64 simde_float64_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_VXN) && !defined(SIMDE_BUG_INTEL_857088)
+  typedef struct    simde_int8x8x2_t {
+    simde_int8x8_t val[2];
+  } simde_int8x8x2_t;
+  typedef struct   simde_int16x4x2_t {
+    simde_int16x4_t val[2];
+  } simde_int16x4x2_t;
+  typedef struct   simde_int32x2x2_t {
+    simde_int32x2_t val[2];
+  } simde_int32x2x2_t;
+  typedef struct   simde_int64x1x2_t {
+    simde_int64x1_t val[2];
+  } simde_int64x1x2_t;
+  typedef struct   simde_uint8x8x2_t {
+    simde_uint8x8_t val[2];
+  } simde_uint8x8x2_t;
+  typedef struct  simde_uint16x4x2_t {
+    simde_uint16x4_t val[2];
+  } simde_uint16x4x2_t;
+  typedef struct  simde_uint32x2x2_t {
+    simde_uint32x2_t val[2];
+  } simde_uint32x2x2_t;
+  typedef struct  simde_uint64x1x2_t {
+    simde_uint64x1_t val[2];
+  } simde_uint64x1x2_t;
+  typedef struct simde_float32x2x2_t {
+    simde_float32x2_t val[2];
+  } simde_float32x2x2_t;
+
+  typedef struct   simde_int8x16x2_t {
+    simde_int8x16_t val[2];
+  } simde_int8x16x2_t;
+  typedef struct   simde_int16x8x2_t {
+    simde_int16x8_t val[2];
+  } simde_int16x8x2_t;
+  typedef struct   simde_int32x4x2_t {
+    simde_int32x4_t val[2];
+  } simde_int32x4x2_t;
+  typedef struct   simde_int64x2x2_t {
+    simde_int64x2_t val[2];
+  } simde_int64x2x2_t;
+  typedef struct  simde_uint8x16x2_t {
+    simde_uint8x16_t val[2];
+  } simde_uint8x16x2_t;
+  typedef struct  simde_uint16x8x2_t {
+    simde_uint16x8_t val[2];
+  } simde_uint16x8x2_t;
+  typedef struct  simde_uint32x4x2_t {
+    simde_uint32x4_t val[2];
+  } simde_uint32x4x2_t;
+  typedef struct  simde_uint64x2x2_t {
+    simde_uint64x2_t val[2];
+  } simde_uint64x2x2_t;
+  typedef struct simde_float32x4x2_t {
+    simde_float32x4_t val[2];
+  } simde_float32x4x2_t;
+
+  typedef struct    simde_int8x8x3_t {
+    simde_int8x8_t val[3];
+  } simde_int8x8x3_t;
+  typedef struct   simde_int16x4x3_t {
+    simde_int16x4_t val[3];
+  } simde_int16x4x3_t;
+  typedef struct   simde_int32x2x3_t {
+    simde_int32x2_t val[3];
+  } simde_int32x2x3_t;
+  typedef struct   simde_int64x1x3_t {
+    simde_int64x1_t val[3];
+  } simde_int64x1x3_t;
+  typedef struct   simde_uint8x8x3_t {
+    simde_uint8x8_t val[3];
+  } simde_uint8x8x3_t;
+  typedef struct  simde_uint16x4x3_t {
+    simde_uint16x4_t val[3];
+  } simde_uint16x4x3_t;
+  typedef struct  simde_uint32x2x3_t {
+    simde_uint32x2_t val[3];
+  } simde_uint32x2x3_t;
+  typedef struct  simde_uint64x1x3_t {
+    simde_uint64x1_t val[3];
+  } simde_uint64x1x3_t;
+  typedef struct simde_float32x2x3_t {
+    simde_float32x2_t val[3];
+  } simde_float32x2x3_t;
+
+  typedef struct   simde_int8x16x3_t {
+    simde_int8x16_t val[3];
+  } simde_int8x16x3_t;
+  typedef struct   simde_int16x8x3_t {
+    simde_int16x8_t val[3];
+  } simde_int16x8x3_t;
+  typedef struct   simde_int32x4x3_t {
+    simde_int32x4_t val[3];
+  } simde_int32x4x3_t;
+  typedef struct   simde_int64x2x3_t {
+    simde_int64x2_t val[3];
+  } simde_int64x2x3_t;
+  typedef struct  simde_uint8x16x3_t {
+    simde_uint8x16_t val[3];
+  } simde_uint8x16x3_t;
+  typedef struct  simde_uint16x8x3_t {
+    simde_uint16x8_t val[3];
+  } simde_uint16x8x3_t;
+  typedef struct  simde_uint32x4x3_t {
+    simde_uint32x4_t val[3];
+  } simde_uint32x4x3_t;
+  typedef struct  simde_uint64x2x3_t {
+    simde_uint64x2_t val[3];
+  } simde_uint64x2x3_t;
+  typedef struct simde_float32x4x3_t {
+    simde_float32x4_t val[3];
+  } simde_float32x4x3_t;
+
+  typedef struct    simde_int8x8x4_t {
+    simde_int8x8_t val[4];
+  } simde_int8x8x4_t;
+  typedef struct   simde_int16x4x4_t {
+    simde_int16x4_t val[4];
+  } simde_int16x4x4_t;
+  typedef struct   simde_int32x2x4_t {
+    simde_int32x2_t val[4];
+  } simde_int32x2x4_t;
+  typedef struct   simde_int64x1x4_t {
+    simde_int64x1_t val[4];
+  } simde_int64x1x4_t;
+  typedef struct   simde_uint8x8x4_t {
+    simde_uint8x8_t val[4];
+  } simde_uint8x8x4_t;
+  typedef struct  simde_uint16x4x4_t {
+    simde_uint16x4_t val[4];
+  } simde_uint16x4x4_t;
+  typedef struct  simde_uint32x2x4_t {
+    simde_uint32x2_t val[4];
+  } simde_uint32x2x4_t;
+  typedef struct  simde_uint64x1x4_t {
+    simde_uint64x1_t val[4];
+  } simde_uint64x1x4_t;
+  typedef struct simde_float32x2x4_t {
+    simde_float32x2_t val[4];
+  } simde_float32x2x4_t;
+
+  typedef struct   simde_int8x16x4_t {
+    simde_int8x16_t val[4];
+  } simde_int8x16x4_t;
+  typedef struct   simde_int16x8x4_t {
+    simde_int16x8_t val[4];
+  } simde_int16x8x4_t;
+  typedef struct   simde_int32x4x4_t {
+    simde_int32x4_t val[4];
+  } simde_int32x4x4_t;
+  typedef struct   simde_int64x2x4_t {
+    simde_int64x2_t val[4];
+  } simde_int64x2x4_t;
+  typedef struct  simde_uint8x16x4_t {
+    simde_uint8x16_t val[4];
+  } simde_uint8x16x4_t;
+  typedef struct  simde_uint16x8x4_t {
+    simde_uint16x8_t val[4];
+  } simde_uint16x8x4_t;
+  typedef struct  simde_uint32x4x4_t {
+    simde_uint32x4_t val[4];
+  } simde_uint32x4x4_t;
+  typedef struct  simde_uint64x2x4_t {
+    simde_uint64x2_t val[4];
+  } simde_uint64x2x4_t;
+  typedef struct simde_float32x4x4_t {
+    simde_float32x4_t val[4];
+  } simde_float32x4x4_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X1XN)
+  typedef struct   simde_float64x1x2_t {
+    simde_float64x1_t val[2];
+  } simde_float64x1x2_t;
+
+  typedef struct   simde_float64x1x3_t {
+    simde_float64x1_t val[3];
+  } simde_float64x1x3_t;
+
+  typedef struct   simde_float64x1x4_t {
+    simde_float64x1_t val[4];
+  } simde_float64x1x4_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_NEED_PORTABLE_F64X2XN)
+  typedef struct   simde_float64x2x2_t {
+    simde_float64x2_t val[2];
+  } simde_float64x2x2_t;
+
+ typedef struct   simde_float64x2x3_t {
+   simde_float64x2_t val[3];
+ } simde_float64x2x3_t;
+
+ typedef struct   simde_float64x2x4_t {
+   simde_float64x2_t val[4];
+ } simde_float64x2x4_t;
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  typedef   simde_float32_t     float32_t;
+
+  typedef    simde_int8x8_t      int8x8_t;
+  typedef   simde_int16x4_t     int16x4_t;
+  typedef   simde_int32x2_t     int32x2_t;
+  typedef   simde_int64x1_t     int64x1_t;
+  typedef   simde_uint8x8_t     uint8x8_t;
+  typedef  simde_uint16x4_t    uint16x4_t;
+  typedef  simde_uint32x2_t    uint32x2_t;
+  typedef  simde_uint64x1_t    uint64x1_t;
+  typedef simde_float32x2_t   float32x2_t;
+
+  typedef   simde_int8x16_t     int8x16_t;
+  typedef   simde_int16x8_t     int16x8_t;
+  typedef   simde_int32x4_t     int32x4_t;
+  typedef   simde_int64x2_t     int64x2_t;
+  typedef  simde_uint8x16_t    uint8x16_t;
+  typedef  simde_uint16x8_t    uint16x8_t;
+  typedef  simde_uint32x4_t    uint32x4_t;
+  typedef  simde_uint64x2_t    uint64x2_t;
+  typedef simde_float32x4_t   float32x4_t;
+
+  typedef  simde_int8x8x2_t    int8x8x2_t;
+  typedef simde_int16x4x2_t   int16x4x2_t;
+  typedef simde_int32x2x2_t   int32x2x2_t;
+  typedef simde_int64x1x2_t   int64x1x2_t;
+  typedef simde_uint8x8x2_t   uint8x8x2_t;
+  typedef simde_uint16x4x2_t  uint16x4x2_t;
+  typedef simde_uint32x2x2_t  uint32x2x2_t;
+  typedef simde_uint64x1x2_t  uint64x1x2_t;
+  typedef simde_float32x2x2_t float32x2x2_t;
+
+  typedef simde_int8x16x2_t   int8x16x2_t;
+  typedef simde_int16x8x2_t   int16x8x2_t;
+  typedef simde_int32x4x2_t   int32x4x2_t;
+  typedef simde_int64x2x2_t   int64x2x2_t;
+  typedef simde_uint8x16x2_t  uint8x16x2_t;
+  typedef simde_uint16x8x2_t  uint16x8x2_t;
+  typedef simde_uint32x4x2_t  uint32x4x2_t;
+  typedef simde_uint64x2x2_t  uint64x2x2_t;
+  typedef simde_float32x4x2_t float32x4x2_t;
+
+  typedef  simde_int8x8x3_t    int8x8x3_t;
+  typedef simde_int16x4x3_t   int16x4x3_t;
+  typedef simde_int32x2x3_t   int32x2x3_t;
+  typedef simde_int64x1x3_t   int64x1x3_t;
+  typedef simde_uint8x8x3_t   uint8x8x3_t;
+  typedef simde_uint16x4x3_t  uint16x4x3_t;
+  typedef simde_uint32x2x3_t  uint32x2x3_t;
+  typedef simde_uint64x1x3_t  uint64x1x3_t;
+  typedef simde_float32x2x3_t float32x2x3_t;
+
+  typedef simde_int8x16x3_t   int8x16x3_t;
+  typedef simde_int16x8x3_t   int16x8x3_t;
+  typedef simde_int32x4x3_t   int32x4x3_t;
+  typedef simde_int64x2x3_t   int64x2x3_t;
+  typedef simde_uint8x16x3_t  uint8x16x3_t;
+  typedef simde_uint16x8x3_t  uint16x8x3_t;
+  typedef simde_uint32x4x3_t  uint32x4x3_t;
+  typedef simde_uint64x2x3_t  uint64x2x3_t;
+  typedef simde_float32x4x3_t float32x4x3_t;
+
+  typedef  simde_int8x8x4_t    int8x8x4_t;
+  typedef simde_int16x4x4_t   int16x4x4_t;
+  typedef simde_int32x2x4_t   int32x2x4_t;
+  typedef simde_int64x1x4_t   int64x1x4_t;
+  typedef simde_uint8x8x4_t   uint8x8x4_t;
+  typedef simde_uint16x4x4_t  uint16x4x4_t;
+  typedef simde_uint32x2x4_t  uint32x2x4_t;
+  typedef simde_uint64x1x4_t  uint64x1x4_t;
+  typedef simde_float32x2x4_t float32x2x4_t;
+
+  typedef simde_int8x16x4_t   int8x16x4_t;
+  typedef simde_int16x8x4_t   int16x8x4_t;
+  typedef simde_int32x4x4_t   int32x4x4_t;
+  typedef simde_int64x2x4_t   int64x2x4_t;
+  typedef simde_uint8x16x4_t  uint8x16x4_t;
+  typedef simde_uint16x8x4_t  uint16x8x4_t;
+  typedef simde_uint32x4x4_t  uint32x4x4_t;
+  typedef simde_uint64x2x4_t  uint64x2x4_t;
+  typedef simde_float32x4x4_t float32x4x4_t;
+#endif
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  typedef   simde_float64_t     float64_t;
+  typedef simde_float64x1_t   float64x1_t;
+  typedef simde_float64x2_t   float64x2_t;
+  typedef simde_float64x1x2_t float64x1x2_t;
+  typedef simde_float64x2x2_t float64x2x2_t;
+  typedef simde_float64x1x3_t float64x1x3_t;
+  typedef simde_float64x2x3_t float64x2x3_t;
+  typedef simde_float64x1x4_t float64x1x4_t;
+  typedef simde_float64x2x4_t float64x2x4_t;
+#endif
+
+#define SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(T) \
+  SIMDE_FUNCTION_ATTRIBUTES simde_##T##_private simde_##T##_to_private (simde_##T##_t value) { simde_##T##_private to; simde_memcpy(&to, &value, sizeof(to)); return to; } \
+  SIMDE_FUNCTION_ATTRIBUTES simde_##T##_t simde_##T##_from_private (simde_##T##_private value) { simde_##T##_t to; simde_memcpy(&to, &value, sizeof(to)); return to; }
+
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int8x8)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int16x4)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int32x2)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int64x1)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint8x8)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint16x4)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint32x2)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint64x1)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(float32x2)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(float64x1)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int8x16)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int16x8)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int32x4)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(int64x2)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint8x16)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint16x8)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint32x4)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(uint64x2)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(float32x4)
+SIMDE_ARM_NEON_TYPE_DEFINE_CONVERSIONS_(float64x2)
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* SIMDE_ARM_NEON_TYPES_H */

--- a/2.0/simde/arm/neon/uzp.h
+++ b/2.0/simde/arm/neon/uzp.h
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_UZP_H) && !defined(SIMDE_BUG_INTEL_857088)
+#define SIMDE_ARM_NEON_UZP_H
+
+#include "types.h"
+#include "uzp1.h"
+#include "uzp2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2x2_t
+simde_vuzp_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_f32(a, b);
+  #else
+    simde_float32x2x2_t r = { { simde_vuzp1_f32(a, b), simde_vuzp2_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_f32
+  #define vuzp_f32(a, b) simde_vuzp_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8x2_t
+simde_vuzp_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_s8(a, b);
+  #else
+    simde_int8x8x2_t r = { { simde_vuzp1_s8(a, b), simde_vuzp2_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_s8
+  #define vuzp_s8(a, b) simde_vuzp_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4x2_t
+simde_vuzp_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_s16(a, b);
+  #else
+    simde_int16x4x2_t r = { { simde_vuzp1_s16(a, b), simde_vuzp2_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_s16
+  #define vuzp_s16(a, b) simde_vuzp_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2x2_t
+simde_vuzp_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_s32(a, b);
+  #else
+    simde_int32x2x2_t r = { { simde_vuzp1_s32(a, b), simde_vuzp2_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_s32
+  #define vuzp_s32(a, b) simde_vuzp_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8x2_t
+simde_vuzp_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_u8(a, b);
+  #else
+    simde_uint8x8x2_t r = { { simde_vuzp1_u8(a, b), simde_vuzp2_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_u8
+  #define vuzp_u8(a, b) simde_vuzp_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4x2_t
+simde_vuzp_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_u16(a, b);
+  #else
+    simde_uint16x4x2_t r = { { simde_vuzp1_u16(a, b), simde_vuzp2_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_u16
+  #define vuzp_u16(a, b) simde_vuzp_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2x2_t
+simde_vuzp_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzp_u32(a, b);
+  #else
+    simde_uint32x2x2_t r = { { simde_vuzp1_u32(a, b), simde_vuzp2_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzp_u32
+  #define vuzp_u32(a, b) simde_vuzp_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4x2_t
+simde_vuzpq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_f32(a, b);
+  #else
+    simde_float32x4x2_t r = { { simde_vuzp1q_f32(a, b), simde_vuzp2q_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_f32
+  #define vuzpq_f32(a, b) simde_vuzpq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16x2_t
+simde_vuzpq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_s8(a, b);
+  #else
+    simde_int8x16x2_t r = { { simde_vuzp1q_s8(a, b), simde_vuzp2q_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_s8
+  #define vuzpq_s8(a, b) simde_vuzpq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8x2_t
+simde_vuzpq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_s16(a, b);
+  #else
+    simde_int16x8x2_t r = { { simde_vuzp1q_s16(a, b), simde_vuzp2q_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_s16
+  #define vuzpq_s16(a, b) simde_vuzpq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4x2_t
+simde_vuzpq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_s32(a, b);
+  #else
+    simde_int32x4x2_t r = { { simde_vuzp1q_s32(a, b), simde_vuzp2q_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_s32
+  #define vuzpq_s32(a, b) simde_vuzpq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16x2_t
+simde_vuzpq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_u8(a, b);
+  #else
+    simde_uint8x16x2_t r = { { simde_vuzp1q_u8(a, b), simde_vuzp2q_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_u8
+  #define vuzpq_u8(a, b) simde_vuzpq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8x2_t
+simde_vuzpq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_u16(a, b);
+  #else
+    simde_uint16x8x2_t r = { { simde_vuzp1q_u16(a, b), simde_vuzp2q_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_u16
+  #define vuzpq_u16(a, b) simde_vuzpq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4x2_t
+simde_vuzpq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vuzpq_u32(a, b);
+  #else
+    simde_uint32x4x2_t r = { { simde_vuzp1q_u32(a, b), simde_vuzp2q_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vuzpq_u32
+  #define vuzpq_u32(a, b) simde_vuzpq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_UZP_H) */

--- a/2.0/simde/arm/neon/uzp1.h
+++ b/2.0/simde/arm/neon/uzp1.h
@@ -1,0 +1,568 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_UZP1_H)
+#define SIMDE_ARM_NEON_UZP1_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vuzp1_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_f32
+  #define vuzp1_f32(a, b) simde_vuzp1_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vuzp1_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_s8
+  #define vuzp1_s8(a, b) simde_vuzp1_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vuzp1_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, b_.values, 0, 2, 4, 6);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_s16
+  #define vuzp1_s16(a, b) simde_vuzp1_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vuzp1_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_s32
+  #define vuzp1_s32(a, b) simde_vuzp1_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vuzp1_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_u8
+  #define vuzp1_u8(a, b) simde_vuzp1_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vuzp1_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, b_.values, 0, 2, 4, 6);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_u16
+  #define vuzp1_u16(a, b) simde_vuzp1_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vuzp1_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1_u32
+  #define vuzp1_u32(a, b) simde_vuzp1_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vuzp1q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_f32(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 0, 2, 4, 6);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_f32
+  #define vuzp1q_f32(a, b) simde_vuzp1q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vuzp1q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_f64(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_f64
+  #define vuzp1q_f64(a, b) simde_vuzp1q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vuzp1q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_s8
+  #define vuzp1q_s8(a, b) simde_vuzp1q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vuzp1q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_s16
+  #define vuzp1q_s16(a, b) simde_vuzp1q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vuzp1q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 0, 2, 4, 6);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_s32
+  #define vuzp1q_s32(a, b) simde_vuzp1q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vuzp1q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_s64(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_s64
+  #define vuzp1q_s64(a, b) simde_vuzp1q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vuzp1q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_u8(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_u8
+  #define vuzp1q_u8(a, b) simde_vuzp1q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vuzp1q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_u16(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, b_.values, 0, 2, 4, 6, 8, 10, 12, 14);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_u16
+  #define vuzp1q_u16(a, b) simde_vuzp1q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vuzp1q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_u32(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 0, 2, 4, 6);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_u32
+  #define vuzp1q_u32(a, b) simde_vuzp1q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vuzp1q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp1q_u64(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 0, 2);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx];
+        r_.values[i + halfway_point] = b_.values[idx];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp1q_u64
+  #define vuzp1q_u64(a, b) simde_vuzp1q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_UZP1_H) */

--- a/2.0/simde/arm/neon/uzp2.h
+++ b/2.0/simde/arm/neon/uzp2.h
@@ -1,0 +1,567 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_UZP2_H)
+#define SIMDE_ARM_NEON_UZP2_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vuzp2_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_f32
+  #define vuzp2_f32(a, b) simde_vuzp2_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vuzp2_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_s8
+  #define vuzp2_s8(a, b) simde_vuzp2_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vuzp2_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, b_.values, 1, 3, 5, 7);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_s16
+  #define vuzp2_s16(a, b) simde_vuzp2_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vuzp2_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_s32
+  #define vuzp2_s32(a, b) simde_vuzp2_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vuzp2_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_u8
+  #define vuzp2_u8(a, b) simde_vuzp2_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vuzp2_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.values, b_.values, 1, 3, 5, 7);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_u16
+  #define vuzp2_u16(a, b) simde_vuzp2_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vuzp2_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2_u32
+  #define vuzp2_u32(a, b) simde_vuzp2_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vuzp2q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_f32(a, b);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 1, 3, 5, 7);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_f32
+  #define vuzp2q_f32(a, b) simde_vuzp2q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vuzp2q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_f64(a, b);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_f64
+  #define vuzp2q_f64(a, b) simde_vuzp2q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vuzp2q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_s8(a, b);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_s8
+  #define vuzp2q_s8(a, b) simde_vuzp2q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vuzp2q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_s16(a, b);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_s16
+  #define vuzp2q_s16(a, b) simde_vuzp2q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vuzp2q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_s32(a, b);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 1, 3, 5, 7);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_s32
+  #define vuzp2q_s32(a, b) simde_vuzp2q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vuzp2q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_s64(a, b);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_s64
+  #define vuzp2q_s64(a, b) simde_vuzp2q_s64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vuzp2q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_u8(a, b);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_u8
+  #define vuzp2q_u8(a, b) simde_vuzp2q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vuzp2q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_u16(a, b);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.values, b_.values, 1, 3, 5, 7, 9, 11, 13, 15);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_u16
+  #define vuzp2q_u16(a, b) simde_vuzp2q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vuzp2q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_u32(a, b);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.values, b_.values, 1, 3, 5, 7);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_u32
+  #define vuzp2q_u32(a, b) simde_vuzp2q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vuzp2q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vuzp2q_u64(a, b);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.values = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.values, b_.values, 1, 3);
+    #else
+      const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < halfway_point ; i++) {
+        const size_t idx = i << 1;
+        r_.values[        i        ] = a_.values[idx | 1];
+        r_.values[i + halfway_point] = b_.values[idx | 1];
+      }
+    #endif
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vuzp2q_u64
+  #define vuzp2q_u64(a, b) simde_vuzp2q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_UZP2_H) */

--- a/2.0/simde/arm/neon/zip.h
+++ b/2.0/simde/arm/neon/zip.h
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ZIP_H) && !defined(SIMDE_BUG_INTEL_857088)
+#define SIMDE_ARM_NEON_ZIP_H
+
+#include "types.h"
+#include "zip1.h"
+#include "zip2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2x2_t
+simde_vzip_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_f32(a, b);
+  #else
+    simde_float32x2x2_t r = { { simde_vzip1_f32(a, b), simde_vzip2_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_f32
+  #define vzip_f32(a, b) simde_vzip_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8x2_t
+simde_vzip_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_s8(a, b);
+  #else
+    simde_int8x8x2_t r = { { simde_vzip1_s8(a, b), simde_vzip2_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_s8
+  #define vzip_s8(a, b) simde_vzip_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4x2_t
+simde_vzip_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_s16(a, b);
+  #else
+    simde_int16x4x2_t r = { { simde_vzip1_s16(a, b), simde_vzip2_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_s16
+  #define vzip_s16(a, b) simde_vzip_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2x2_t
+simde_vzip_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_s32(a, b);
+  #else
+    simde_int32x2x2_t r = { { simde_vzip1_s32(a, b), simde_vzip2_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_s32
+  #define vzip_s32(a, b) simde_vzip_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8x2_t
+simde_vzip_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_u8(a, b);
+  #else
+    simde_uint8x8x2_t r = { { simde_vzip1_u8(a, b), simde_vzip2_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_u8
+  #define vzip_u8(a, b) simde_vzip_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4x2_t
+simde_vzip_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_u16(a, b);
+  #else
+    simde_uint16x4x2_t r = { { simde_vzip1_u16(a, b), simde_vzip2_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_u16
+  #define vzip_u16(a, b) simde_vzip_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2x2_t
+simde_vzip_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzip_u32(a, b);
+  #else
+    simde_uint32x2x2_t r = { { simde_vzip1_u32(a, b), simde_vzip2_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzip_u32
+  #define vzip_u32(a, b) simde_vzip_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4x2_t
+simde_vzipq_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_f32(a, b);
+  #else
+    simde_float32x4x2_t r = { { simde_vzip1q_f32(a, b), simde_vzip2q_f32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_f32
+  #define vzipq_f32(a, b) simde_vzipq_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16x2_t
+simde_vzipq_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_s8(a, b);
+  #else
+    simde_int8x16x2_t r = { { simde_vzip1q_s8(a, b), simde_vzip2q_s8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_s8
+  #define vzipq_s8(a, b) simde_vzipq_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8x2_t
+simde_vzipq_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_s16(a, b);
+  #else
+    simde_int16x8x2_t r = { { simde_vzip1q_s16(a, b), simde_vzip2q_s16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_s16
+  #define vzipq_s16(a, b) simde_vzipq_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4x2_t
+simde_vzipq_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_s32(a, b);
+  #else
+    simde_int32x4x2_t r = { { simde_vzip1q_s32(a, b), simde_vzip2q_s32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_s32
+  #define vzipq_s32(a, b) simde_vzipq_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16x2_t
+simde_vzipq_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_u8(a, b);
+  #else
+    simde_uint8x16x2_t r = { { simde_vzip1q_u8(a, b), simde_vzip2q_u8(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_u8
+  #define vzipq_u8(a, b) simde_vzipq_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8x2_t
+simde_vzipq_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_u16(a, b);
+  #else
+    simde_uint16x8x2_t r = { { simde_vzip1q_u16(a, b), simde_vzip2q_u16(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_u16
+  #define vzipq_u16(a, b) simde_vzipq_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4x2_t
+simde_vzipq_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vzipq_u32(a, b);
+  #else
+    simde_uint32x4x2_t r = { { simde_vzip1q_u32(a, b), simde_vzip2q_u32(a, b) } };
+    return r;
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES)
+  #undef vzipq_u32
+  #define vzipq_u32(a, b) simde_vzipq_u32((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ZIP_H) */

--- a/2.0/simde/arm/neon/zip1.h
+++ b/2.0/simde/arm/neon/zip1.h
@@ -1,0 +1,513 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ZIP1_H)
+#define SIMDE_ARM_NEON_ZIP1_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vzip1_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_f32
+  #define vzip1_f32(a, b) simde_vzip1_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vzip1_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_s8
+  #define vzip1_s8(a, b) simde_vzip1_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vzip1_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_s16
+  #define vzip1_s16(a, b) simde_vzip1_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vzip1_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_s32
+  #define vzip1_s32(a, b) simde_vzip1_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vzip1_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_u8
+  #define vzip1_u8(a, b) simde_vzip1_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vzip1_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_u16
+  #define vzip1_u16(a, b) simde_vzip1_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vzip1_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1_u32
+  #define vzip1_u32(a, b) simde_vzip1_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vzip1q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_f32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_f32
+  #define vzip1q_f32(a, b) simde_vzip1q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vzip1q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_f64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_f64
+  #define vzip1q_f64(a, b) simde_vzip1q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vzip1q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_s8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_s8
+  #define vzip1q_s8(a, b) simde_vzip1q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vzip1q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_s16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_s16
+  #define vzip1q_s16(a, b) simde_vzip1q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vzip1q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_s32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_s32
+  #define vzip1q_s32(a, b) simde_vzip1q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vzip1q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_s64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_s64
+  #define vzip1q_s64(a, b) simde_vzip1q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vzip1q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_u8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_u8
+  #define vzip1q_u8(a, b) simde_vzip1q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vzip1q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 16, 17, 2, 3, 18, 19, 4, 5, 20, 21, 6, 7, 22, 23);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_u16
+  #define vzip1q_u16(a, b) simde_vzip1q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vzip1q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 16, 17, 18, 19, 4, 5, 6, 7, 20, 21, 22, 23);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_u32
+  #define vzip1q_u32(a, b) simde_vzip1q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vzip1q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip1q_u64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[2 * i    ] = a_.values[i];
+      r_.values[2 * i + 1] = b_.values[i];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip1q_u64
+  #define vzip1q_u64(a, b) simde_vzip1q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ZIP1_H) */

--- a/2.0/simde/arm/neon/zip2.h
+++ b/2.0/simde/arm/neon/zip2.h
@@ -1,0 +1,513 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Sean Maher <seanptmaher@gmail.com> (Copyright owned by Google, LLC)
+ */
+
+#if !defined(SIMDE_ARM_NEON_ZIP2_H)
+#define SIMDE_ARM_NEON_ZIP2_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x2_t
+simde_vzip2_f32(simde_float32x2_t a, simde_float32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_f32(a, b);
+  #else
+    simde_float32x2_private
+      r_,
+      a_ = simde_float32x2_to_private(a),
+      b_ = simde_float32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_float32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_f32
+  #define vzip2_f32(a, b) simde_vzip2_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x8_t
+simde_vzip2_s8(simde_int8x8_t a, simde_int8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_s8(a, b);
+  #else
+    simde_int8x8_private
+      r_,
+      a_ = simde_int8x8_to_private(a),
+      b_ = simde_int8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_s8
+  #define vzip2_s8(a, b) simde_vzip2_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x4_t
+simde_vzip2_s16(simde_int16x4_t a, simde_int16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_s16(a, b);
+  #else
+    simde_int16x4_private
+      r_,
+      a_ = simde_int16x4_to_private(a),
+      b_ = simde_int16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_s16
+  #define vzip2_s16(a, b) simde_vzip2_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x2_t
+simde_vzip2_s32(simde_int32x2_t a, simde_int32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_s32(a, b);
+  #else
+    simde_int32x2_private
+      r_,
+      a_ = simde_int32x2_to_private(a),
+      b_ = simde_int32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_s32
+  #define vzip2_s32(a, b) simde_vzip2_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x8_t
+simde_vzip2_u8(simde_uint8x8_t a, simde_uint8x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_u8(a, b);
+  #else
+    simde_uint8x8_private
+      r_,
+      a_ = simde_uint8x8_to_private(a),
+      b_ = simde_uint8x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint8x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_u8
+  #define vzip2_u8(a, b) simde_vzip2_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x4_t
+simde_vzip2_u16(simde_uint16x4_t a, simde_uint16x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_u16(a, b);
+  #else
+    simde_uint16x4_private
+      r_,
+      a_ = simde_uint16x4_to_private(a),
+      b_ = simde_uint16x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint16x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_u16
+  #define vzip2_u16(a, b) simde_vzip2_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x2_t
+simde_vzip2_u32(simde_uint32x2_t a, simde_uint32x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2_u32(a, b);
+  #else
+    simde_uint32x2_private
+      r_,
+      a_ = simde_uint32x2_to_private(a),
+      b_ = simde_uint32x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint32x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2_u32
+  #define vzip2_u32(a, b) simde_vzip2_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32x4_t
+simde_vzip2q_f32(simde_float32x4_t a, simde_float32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_f32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
+  #else
+    simde_float32x4_private
+      r_,
+      a_ = simde_float32x4_to_private(a),
+      b_ = simde_float32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_float32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_f32
+  #define vzip2q_f32(a, b) simde_vzip2q_f32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64x2_t
+simde_vzip2q_f64(simde_float64x2_t a, simde_float64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_f64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
+  #else
+    simde_float64x2_private
+      r_,
+      a_ = simde_float64x2_to_private(a),
+      b_ = simde_float64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_float64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_f64
+  #define vzip2q_f64(a, b) simde_vzip2q_f64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int8x16_t
+simde_vzip2q_s8(simde_int8x16_t a, simde_int8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_s8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+  #else
+    simde_int8x16_private
+      r_,
+      a_ = simde_int8x16_to_private(a),
+      b_ = simde_int8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_s8
+  #define vzip2q_s8(a, b) simde_vzip2q_s8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int16x8_t
+simde_vzip2q_s16(simde_int16x8_t a, simde_int16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_s16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31);
+  #else
+    simde_int16x8_private
+      r_,
+      a_ = simde_int16x8_to_private(a),
+      b_ = simde_int16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_s16
+  #define vzip2q_s16(a, b) simde_vzip2q_s16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int32x4_t
+simde_vzip2q_s32(simde_int32x4_t a, simde_int32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_s32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
+  #else
+    simde_int32x4_private
+      r_,
+      a_ = simde_int32x4_to_private(a),
+      b_ = simde_int32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_s32
+  #define vzip2q_s32(a, b) simde_vzip2q_s32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_int64x2_t
+simde_vzip2q_s64(simde_int64x2_t a, simde_int64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_s64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
+  #else
+    simde_int64x2_private
+      r_,
+      a_ = simde_int64x2_to_private(a),
+      b_ = simde_int64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_int64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_s64
+  #define vzip2q_s64(a, b) simde_vzip2q_s64((a), (b))
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint8x16_t
+simde_vzip2q_u8(simde_uint8x16_t a, simde_uint8x16_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_u8(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+  #else
+    simde_uint8x16_private
+      r_,
+      a_ = simde_uint8x16_to_private(a),
+      b_ = simde_uint8x16_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint8x16_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_u8
+  #define vzip2q_u8(a, b) simde_vzip2q_u8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint16x8_t
+simde_vzip2q_u16(simde_uint16x8_t a, simde_uint16x8_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_u16(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 24, 25, 10, 11, 26, 27, 12, 13, 28, 29, 14, 15, 30, 31);
+  #else
+    simde_uint16x8_private
+      r_,
+      a_ = simde_uint16x8_to_private(a),
+      b_ = simde_uint16x8_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint16x8_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_u16
+  #define vzip2q_u16(a, b) simde_vzip2q_u16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint32x4_t
+simde_vzip2q_u32(simde_uint32x4_t a, simde_uint32x4_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_u32(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31);
+  #else
+    simde_uint32x4_private
+      r_,
+      a_ = simde_uint32x4_to_private(a),
+      b_ = simde_uint32x4_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint32x4_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_u32
+  #define vzip2q_u32(a, b) simde_vzip2q_u32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_uint64x2_t
+simde_vzip2q_u64(simde_uint64x2_t a, simde_uint64x2_t b) {
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vzip2q_u64(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v8x16_shuffle(a, b,
+                             8, 9, 10, 11, 12, 13, 14, 15, 24, 25, 26, 27, 28, 29, 30, 31);
+  #else
+    simde_uint64x2_private
+      r_,
+      a_ = simde_uint64x2_to_private(a),
+      b_ = simde_uint64x2_to_private(b);
+
+    const size_t halfway_point = sizeof(r_.values) / sizeof(r_.values[0]) / 2;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < halfway_point ; i++) {
+      r_.values[(2 * i)    ] = a_.values[halfway_point + i];
+      r_.values[(2 * i) + 1] = b_.values[halfway_point + i];
+    }
+
+    return simde_uint64x2_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES)
+  #undef vzip2q_u64
+  #define vzip2q_u64(a, b) simde_vzip2q_u64((a), (b))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_ARM_NEON_ZIP2_H) */

--- a/2.0/simde/check.h
+++ b/2.0/simde/check.h
@@ -1,0 +1,276 @@
+/* Check (assertions)
+ * Portable Snippets - https://gitub.com/nemequ/portable-snippets
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ *   To the extent possible under law, the authors have waived all
+ *   copyright and related or neighboring rights to this code.  For
+ *   details, see the Creative Commons Zero 1.0 Universal license at
+ *   https://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#if !defined(SIMDE_CHECK_H)
+#define SIMDE_CHECK_H
+
+#if !defined(SIMDE_NDEBUG) && !defined(SIMDE_DEBUG)
+#  define SIMDE_NDEBUG 1
+#endif
+
+#include "hedley.h"
+#include "simde-diagnostic.h"
+#include <stdint.h>
+
+#if !defined(_WIN32)
+#  define SIMDE_SIZE_MODIFIER "z"
+#  define SIMDE_CHAR_MODIFIER "hh"
+#  define SIMDE_SHORT_MODIFIER "h"
+#else
+#  if defined(_M_X64) || defined(__amd64__)
+#    define SIMDE_SIZE_MODIFIER "I64"
+#  else
+#    define SIMDE_SIZE_MODIFIER ""
+#  endif
+#  define SIMDE_CHAR_MODIFIER ""
+#  define SIMDE_SHORT_MODIFIER ""
+#endif
+
+#if defined(_MSC_VER) &&  (_MSC_VER >= 1500)
+#  define SIMDE_PUSH_DISABLE_MSVC_C4127_ __pragma(warning(push)) __pragma(warning(disable:4127))
+#  define SIMDE_POP_DISABLE_MSVC_C4127_ __pragma(warning(pop))
+#else
+#  define SIMDE_PUSH_DISABLE_MSVC_C4127_
+#  define SIMDE_POP_DISABLE_MSVC_C4127_
+#endif
+
+#if !defined(simde_errorf)
+#  if defined(__has_include)
+#    if __has_include(<stdio.h>)
+#      include <stdio.h>
+#    endif
+#  elif defined(SIMDE_STDC_HOSTED)
+#    if SIMDE_STDC_HOSTED == 1
+#      include <stdio.h>
+#    endif
+#  elif defined(__STDC_HOSTED__)
+#    if __STDC_HOSTETD__ == 1
+#      include <stdio.h>
+#    endif
+#  endif
+
+#  include "debug-trap.h"
+
+   HEDLEY_DIAGNOSTIC_PUSH
+   SIMDE_DIAGNOSTIC_DISABLE_VARIADIC_MACROS_
+#  if defined(EOF)
+#    define simde_errorf(format, ...) (fprintf(stderr, format, __VA_ARGS__), abort())
+#  else
+#    define simde_errorf(format, ...) (simde_trap())
+#  endif
+   HEDLEY_DIAGNOSTIC_POP
+#endif
+
+#define simde_error(msg) simde_errorf("%s", msg)
+
+#if defined(SIMDE_NDEBUG) || \
+    (defined(__cplusplus) && (__cplusplus < 201103L)) || \
+    (defined(__STDC__) && (__STDC__ < 199901L))
+#  if defined(SIMDE_CHECK_FAIL_DEFINED)
+#    define simde_assert(expr)
+#  else
+#    if defined(HEDLEY_ASSUME)
+#      define simde_assert(expr) HEDLEY_ASSUME(expr)
+#    elif HEDLEY_GCC_VERSION_CHECK(4,5,0)
+#      define simde_assert(expr) ((void) (!!(expr) ? 1 : (__builtin_unreachable(), 1)))
+#    elif HEDLEY_MSVC_VERSION_CHECK(13,10,0)
+#      define simde_assert(expr) __assume(expr)
+#    else
+#      define simde_assert(expr)
+#    endif
+#  endif
+#  define simde_assert_true(expr) simde_assert(expr)
+#  define simde_assert_false(expr) simde_assert(!(expr))
+#  define simde_assert_type_full(prefix, suffix, T, fmt, a, op, b) simde_assert(((a) op (b)))
+#  define simde_assert_double_equal(a, b, precision)
+#  define simde_assert_string_equal(a, b)
+#  define simde_assert_string_not_equal(a, b)
+#  define simde_assert_memory_equal(size, a, b)
+#  define simde_assert_memory_not_equal(size, a, b)
+#else
+#  define simde_assert(expr) \
+    do { \
+      if (!HEDLEY_LIKELY(expr)) { \
+        simde_error("assertion failed: " #expr "\n"); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_true(expr) \
+    do { \
+      if (!HEDLEY_LIKELY(expr)) { \
+        simde_error("assertion failed: " #expr " is not true\n"); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_false(expr) \
+    do { \
+      if (!HEDLEY_LIKELY(!(expr))) { \
+        simde_error("assertion failed: " #expr " is not false\n"); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_type_full(prefix, suffix, T, fmt, a, op, b)   \
+    do { \
+      T simde_tmp_a_ = (a); \
+      T simde_tmp_b_ = (b); \
+      if (!(simde_tmp_a_ op simde_tmp_b_)) { \
+        simde_errorf("assertion failed: %s %s %s (" prefix "%" fmt suffix " %s " prefix "%" fmt suffix ")\n", \
+                     #a, #op, #b, simde_tmp_a_, #op, simde_tmp_b_); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_double_equal(a, b, precision) \
+    do { \
+      const double simde_tmp_a_ = (a); \
+      const double simde_tmp_b_ = (b); \
+      const double simde_tmp_diff_ = ((simde_tmp_a_ - simde_tmp_b_) < 0) ? \
+        -(simde_tmp_a_ - simde_tmp_b_) : \
+        (simde_tmp_a_ - simde_tmp_b_); \
+      if (HEDLEY_UNLIKELY(simde_tmp_diff_ > 1e-##precision)) { \
+        simde_errorf("assertion failed: %s == %s (%0." #precision "g == %0." #precision "g)\n", \
+                     #a, #b, simde_tmp_a_, simde_tmp_b_); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  include <string.h>
+#  define simde_assert_string_equal(a, b) \
+    do { \
+      const char* simde_tmp_a_ = a; \
+      const char* simde_tmp_b_ = b; \
+      if (HEDLEY_UNLIKELY(strcmp(simde_tmp_a_, simde_tmp_b_) != 0)) { \
+        simde_errorf("assertion failed: string %s == %s (\"%s\" == \"%s\")\n", \
+                     #a, #b, simde_tmp_a_, simde_tmp_b_); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_string_not_equal(a, b) \
+    do { \
+      const char* simde_tmp_a_ = a; \
+      const char* simde_tmp_b_ = b; \
+      if (HEDLEY_UNLIKELY(strcmp(simde_tmp_a_, simde_tmp_b_) == 0)) { \
+        simde_errorf("assertion failed: string %s != %s (\"%s\" == \"%s\")\n", \
+                     #a, #b, simde_tmp_a_, simde_tmp_b_); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_memory_equal(size, a, b) \
+    do { \
+      const unsigned char* simde_tmp_a_ = (const unsigned char*) (a); \
+      const unsigned char* simde_tmp_b_ = (const unsigned char*) (b); \
+      const size_t simde_tmp_size_ = (size); \
+      if (HEDLEY_UNLIKELY(memcmp(simde_tmp_a_, simde_tmp_b_, simde_tmp_size_)) != 0) { \
+        size_t simde_tmp_pos_; \
+        for (simde_tmp_pos_ = 0 ; simde_tmp_pos_ < simde_tmp_size_ ; simde_tmp_pos_++) { \
+          if (simde_tmp_a_[simde_tmp_pos_] != simde_tmp_b_[simde_tmp_pos_]) { \
+            simde_errorf("assertion failed: memory %s == %s, at offset %" SIMDE_SIZE_MODIFIER "u\n", \
+                         #a, #b, simde_tmp_pos_); \
+            break; \
+          } \
+        } \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+
+#  define simde_assert_memory_not_equal(size, a, b) \
+    do { \
+      const unsigned char* simde_tmp_a_ = (const unsigned char*) (a); \
+      const unsigned char* simde_tmp_b_ = (const unsigned char*) (b); \
+      const size_t simde_tmp_size_ = (size); \
+      if (HEDLEY_UNLIKELY(memcmp(simde_tmp_a_, simde_tmp_b_, simde_tmp_size_)) == 0) { \
+        simde_errorf("assertion failed: memory %s != %s (%" SIMDE_SIZE_MODIFIER "u bytes)\n", \
+                     #a, #b, simde_tmp_size_); \
+      } \
+      SIMDE_PUSH_DISABLE_MSVC_C4127_ \
+    } while (0) \
+    SIMDE_POP_DISABLE_MSVC_C4127_
+#endif
+
+#define simde_assert_type(T, fmt, a, op, b) \
+  simde_assert_type_full("", "", T, fmt, a, op, b)
+
+#define simde_assert_char(a, op, b) \
+  simde_assert_type_full("'\\x", "'", char, "02" SIMDE_CHAR_MODIFIER "x", a, op, b)
+#define simde_assert_uchar(a, op, b) \
+  simde_assert_type_full("'\\x", "'", unsigned char, "02" SIMDE_CHAR_MODIFIER "x", a, op, b)
+#define simde_assert_short(a, op, b) \
+  simde_assert_type(short, SIMDE_SHORT_MODIFIER "d", a, op, b)
+#define simde_assert_ushort(a, op, b) \
+  simde_assert_type(unsigned short, SIMDE_SHORT_MODIFIER "u", a, op, b)
+#define simde_assert_int(a, op, b) \
+  simde_assert_type(int, "d", a, op, b)
+#define simde_assert_uint(a, op, b) \
+  simde_assert_type(unsigned int, "u", a, op, b)
+#define simde_assert_long(a, op, b) \
+  simde_assert_type(long int, "ld", a, op, b)
+#define simde_assert_ulong(a, op, b) \
+  simde_assert_type(unsigned long int, "lu", a, op, b)
+#define simde_assert_llong(a, op, b) \
+  simde_assert_type(long long int, "lld", a, op, b)
+#define simde_assert_ullong(a, op, b) \
+  simde_assert_type(unsigned long long int, "llu", a, op, b)
+
+#define simde_assert_size(a, op, b) \
+  simde_assert_type(size_t, SIMDE_SIZE_MODIFIER "u", a, op, b)
+
+#define simde_assert_float(a, op, b) \
+  simde_assert_type(float, "f", a, op, b)
+#define simde_assert_double(a, op, b) \
+  simde_assert_type(double, "g", a, op, b)
+#define simde_assert_ptr(a, op, b) \
+  simde_assert_type(const void*, "p", a, op, b)
+
+#define simde_assert_int8(a, op, b) \
+  simde_assert_type(int8_t, PRIi8, a, op, b)
+#define simde_assert_uint8(a, op, b) \
+  simde_assert_type(uint8_t, PRIu8, a, op, b)
+#define simde_assert_int16(a, op, b) \
+  simde_assert_type(int16_t, PRIi16, a, op, b)
+#define simde_assert_uint16(a, op, b) \
+  simde_assert_type(uint16_t, PRIu16, a, op, b)
+#define simde_assert_int32(a, op, b) \
+  simde_assert_type(int32_t, PRIi32, a, op, b)
+#define simde_assert_uint32(a, op, b) \
+  simde_assert_type(uint32_t, PRIu32, a, op, b)
+#define simde_assert_int64(a, op, b) \
+  simde_assert_type(int64_t, PRIi64, a, op, b)
+#define simde_assert_uint64(a, op, b) \
+  simde_assert_type(uint64_t, PRIu64, a, op, b)
+
+#define simde_assert_ptr_equal(a, b) \
+  simde_assert_ptr(a, ==, b)
+#define simde_assert_ptr_not_equal(a, b) \
+  simde_assert_ptr(a, !=, b)
+#define simde_assert_null(ptr) \
+  simde_assert_ptr(ptr, ==, NULL)
+#define simde_assert_not_null(ptr) \
+  simde_assert_ptr(ptr, !=, NULL)
+#define simde_assert_ptr_null(ptr) \
+  simde_assert_ptr(ptr, ==, NULL)
+#define simde_assert_ptr_not_null(ptr) \
+  simde_assert_ptr(ptr, !=, NULL)
+
+#endif /* !defined(SIMDE_CHECK_H) */

--- a/2.0/simde/debug-trap.h
+++ b/2.0/simde/debug-trap.h
@@ -1,0 +1,85 @@
+/* Debugging assertions and traps
+ * Portable Snippets - https://gitub.com/nemequ/portable-snippets
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ *   To the extent possible under law, the authors have waived all
+ *   copyright and related or neighboring rights to this code.  For
+ *   details, see the Creative Commons Zero 1.0 Universal license at
+ *   https://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#if !defined(SIMDE_DEBUG_TRAP_H)
+#define SIMDE_DEBUG_TRAP_H
+
+#if !defined(SIMDE_NDEBUG) && defined(NDEBUG) && !defined(SIMDE_DEBUG)
+#  define SIMDE_NDEBUG 1
+#endif
+
+#if defined(__has_builtin) && !defined(__ibmxl__)
+#  if __has_builtin(__builtin_debugtrap)
+#    define simde_trap() __builtin_debugtrap()
+#  elif __has_builtin(__debugbreak)
+#    define simde_trap() __debugbreak()
+#  endif
+#endif
+#if !defined(simde_trap)
+#  if defined(_MSC_VER) || defined(__INTEL_COMPILER)
+#    define simde_trap() __debugbreak()
+#  elif defined(__ARMCC_VERSION)
+#    define simde_trap() __breakpoint(42)
+#  elif defined(__ibmxl__) || defined(__xlC__)
+#    include <builtins.h>
+#    define simde_trap() __trap(42)
+#  elif defined(__DMC__) && defined(_M_IX86)
+     static inline void simde_trap(void) { __asm int 3h; }
+#  elif defined(__i386__) || defined(__x86_64__)
+     static inline void simde_trap(void) { __asm__ __volatile__("int $03"); }
+#  elif defined(__thumb__)
+     static inline void simde_trap(void) { __asm__ __volatile__(".inst 0xde01"); }
+#  elif defined(__aarch64__)
+     static inline void simde_trap(void) { __asm__ __volatile__(".inst 0xd4200000"); }
+#  elif defined(__arm__)
+     static inline void simde_trap(void) { __asm__ __volatile__(".inst 0xe7f001f0"); }
+#  elif defined (__alpha__) && !defined(__osf__)
+     static inline void simde_trap(void) { __asm__ __volatile__("bpt"); }
+#  elif defined(_54_)
+     static inline void simde_trap(void) { __asm__ __volatile__("ESTOP"); }
+#  elif defined(_55_)
+     static inline void simde_trap(void) { __asm__ __volatile__(";\n .if (.MNEMONIC)\n ESTOP_1\n .else\n ESTOP_1()\n .endif\n NOP"); }
+#  elif defined(_64P_)
+     static inline void simde_trap(void) { __asm__ __volatile__("SWBP 0"); }
+#  elif defined(_6x_)
+     static inline void simde_trap(void) { __asm__ __volatile__("NOP\n .word 0x10000000"); }
+#  elif defined(__STDC_HOSTED__) && (__STDC_HOSTED__ == 0) && defined(__GNUC__)
+#    define simde_trap() __builtin_trap()
+#  else
+#    include <signal.h>
+#    if defined(SIGTRAP)
+#      define simde_trap() raise(SIGTRAP)
+#    else
+#      define simde_trap() raise(SIGABRT)
+#    endif
+#  endif
+#endif
+
+#if defined(HEDLEY_LIKELY)
+#  define SIMDE_DBG_LIKELY(expr) HEDLEY_LIKELY(expr)
+#elif defined(__GNUC__) && (__GNUC__ >= 3)
+#  define SIMDE_DBG_LIKELY(expr) __builtin_expect(!!(expr), 1)
+#else
+#  define SIMDE_DBG_LIKELY(expr) (!!(expr))
+#endif
+
+#if !defined(SIMDE_NDEBUG) || (SIMDE_NDEBUG == 0)
+#  define simde_dbg_assert(expr) do { \
+    if (!SIMDE_DBG_LIKELY(expr)) { \
+      simde_trap(); \
+    } \
+  } while (0)
+#else
+#  define simde_dbg_assert(expr)
+#endif
+
+#endif /* !defined(SIMDE_DEBUG_TRAP_H) */

--- a/2.0/simde/hedley.h
+++ b/2.0/simde/hedley.h
@@ -1,0 +1,1971 @@
+/* Hedley - https://nemequ.github.io/hedley
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to
+ * the public domain worldwide. This software is distributed without
+ * any warranty.
+ *
+ * For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+#if !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < 14)
+#if defined(HEDLEY_VERSION)
+#  undef HEDLEY_VERSION
+#endif
+#define HEDLEY_VERSION 14
+
+#if defined(HEDLEY_STRINGIFY_EX)
+#  undef HEDLEY_STRINGIFY_EX
+#endif
+#define HEDLEY_STRINGIFY_EX(x) #x
+
+#if defined(HEDLEY_STRINGIFY)
+#  undef HEDLEY_STRINGIFY
+#endif
+#define HEDLEY_STRINGIFY(x) HEDLEY_STRINGIFY_EX(x)
+
+#if defined(HEDLEY_CONCAT_EX)
+#  undef HEDLEY_CONCAT_EX
+#endif
+#define HEDLEY_CONCAT_EX(a,b) a##b
+
+#if defined(HEDLEY_CONCAT)
+#  undef HEDLEY_CONCAT
+#endif
+#define HEDLEY_CONCAT(a,b) HEDLEY_CONCAT_EX(a,b)
+
+#if defined(HEDLEY_CONCAT3_EX)
+#  undef HEDLEY_CONCAT3_EX
+#endif
+#define HEDLEY_CONCAT3_EX(a,b,c) a##b##c
+
+#if defined(HEDLEY_CONCAT3)
+#  undef HEDLEY_CONCAT3
+#endif
+#define HEDLEY_CONCAT3(a,b,c) HEDLEY_CONCAT3_EX(a,b,c)
+
+#if defined(HEDLEY_VERSION_ENCODE)
+#  undef HEDLEY_VERSION_ENCODE
+#endif
+#define HEDLEY_VERSION_ENCODE(major,minor,revision) (((major) * 1000000) + ((minor) * 1000) + (revision))
+
+#if defined(HEDLEY_VERSION_DECODE_MAJOR)
+#  undef HEDLEY_VERSION_DECODE_MAJOR
+#endif
+#define HEDLEY_VERSION_DECODE_MAJOR(version) ((version) / 1000000)
+
+#if defined(HEDLEY_VERSION_DECODE_MINOR)
+#  undef HEDLEY_VERSION_DECODE_MINOR
+#endif
+#define HEDLEY_VERSION_DECODE_MINOR(version) (((version) % 1000000) / 1000)
+
+#if defined(HEDLEY_VERSION_DECODE_REVISION)
+#  undef HEDLEY_VERSION_DECODE_REVISION
+#endif
+#define HEDLEY_VERSION_DECODE_REVISION(version) ((version) % 1000)
+
+#if defined(HEDLEY_GNUC_VERSION)
+#  undef HEDLEY_GNUC_VERSION
+#endif
+#if defined(__GNUC__) && defined(__GNUC_PATCHLEVEL__)
+#  define HEDLEY_GNUC_VERSION HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__)
+#elif defined(__GNUC__)
+#  define HEDLEY_GNUC_VERSION HEDLEY_VERSION_ENCODE(__GNUC__, __GNUC_MINOR__, 0)
+#endif
+
+#if defined(HEDLEY_GNUC_VERSION_CHECK)
+#  undef HEDLEY_GNUC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_GNUC_VERSION)
+#  define HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (HEDLEY_GNUC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_GNUC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION)
+#  undef HEDLEY_MSVC_VERSION
+#endif
+#if defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 140000000) && !defined(__ICL)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 10000000, (_MSC_FULL_VER % 10000000) / 100000, (_MSC_FULL_VER % 100000) / 100)
+#elif defined(_MSC_FULL_VER) && !defined(__ICL)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_FULL_VER / 1000000, (_MSC_FULL_VER % 1000000) / 10000, (_MSC_FULL_VER % 10000) / 10)
+#elif defined(_MSC_VER) && !defined(__ICL)
+#  define HEDLEY_MSVC_VERSION HEDLEY_VERSION_ENCODE(_MSC_VER / 100, _MSC_VER % 100, 0)
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION_CHECK)
+#  undef HEDLEY_MSVC_VERSION_CHECK
+#endif
+#if !defined(HEDLEY_MSVC_VERSION)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (0)
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 10000000) + (minor * 100000) + (patch)))
+#elif defined(_MSC_VER) && (_MSC_VER >= 1200)
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_FULL_VER >= ((major * 1000000) + (minor * 10000) + (patch)))
+#else
+#  define HEDLEY_MSVC_VERSION_CHECK(major,minor,patch) (_MSC_VER >= ((major * 100) + (minor)))
+#endif
+
+#if defined(HEDLEY_INTEL_VERSION)
+#  undef HEDLEY_INTEL_VERSION
+#endif
+#if defined(__INTEL_COMPILER) && defined(__INTEL_COMPILER_UPDATE) && !defined(__ICL)
+#  define HEDLEY_INTEL_VERSION HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, __INTEL_COMPILER_UPDATE)
+#elif defined(__INTEL_COMPILER) && !defined(__ICL)
+#  define HEDLEY_INTEL_VERSION HEDLEY_VERSION_ENCODE(__INTEL_COMPILER / 100, __INTEL_COMPILER % 100, 0)
+#endif
+
+#if defined(HEDLEY_INTEL_VERSION_CHECK)
+#  undef HEDLEY_INTEL_VERSION_CHECK
+#endif
+#if defined(HEDLEY_INTEL_VERSION)
+#  define HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (HEDLEY_INTEL_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_INTEL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_INTEL_CL_VERSION)
+#  undef HEDLEY_INTEL_CL_VERSION
+#endif
+#if defined(__INTEL_COMPILER) && defined(__INTEL_COMPILER_UPDATE) && defined(__ICL)
+#  define HEDLEY_INTEL_CL_VERSION HEDLEY_VERSION_ENCODE(__INTEL_COMPILER, __INTEL_COMPILER_UPDATE, 0)
+#endif
+
+#if defined(HEDLEY_INTEL_CL_VERSION_CHECK)
+#  undef HEDLEY_INTEL_CL_VERSION_CHECK
+#endif
+#if defined(HEDLEY_INTEL_CL_VERSION)
+#  define HEDLEY_INTEL_CL_VERSION_CHECK(major,minor,patch) (HEDLEY_INTEL_CL_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_INTEL_CL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_PGI_VERSION)
+#  undef HEDLEY_PGI_VERSION
+#endif
+#if defined(__PGI) && defined(__PGIC__) && defined(__PGIC_MINOR__) && defined(__PGIC_PATCHLEVEL__)
+#  define HEDLEY_PGI_VERSION HEDLEY_VERSION_ENCODE(__PGIC__, __PGIC_MINOR__, __PGIC_PATCHLEVEL__)
+#endif
+
+#if defined(HEDLEY_PGI_VERSION_CHECK)
+#  undef HEDLEY_PGI_VERSION_CHECK
+#endif
+#if defined(HEDLEY_PGI_VERSION)
+#  define HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (HEDLEY_PGI_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_PGI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_SUNPRO_VERSION)
+#  undef HEDLEY_SUNPRO_VERSION
+#endif
+#if defined(__SUNPRO_C) && (__SUNPRO_C > 0x1000)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((((__SUNPRO_C >> 16) & 0xf) * 10) + ((__SUNPRO_C >> 12) & 0xf), (((__SUNPRO_C >> 8) & 0xf) * 10) + ((__SUNPRO_C >> 4) & 0xf), (__SUNPRO_C & 0xf) * 10)
+#elif defined(__SUNPRO_C)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((__SUNPRO_C >> 8) & 0xf, (__SUNPRO_C >> 4) & 0xf, (__SUNPRO_C) & 0xf)
+#elif defined(__SUNPRO_CC) && (__SUNPRO_CC > 0x1000)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((((__SUNPRO_CC >> 16) & 0xf) * 10) + ((__SUNPRO_CC >> 12) & 0xf), (((__SUNPRO_CC >> 8) & 0xf) * 10) + ((__SUNPRO_CC >> 4) & 0xf), (__SUNPRO_CC & 0xf) * 10)
+#elif defined(__SUNPRO_CC)
+#  define HEDLEY_SUNPRO_VERSION HEDLEY_VERSION_ENCODE((__SUNPRO_CC >> 8) & 0xf, (__SUNPRO_CC >> 4) & 0xf, (__SUNPRO_CC) & 0xf)
+#endif
+
+#if defined(HEDLEY_SUNPRO_VERSION_CHECK)
+#  undef HEDLEY_SUNPRO_VERSION_CHECK
+#endif
+#if defined(HEDLEY_SUNPRO_VERSION)
+#  define HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (HEDLEY_SUNPRO_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_SUNPRO_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_EMSCRIPTEN_VERSION)
+#  undef HEDLEY_EMSCRIPTEN_VERSION
+#endif
+#if defined(__EMSCRIPTEN__)
+#  define HEDLEY_EMSCRIPTEN_VERSION HEDLEY_VERSION_ENCODE(__EMSCRIPTEN_major__, __EMSCRIPTEN_minor__, __EMSCRIPTEN_tiny__)
+#endif
+
+#if defined(HEDLEY_EMSCRIPTEN_VERSION_CHECK)
+#  undef HEDLEY_EMSCRIPTEN_VERSION_CHECK
+#endif
+#if defined(HEDLEY_EMSCRIPTEN_VERSION)
+#  define HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (HEDLEY_EMSCRIPTEN_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_EMSCRIPTEN_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_ARM_VERSION)
+#  undef HEDLEY_ARM_VERSION
+#endif
+#if defined(__CC_ARM) && defined(__ARMCOMPILER_VERSION)
+#  define HEDLEY_ARM_VERSION HEDLEY_VERSION_ENCODE(__ARMCOMPILER_VERSION / 1000000, (__ARMCOMPILER_VERSION % 1000000) / 10000, (__ARMCOMPILER_VERSION % 10000) / 100)
+#elif defined(__CC_ARM) && defined(__ARMCC_VERSION)
+#  define HEDLEY_ARM_VERSION HEDLEY_VERSION_ENCODE(__ARMCC_VERSION / 1000000, (__ARMCC_VERSION % 1000000) / 10000, (__ARMCC_VERSION % 10000) / 100)
+#endif
+
+#if defined(HEDLEY_ARM_VERSION_CHECK)
+#  undef HEDLEY_ARM_VERSION_CHECK
+#endif
+#if defined(HEDLEY_ARM_VERSION)
+#  define HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (HEDLEY_ARM_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_ARM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_IBM_VERSION)
+#  undef HEDLEY_IBM_VERSION
+#endif
+#if defined(__ibmxl__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__ibmxl_version__, __ibmxl_release__, __ibmxl_modification__)
+#elif defined(__xlC__) && defined(__xlC_ver__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, (__xlC_ver__ >> 8) & 0xff)
+#elif defined(__xlC__)
+#  define HEDLEY_IBM_VERSION HEDLEY_VERSION_ENCODE(__xlC__ >> 8, __xlC__ & 0xff, 0)
+#endif
+
+#if defined(HEDLEY_IBM_VERSION_CHECK)
+#  undef HEDLEY_IBM_VERSION_CHECK
+#endif
+#if defined(HEDLEY_IBM_VERSION)
+#  define HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (HEDLEY_IBM_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_IBM_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_VERSION)
+#  undef HEDLEY_TI_VERSION
+#endif
+#if \
+    defined(__TI_COMPILER_VERSION__) && \
+    ( \
+      defined(__TMS470__) || defined(__TI_ARM__) || \
+      defined(__MSP430__) || \
+      defined(__TMS320C2000__) \
+    )
+#  if (__TI_COMPILER_VERSION__ >= 16000000)
+#    define HEDLEY_TI_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#  endif
+#endif
+
+#if defined(HEDLEY_TI_VERSION_CHECK)
+#  undef HEDLEY_TI_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_VERSION)
+#  define HEDLEY_TI_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_CL2000_VERSION)
+#  undef HEDLEY_TI_CL2000_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__TMS320C2000__)
+#  define HEDLEY_TI_CL2000_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_CL2000_VERSION_CHECK)
+#  undef HEDLEY_TI_CL2000_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_CL2000_VERSION)
+#  define HEDLEY_TI_CL2000_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_CL2000_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_CL2000_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_CL430_VERSION)
+#  undef HEDLEY_TI_CL430_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__MSP430__)
+#  define HEDLEY_TI_CL430_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_CL430_VERSION_CHECK)
+#  undef HEDLEY_TI_CL430_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_CL430_VERSION)
+#  define HEDLEY_TI_CL430_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_CL430_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_CL430_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_ARMCL_VERSION)
+#  undef HEDLEY_TI_ARMCL_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && (defined(__TMS470__) || defined(__TI_ARM__))
+#  define HEDLEY_TI_ARMCL_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_ARMCL_VERSION_CHECK)
+#  undef HEDLEY_TI_ARMCL_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_ARMCL_VERSION)
+#  define HEDLEY_TI_ARMCL_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_ARMCL_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_ARMCL_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_CL6X_VERSION)
+#  undef HEDLEY_TI_CL6X_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__TMS320C6X__)
+#  define HEDLEY_TI_CL6X_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_CL6X_VERSION_CHECK)
+#  undef HEDLEY_TI_CL6X_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_CL6X_VERSION)
+#  define HEDLEY_TI_CL6X_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_CL6X_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_CL6X_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_CL7X_VERSION)
+#  undef HEDLEY_TI_CL7X_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__C7000__)
+#  define HEDLEY_TI_CL7X_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_CL7X_VERSION_CHECK)
+#  undef HEDLEY_TI_CL7X_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_CL7X_VERSION)
+#  define HEDLEY_TI_CL7X_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_CL7X_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_CL7X_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TI_CLPRU_VERSION)
+#  undef HEDLEY_TI_CLPRU_VERSION
+#endif
+#if defined(__TI_COMPILER_VERSION__) && defined(__PRU__)
+#  define HEDLEY_TI_CLPRU_VERSION HEDLEY_VERSION_ENCODE(__TI_COMPILER_VERSION__ / 1000000, (__TI_COMPILER_VERSION__ % 1000000) / 1000, (__TI_COMPILER_VERSION__ % 1000))
+#endif
+
+#if defined(HEDLEY_TI_CLPRU_VERSION_CHECK)
+#  undef HEDLEY_TI_CLPRU_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TI_CLPRU_VERSION)
+#  define HEDLEY_TI_CLPRU_VERSION_CHECK(major,minor,patch) (HEDLEY_TI_CLPRU_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TI_CLPRU_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_CRAY_VERSION)
+#  undef HEDLEY_CRAY_VERSION
+#endif
+#if defined(_CRAYC)
+#  if defined(_RELEASE_PATCHLEVEL)
+#    define HEDLEY_CRAY_VERSION HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, _RELEASE_PATCHLEVEL)
+#  else
+#    define HEDLEY_CRAY_VERSION HEDLEY_VERSION_ENCODE(_RELEASE_MAJOR, _RELEASE_MINOR, 0)
+#  endif
+#endif
+
+#if defined(HEDLEY_CRAY_VERSION_CHECK)
+#  undef HEDLEY_CRAY_VERSION_CHECK
+#endif
+#if defined(HEDLEY_CRAY_VERSION)
+#  define HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (HEDLEY_CRAY_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_CRAY_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_IAR_VERSION)
+#  undef HEDLEY_IAR_VERSION
+#endif
+#if defined(__IAR_SYSTEMS_ICC__)
+#  if __VER__ > 1000
+#    define HEDLEY_IAR_VERSION HEDLEY_VERSION_ENCODE((__VER__ / 1000000), ((__VER__ / 1000) % 1000), (__VER__ % 1000))
+#  else
+#    define HEDLEY_IAR_VERSION HEDLEY_VERSION_ENCODE(VER / 100, __VER__ % 100, 0)
+#  endif
+#endif
+
+#if defined(HEDLEY_IAR_VERSION_CHECK)
+#  undef HEDLEY_IAR_VERSION_CHECK
+#endif
+#if defined(HEDLEY_IAR_VERSION)
+#  define HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (HEDLEY_IAR_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_IAR_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_TINYC_VERSION)
+#  undef HEDLEY_TINYC_VERSION
+#endif
+#if defined(__TINYC__)
+#  define HEDLEY_TINYC_VERSION HEDLEY_VERSION_ENCODE(__TINYC__ / 1000, (__TINYC__ / 100) % 10, __TINYC__ % 100)
+#endif
+
+#if defined(HEDLEY_TINYC_VERSION_CHECK)
+#  undef HEDLEY_TINYC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_TINYC_VERSION)
+#  define HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (HEDLEY_TINYC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_TINYC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_DMC_VERSION)
+#  undef HEDLEY_DMC_VERSION
+#endif
+#if defined(__DMC__)
+#  define HEDLEY_DMC_VERSION HEDLEY_VERSION_ENCODE(__DMC__ >> 8, (__DMC__ >> 4) & 0xf, __DMC__ & 0xf)
+#endif
+
+#if defined(HEDLEY_DMC_VERSION_CHECK)
+#  undef HEDLEY_DMC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_DMC_VERSION)
+#  define HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (HEDLEY_DMC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_DMC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_COMPCERT_VERSION)
+#  undef HEDLEY_COMPCERT_VERSION
+#endif
+#if defined(__COMPCERT_VERSION__)
+#  define HEDLEY_COMPCERT_VERSION HEDLEY_VERSION_ENCODE(__COMPCERT_VERSION__ / 10000, (__COMPCERT_VERSION__ / 100) % 100, __COMPCERT_VERSION__ % 100)
+#endif
+
+#if defined(HEDLEY_COMPCERT_VERSION_CHECK)
+#  undef HEDLEY_COMPCERT_VERSION_CHECK
+#endif
+#if defined(HEDLEY_COMPCERT_VERSION)
+#  define HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (HEDLEY_COMPCERT_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_COMPCERT_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_PELLES_VERSION)
+#  undef HEDLEY_PELLES_VERSION
+#endif
+#if defined(__POCC__)
+#  define HEDLEY_PELLES_VERSION HEDLEY_VERSION_ENCODE(__POCC__ / 100, __POCC__ % 100, 0)
+#endif
+
+#if defined(HEDLEY_PELLES_VERSION_CHECK)
+#  undef HEDLEY_PELLES_VERSION_CHECK
+#endif
+#if defined(HEDLEY_PELLES_VERSION)
+#  define HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (HEDLEY_PELLES_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_PELLES_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_GCC_VERSION)
+#  undef HEDLEY_GCC_VERSION
+#endif
+#if \
+  defined(HEDLEY_GNUC_VERSION) && \
+  !defined(__clang__) && \
+  !defined(HEDLEY_INTEL_VERSION) && \
+  !defined(HEDLEY_PGI_VERSION) && \
+  !defined(HEDLEY_ARM_VERSION) && \
+  !defined(HEDLEY_TI_VERSION) && \
+  !defined(HEDLEY_TI_ARMCL_VERSION) && \
+  !defined(HEDLEY_TI_CL430_VERSION) && \
+  !defined(HEDLEY_TI_CL2000_VERSION) && \
+  !defined(HEDLEY_TI_CL6X_VERSION) && \
+  !defined(HEDLEY_TI_CL7X_VERSION) && \
+  !defined(HEDLEY_TI_CLPRU_VERSION) && \
+  !defined(__COMPCERT__)
+#  define HEDLEY_GCC_VERSION HEDLEY_GNUC_VERSION
+#endif
+
+#if defined(HEDLEY_GCC_VERSION_CHECK)
+#  undef HEDLEY_GCC_VERSION_CHECK
+#endif
+#if defined(HEDLEY_GCC_VERSION)
+#  define HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (HEDLEY_GCC_VERSION >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+#else
+#  define HEDLEY_GCC_VERSION_CHECK(major,minor,patch) (0)
+#endif
+
+#if defined(HEDLEY_HAS_ATTRIBUTE)
+#  undef HEDLEY_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_HAS_ATTRIBUTE(attribute) __has_attribute(attribute)
+#else
+#  define HEDLEY_HAS_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) __has_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_ATTRIBUTE
+#endif
+#if defined(__has_attribute)
+#  define HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) __has_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_HAS_CPP_ATTRIBUTE
+#endif
+#if \
+  defined(__has_cpp_attribute) && \
+  defined(__cplusplus) && \
+  (!defined(HEDLEY_SUNPRO_VERSION) || HEDLEY_SUNPRO_VERSION_CHECK(5,15,0))
+#  define HEDLEY_HAS_CPP_ATTRIBUTE(attribute) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_HAS_CPP_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_HAS_CPP_ATTRIBUTE_NS)
+#  undef HEDLEY_HAS_CPP_ATTRIBUTE_NS
+#endif
+#if !defined(__cplusplus) || !defined(__has_cpp_attribute)
+#  define HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) (0)
+#elif \
+  !defined(HEDLEY_PGI_VERSION) && \
+  !defined(HEDLEY_IAR_VERSION) && \
+  (!defined(HEDLEY_SUNPRO_VERSION) || HEDLEY_SUNPRO_VERSION_CHECK(5,15,0)) && \
+  (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,20,0))
+#  define HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) HEDLEY_HAS_CPP_ATTRIBUTE(ns::attribute)
+#else
+#  define HEDLEY_HAS_CPP_ATTRIBUTE_NS(ns,attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+#  define HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_CPP_ATTRIBUTE
+#endif
+#if defined(__has_cpp_attribute) && defined(__cplusplus)
+#  define HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) __has_cpp_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_CPP_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_BUILTIN)
+#  undef HEDLEY_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_HAS_BUILTIN(builtin) __has_builtin(builtin)
+#else
+#  define HEDLEY_HAS_BUILTIN(builtin) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_BUILTIN)
+#  undef HEDLEY_GNUC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+#  define HEDLEY_GNUC_HAS_BUILTIN(builtin,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_BUILTIN)
+#  undef HEDLEY_GCC_HAS_BUILTIN
+#endif
+#if defined(__has_builtin)
+#  define HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) __has_builtin(builtin)
+#else
+#  define HEDLEY_GCC_HAS_BUILTIN(builtin,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_FEATURE)
+#  undef HEDLEY_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_HAS_FEATURE(feature) __has_feature(feature)
+#else
+#  define HEDLEY_HAS_FEATURE(feature) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_FEATURE)
+#  undef HEDLEY_GNUC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+#  define HEDLEY_GNUC_HAS_FEATURE(feature,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_FEATURE)
+#  undef HEDLEY_GCC_HAS_FEATURE
+#endif
+#if defined(__has_feature)
+#  define HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) __has_feature(feature)
+#else
+#  define HEDLEY_GCC_HAS_FEATURE(feature,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_EXTENSION)
+#  undef HEDLEY_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_HAS_EXTENSION(extension) __has_extension(extension)
+#else
+#  define HEDLEY_HAS_EXTENSION(extension) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_EXTENSION)
+#  undef HEDLEY_GNUC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+#  define HEDLEY_GNUC_HAS_EXTENSION(extension,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_EXTENSION)
+#  undef HEDLEY_GCC_HAS_EXTENSION
+#endif
+#if defined(__has_extension)
+#  define HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) __has_extension(extension)
+#else
+#  define HEDLEY_GCC_HAS_EXTENSION(extension,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_GNUC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE
+#endif
+#if defined(__has_declspec_attribute)
+#  define HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) __has_declspec_attribute(attribute)
+#else
+#  define HEDLEY_GCC_HAS_DECLSPEC_ATTRIBUTE(attribute,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_HAS_WARNING)
+#  undef HEDLEY_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_HAS_WARNING(warning) __has_warning(warning)
+#else
+#  define HEDLEY_HAS_WARNING(warning) (0)
+#endif
+
+#if defined(HEDLEY_GNUC_HAS_WARNING)
+#  undef HEDLEY_GNUC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+#  define HEDLEY_GNUC_HAS_WARNING(warning,major,minor,patch) HEDLEY_GNUC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_GCC_HAS_WARNING)
+#  undef HEDLEY_GCC_HAS_WARNING
+#endif
+#if defined(__has_warning)
+#  define HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) __has_warning(warning)
+#else
+#  define HEDLEY_GCC_HAS_WARNING(warning,major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if \
+  (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+  defined(__clang__) || \
+  HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+  HEDLEY_PGI_VERSION_CHECK(18,4,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(4,7,0) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(2,0,1) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,1,0) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,0,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  HEDLEY_CRAY_VERSION_CHECK(5,0,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,17) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(8,0,0) || \
+  (HEDLEY_IBM_VERSION_CHECK(10,1,0) && defined(__C99_PRAGMA_OPERATOR))
+#  define HEDLEY_PRAGMA(value) _Pragma(#value)
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_PRAGMA(value) __pragma(value)
+#else
+#  define HEDLEY_PRAGMA(value)
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_PUSH)
+#  undef HEDLEY_DIAGNOSTIC_PUSH
+#endif
+#if defined(HEDLEY_DIAGNOSTIC_POP)
+#  undef HEDLEY_DIAGNOSTIC_POP
+#endif
+#if defined(__clang__)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#elif HEDLEY_GCC_VERSION_CHECK(4,6,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(15,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH __pragma(warning(push))
+#  define HEDLEY_DIAGNOSTIC_POP __pragma(warning(pop))
+#elif HEDLEY_ARM_VERSION_CHECK(5,6,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("pop")
+#elif \
+    HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    HEDLEY_TI_CL430_VERSION_CHECK(4,4,0) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(8,1,0) || \
+    HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("diag_push")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("diag_pop")
+#elif HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+#  define HEDLEY_DIAGNOSTIC_PUSH _Pragma("warning(push)")
+#  define HEDLEY_DIAGNOSTIC_POP _Pragma("warning(pop)")
+#else
+#  define HEDLEY_DIAGNOSTIC_PUSH
+#  define HEDLEY_DIAGNOSTIC_POP
+#endif
+
+/* HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_ is for
+   HEDLEY INTERNAL USE ONLY.  API subject to change without notice. */
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_
+#endif
+#if defined(__cplusplus)
+#  if HEDLEY_HAS_WARNING("-Wc++98-compat")
+#    if HEDLEY_HAS_WARNING("-Wc++17-extensions")
+#      if HEDLEY_HAS_WARNING("-Wc++1z-extensions")
+#        define HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+           HEDLEY_DIAGNOSTIC_PUSH \
+           _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+           _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"") \
+           _Pragma("clang diagnostic ignored \"-Wc++1z-extensions\"") \
+           xpr \
+           HEDLEY_DIAGNOSTIC_POP
+#      else
+#        define HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+           HEDLEY_DIAGNOSTIC_PUSH \
+           _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+           _Pragma("clang diagnostic ignored \"-Wc++17-extensions\"") \
+           xpr \
+           HEDLEY_DIAGNOSTIC_POP
+#      endif
+#    else
+#      define HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(xpr) \
+         HEDLEY_DIAGNOSTIC_PUSH \
+         _Pragma("clang diagnostic ignored \"-Wc++98-compat\"") \
+         xpr \
+         HEDLEY_DIAGNOSTIC_POP
+#    endif
+#  endif
+#endif
+#if !defined(HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(x) x
+#endif
+
+#if defined(HEDLEY_CONST_CAST)
+#  undef HEDLEY_CONST_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_CONST_CAST(T, expr) (const_cast<T>(expr))
+#elif \
+  HEDLEY_HAS_WARNING("-Wcast-qual") || \
+  HEDLEY_GCC_VERSION_CHECK(4,6,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_CONST_CAST(T, expr) (__extension__ ({ \
+      HEDLEY_DIAGNOSTIC_PUSH \
+      HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL \
+      ((T) (expr)); \
+      HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define HEDLEY_CONST_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(HEDLEY_REINTERPRET_CAST)
+#  undef HEDLEY_REINTERPRET_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_REINTERPRET_CAST(T, expr) (reinterpret_cast<T>(expr))
+#else
+#  define HEDLEY_REINTERPRET_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(HEDLEY_STATIC_CAST)
+#  undef HEDLEY_STATIC_CAST
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_STATIC_CAST(T, expr) (static_cast<T>(expr))
+#else
+#  define HEDLEY_STATIC_CAST(T, expr) ((T) (expr))
+#endif
+
+#if defined(HEDLEY_CPP_CAST)
+#  undef HEDLEY_CPP_CAST
+#endif
+#if defined(__cplusplus)
+#  if HEDLEY_HAS_WARNING("-Wold-style-cast")
+#    define HEDLEY_CPP_CAST(T, expr) \
+       HEDLEY_DIAGNOSTIC_PUSH \
+       _Pragma("clang diagnostic ignored \"-Wold-style-cast\"") \
+       ((T) (expr)) \
+       HEDLEY_DIAGNOSTIC_POP
+#  elif HEDLEY_IAR_VERSION_CHECK(8,3,0)
+#    define HEDLEY_CPP_CAST(T, expr) \
+       HEDLEY_DIAGNOSTIC_PUSH \
+       _Pragma("diag_suppress=Pe137") \
+       HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define HEDLEY_CPP_CAST(T, expr) ((T) (expr))
+#  endif
+#else
+#  define HEDLEY_CPP_CAST(T, expr) (expr)
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+#if HEDLEY_HAS_WARNING("-Wdeprecated-declarations")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warning(disable:1478 1786)")
+#elif HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable:1478 1786))
+#elif HEDLEY_PGI_VERSION_CHECK(20,7,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1216,1444,1445")
+#elif HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1215,1444")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED __pragma(warning(disable:4996))
+#elif \
+    HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+    (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+    (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+    (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+    (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+    HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress 1291,1718")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && !defined(__cplusplus)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,E_DEPRECATED_ATT,E_DEPRECATED_ATT_MESS)")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) && defined(__cplusplus)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("error_messages(off,symdeprecated,symdeprecated2)")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("diag_suppress=Pe1444,Pe1215")
+#elif HEDLEY_PELLES_VERSION_CHECK(2,90,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED _Pragma("warn(disable:2241)")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_DEPRECATED
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("clang diagnostic ignored \"-Wunknown-pragmas\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("warning(disable:161)")
+#elif HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS __pragma(warning(disable:161))
+#elif HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 1675")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(15,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS __pragma(warning(disable:4068))
+#elif \
+    HEDLEY_TI_VERSION_CHECK(16,9,0) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0) || \
+    HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+    HEDLEY_TI_CLPRU_VERSION_CHECK(2,3,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
+#elif HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress 163")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS _Pragma("diag_suppress=Pe161")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-attributes")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("clang diagnostic ignored \"-Wunknown-attributes\"")
+#elif HEDLEY_GCC_VERSION_CHECK(4,6,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(17,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("warning(disable:1292)")
+#elif HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES __pragma(warning(disable:1292))
+#elif HEDLEY_MSVC_VERSION_CHECK(19,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES __pragma(warning(disable:5030))
+#elif HEDLEY_PGI_VERSION_CHECK(20,7,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1097,1098")
+#elif HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1097")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("error_messages(off,attrskipunsup)")
+#elif \
+    HEDLEY_TI_VERSION_CHECK(18,1,0) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(8,3,0) || \
+    HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress 1173")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES _Pragma("diag_suppress=Pe1097")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_CPP_ATTRIBUTES
+#endif
+
+#if defined(HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL)
+#  undef HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+#if HEDLEY_HAS_WARNING("-Wcast-qual")
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("clang diagnostic ignored \"-Wcast-qual\"")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("warning(disable:2203 2331)")
+#elif HEDLEY_GCC_VERSION_CHECK(3,0,0)
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL _Pragma("GCC diagnostic ignored \"-Wcast-qual\"")
+#else
+#  define HEDLEY_DIAGNOSTIC_DISABLE_CAST_QUAL
+#endif
+
+#if defined(HEDLEY_DEPRECATED)
+#  undef HEDLEY_DEPRECATED
+#endif
+#if defined(HEDLEY_DEPRECATED_FOR)
+#  undef HEDLEY_DEPRECATED_FOR
+#endif
+#if \
+  HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DEPRECATED(since) __declspec(deprecated("Since " # since))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated("Since " #since "; use " #replacement))
+#elif \
+  HEDLEY_HAS_EXTENSION(attribute_deprecated_with_message) || \
+  HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,13,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+  HEDLEY_TI_VERSION_CHECK(18,1,0) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(18,1,0) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(8,3,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,3,0)
+#  define HEDLEY_DEPRECATED(since) __attribute__((__deprecated__("Since " #since)))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__("Since " #since "; use " #replacement)))
+#elif defined(__cplusplus) && (__cplusplus >= 201402L)
+#  define HEDLEY_DEPRECATED(since) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[deprecated("Since " #since)]])
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[deprecated("Since " #since "; use " #replacement)]])
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(deprecated) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_DEPRECATED(since) __attribute__((__deprecated__))
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __attribute__((__deprecated__))
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_PELLES_VERSION_CHECK(6,50,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_DEPRECATED(since) __declspec(deprecated)
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) __declspec(deprecated)
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_DEPRECATED(since) _Pragma("deprecated")
+#  define HEDLEY_DEPRECATED_FOR(since, replacement) _Pragma("deprecated")
+#else
+#  define HEDLEY_DEPRECATED(since)
+#  define HEDLEY_DEPRECATED_FOR(since, replacement)
+#endif
+
+#if defined(HEDLEY_UNAVAILABLE)
+#  undef HEDLEY_UNAVAILABLE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(warning) || \
+  HEDLEY_GCC_VERSION_CHECK(4,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_UNAVAILABLE(available_since) __attribute__((__warning__("Not available until " #available_since)))
+#else
+#  define HEDLEY_UNAVAILABLE(available_since)
+#endif
+
+#if defined(HEDLEY_WARN_UNUSED_RESULT)
+#  undef HEDLEY_WARN_UNUSED_RESULT
+#endif
+#if defined(HEDLEY_WARN_UNUSED_RESULT_MSG)
+#  undef HEDLEY_WARN_UNUSED_RESULT_MSG
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(warn_unused_result) || \
+  HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_WARN_UNUSED_RESULT __attribute__((__warn_unused_result__))
+#  define HEDLEY_WARN_UNUSED_RESULT_MSG(msg) __attribute__((__warn_unused_result__))
+#elif (HEDLEY_HAS_CPP_ATTRIBUTE(nodiscard) >= 201907L)
+#  define HEDLEY_WARN_UNUSED_RESULT HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+#  define HEDLEY_WARN_UNUSED_RESULT_MSG(msg) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard(msg)]])
+#elif HEDLEY_HAS_CPP_ATTRIBUTE(nodiscard)
+#  define HEDLEY_WARN_UNUSED_RESULT HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+#  define HEDLEY_WARN_UNUSED_RESULT_MSG(msg) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[nodiscard]])
+#elif defined(_Check_return_) /* SAL */
+#  define HEDLEY_WARN_UNUSED_RESULT _Check_return_
+#  define HEDLEY_WARN_UNUSED_RESULT_MSG(msg) _Check_return_
+#else
+#  define HEDLEY_WARN_UNUSED_RESULT
+#  define HEDLEY_WARN_UNUSED_RESULT_MSG(msg)
+#endif
+
+#if defined(HEDLEY_SENTINEL)
+#  undef HEDLEY_SENTINEL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(sentinel) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,4,0)
+#  define HEDLEY_SENTINEL(position) __attribute__((__sentinel__(position)))
+#else
+#  define HEDLEY_SENTINEL(position)
+#endif
+
+#if defined(HEDLEY_NO_RETURN)
+#  undef HEDLEY_NO_RETURN
+#endif
+#if HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_NO_RETURN __noreturn
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#  define HEDLEY_NO_RETURN _Noreturn
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#  define HEDLEY_NO_RETURN HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[noreturn]])
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(noreturn) || \
+  HEDLEY_GCC_VERSION_CHECK(3,2,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_NO_RETURN __attribute__((__noreturn__))
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+#  define HEDLEY_NO_RETURN _Pragma("does_not_return")
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_NO_RETURN __declspec(noreturn)
+#elif HEDLEY_TI_CL6X_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#  define HEDLEY_NO_RETURN _Pragma("FUNC_NEVER_RETURNS;")
+#elif HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+#  define HEDLEY_NO_RETURN __attribute((noreturn))
+#elif HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+#  define HEDLEY_NO_RETURN __declspec(noreturn)
+#else
+#  define HEDLEY_NO_RETURN
+#endif
+
+#if defined(HEDLEY_NO_ESCAPE)
+#  undef HEDLEY_NO_ESCAPE
+#endif
+#if HEDLEY_HAS_ATTRIBUTE(noescape)
+#  define HEDLEY_NO_ESCAPE __attribute__((__noescape__))
+#else
+#  define HEDLEY_NO_ESCAPE
+#endif
+
+#if defined(HEDLEY_UNREACHABLE)
+#  undef HEDLEY_UNREACHABLE
+#endif
+#if defined(HEDLEY_UNREACHABLE_RETURN)
+#  undef HEDLEY_UNREACHABLE_RETURN
+#endif
+#if defined(HEDLEY_ASSUME)
+#  undef HEDLEY_ASSUME
+#endif
+#if \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_ASSUME(expr) __assume(expr)
+#elif HEDLEY_HAS_BUILTIN(__builtin_assume)
+#  define HEDLEY_ASSUME(expr) __builtin_assume(expr)
+#elif \
+    HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0)
+#  if defined(__cplusplus)
+#    define HEDLEY_ASSUME(expr) std::_nassert(expr)
+#  else
+#    define HEDLEY_ASSUME(expr) _nassert(expr)
+#  endif
+#endif
+#if \
+  (HEDLEY_HAS_BUILTIN(__builtin_unreachable) && (!defined(HEDLEY_ARM_VERSION))) || \
+  HEDLEY_GCC_VERSION_CHECK(4,5,0) || \
+  HEDLEY_PGI_VERSION_CHECK(18,10,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,5)
+#  define HEDLEY_UNREACHABLE() __builtin_unreachable()
+#elif defined(HEDLEY_ASSUME)
+#  define HEDLEY_UNREACHABLE() HEDLEY_ASSUME(0)
+#endif
+#if !defined(HEDLEY_ASSUME)
+#  if defined(HEDLEY_UNREACHABLE)
+#    define HEDLEY_ASSUME(expr) HEDLEY_STATIC_CAST(void, ((expr) ? 1 : (HEDLEY_UNREACHABLE(), 1)))
+#  else
+#    define HEDLEY_ASSUME(expr) HEDLEY_STATIC_CAST(void, expr)
+#  endif
+#endif
+#if defined(HEDLEY_UNREACHABLE)
+#  if  \
+      HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+      HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0)
+#    define HEDLEY_UNREACHABLE_RETURN(value) return (HEDLEY_STATIC_CAST(void, HEDLEY_ASSUME(0)), (value))
+#  else
+#    define HEDLEY_UNREACHABLE_RETURN(value) HEDLEY_UNREACHABLE()
+#  endif
+#else
+#  define HEDLEY_UNREACHABLE_RETURN(value) return (value)
+#endif
+#if !defined(HEDLEY_UNREACHABLE)
+#  define HEDLEY_UNREACHABLE() HEDLEY_ASSUME(0)
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+#if HEDLEY_HAS_WARNING("-Wpedantic")
+#  pragma clang diagnostic ignored "-Wpedantic"
+#endif
+#if HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic") && defined(__cplusplus)
+#  pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#endif
+#if HEDLEY_GCC_HAS_WARNING("-Wvariadic-macros",4,0,0)
+#  if defined(__clang__)
+#    pragma clang diagnostic ignored "-Wvariadic-macros"
+#  elif defined(HEDLEY_GCC_VERSION)
+#    pragma GCC diagnostic ignored "-Wvariadic-macros"
+#  endif
+#endif
+#if defined(HEDLEY_NON_NULL)
+#  undef HEDLEY_NON_NULL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(nonnull) || \
+  HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0)
+#  define HEDLEY_NON_NULL(...) __attribute__((__nonnull__(__VA_ARGS__)))
+#else
+#  define HEDLEY_NON_NULL(...)
+#endif
+HEDLEY_DIAGNOSTIC_POP
+
+#if defined(HEDLEY_PRINTF_FORMAT)
+#  undef HEDLEY_PRINTF_FORMAT
+#endif
+#if defined(__MINGW32__) && HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && !defined(__USE_MINGW_ANSI_STDIO)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(ms_printf, string_idx, first_to_check)))
+#elif defined(__MINGW32__) && HEDLEY_GCC_HAS_ATTRIBUTE(format,4,4,0) && defined(__USE_MINGW_ANSI_STDIO)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(gnu_printf, string_idx, first_to_check)))
+#elif \
+  HEDLEY_HAS_ATTRIBUTE(format) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_ARM_VERSION_CHECK(5,6,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __attribute__((__format__(__printf__, string_idx, first_to_check)))
+#elif HEDLEY_PELLES_VERSION_CHECK(6,0,0)
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check) __declspec(vaformat(printf,string_idx,first_to_check))
+#else
+#  define HEDLEY_PRINTF_FORMAT(string_idx,first_to_check)
+#endif
+
+#if defined(HEDLEY_CONSTEXPR)
+#  undef HEDLEY_CONSTEXPR
+#endif
+#if defined(__cplusplus)
+#  if __cplusplus >= 201103L
+#    define HEDLEY_CONSTEXPR HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(constexpr)
+#  endif
+#endif
+#if !defined(HEDLEY_CONSTEXPR)
+#  define HEDLEY_CONSTEXPR
+#endif
+
+#if defined(HEDLEY_PREDICT)
+#  undef HEDLEY_PREDICT
+#endif
+#if defined(HEDLEY_LIKELY)
+#  undef HEDLEY_LIKELY
+#endif
+#if defined(HEDLEY_UNLIKELY)
+#  undef HEDLEY_UNLIKELY
+#endif
+#if defined(HEDLEY_UNPREDICTABLE)
+#  undef HEDLEY_UNPREDICTABLE
+#endif
+#if HEDLEY_HAS_BUILTIN(__builtin_unpredictable)
+#  define HEDLEY_UNPREDICTABLE(expr) __builtin_unpredictable((expr))
+#endif
+#if \
+  (HEDLEY_HAS_BUILTIN(__builtin_expect_with_probability) && !defined(HEDLEY_PGI_VERSION)) || \
+  HEDLEY_GCC_VERSION_CHECK(9,0,0)
+#  define HEDLEY_PREDICT(expr, value, probability) __builtin_expect_with_probability(  (expr), (value), (probability))
+#  define HEDLEY_PREDICT_TRUE(expr, probability)   __builtin_expect_with_probability(!!(expr),    1   , (probability))
+#  define HEDLEY_PREDICT_FALSE(expr, probability)  __builtin_expect_with_probability(!!(expr),    0   , (probability))
+#  define HEDLEY_LIKELY(expr)                      __builtin_expect                 (!!(expr),    1                  )
+#  define HEDLEY_UNLIKELY(expr)                    __builtin_expect                 (!!(expr),    0                  )
+#elif \
+  (HEDLEY_HAS_BUILTIN(__builtin_expect) && !defined(HEDLEY_INTEL_CL_VERSION)) || \
+  HEDLEY_GCC_VERSION_CHECK(3,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,15,0) && defined(__cplusplus)) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(4,7,0) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(3,1,0) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,1,0) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,27) || \
+  HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+#  define HEDLEY_PREDICT(expr, expected, probability) \
+     (((probability) >= 0.9) ? __builtin_expect((expr), (expected)) : (HEDLEY_STATIC_CAST(void, expected), (expr)))
+#  define HEDLEY_PREDICT_TRUE(expr, probability) \
+     (__extension__ ({ \
+       double hedley_probability_ = (probability); \
+       ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 1) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 0) : !!(expr))); \
+     }))
+#  define HEDLEY_PREDICT_FALSE(expr, probability) \
+     (__extension__ ({ \
+       double hedley_probability_ = (probability); \
+       ((hedley_probability_ >= 0.9) ? __builtin_expect(!!(expr), 0) : ((hedley_probability_ <= 0.1) ? __builtin_expect(!!(expr), 1) : !!(expr))); \
+     }))
+#  define HEDLEY_LIKELY(expr)   __builtin_expect(!!(expr), 1)
+#  define HEDLEY_UNLIKELY(expr) __builtin_expect(!!(expr), 0)
+#else
+#  define HEDLEY_PREDICT(expr, expected, probability) (HEDLEY_STATIC_CAST(void, expected), (expr))
+#  define HEDLEY_PREDICT_TRUE(expr, probability) (!!(expr))
+#  define HEDLEY_PREDICT_FALSE(expr, probability) (!!(expr))
+#  define HEDLEY_LIKELY(expr) (!!(expr))
+#  define HEDLEY_UNLIKELY(expr) (!!(expr))
+#endif
+#if !defined(HEDLEY_UNPREDICTABLE)
+#  define HEDLEY_UNPREDICTABLE(expr) HEDLEY_PREDICT(expr, 1, 0.5)
+#endif
+
+#if defined(HEDLEY_MALLOC)
+#  undef HEDLEY_MALLOC
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(malloc) || \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_MALLOC __attribute__((__malloc__))
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+#  define HEDLEY_MALLOC _Pragma("returns_new_memory")
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_MALLOC __declspec(restrict)
+#else
+#  define HEDLEY_MALLOC
+#endif
+
+#if defined(HEDLEY_PURE)
+#  undef HEDLEY_PURE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(pure) || \
+  HEDLEY_GCC_VERSION_CHECK(2,96,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_PURE __attribute__((__pure__))
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+#  define HEDLEY_PURE _Pragma("does_not_write_global_data")
+#elif defined(__cplusplus) && \
+    ( \
+      HEDLEY_TI_CL430_VERSION_CHECK(2,0,1) || \
+      HEDLEY_TI_CL6X_VERSION_CHECK(4,0,0) || \
+      HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) \
+    )
+#  define HEDLEY_PURE _Pragma("FUNC_IS_PURE;")
+#else
+#  define HEDLEY_PURE
+#endif
+
+#if defined(HEDLEY_CONST)
+#  undef HEDLEY_CONST
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(const) || \
+  HEDLEY_GCC_VERSION_CHECK(2,5,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0)
+#  define HEDLEY_CONST __attribute__((__const__))
+#elif \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,10,0)
+#  define HEDLEY_CONST _Pragma("no_side_effect")
+#else
+#  define HEDLEY_CONST HEDLEY_PURE
+#endif
+
+#if defined(HEDLEY_RESTRICT)
+#  undef HEDLEY_RESTRICT
+#endif
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && !defined(__cplusplus)
+#  define HEDLEY_RESTRICT restrict
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(3,1,0) || \
+  HEDLEY_MSVC_VERSION_CHECK(14,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_PGI_VERSION_CHECK(17,10,0) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,2,4) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(8,1,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)) || \
+  HEDLEY_IAR_VERSION_CHECK(8,0,0) || \
+  defined(__clang__)
+#  define HEDLEY_RESTRICT __restrict
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,3,0) && !defined(__cplusplus)
+#  define HEDLEY_RESTRICT _Restrict
+#else
+#  define HEDLEY_RESTRICT
+#endif
+
+#if defined(HEDLEY_INLINE)
+#  undef HEDLEY_INLINE
+#endif
+#if \
+  (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)) || \
+  (defined(__cplusplus) && (__cplusplus >= 199711L))
+#  define HEDLEY_INLINE inline
+#elif \
+  defined(HEDLEY_GCC_VERSION) || \
+  HEDLEY_ARM_VERSION_CHECK(6,2,0)
+#  define HEDLEY_INLINE __inline__
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(12,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,1,0) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(3,1,0) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,2,0) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_INLINE __inline
+#else
+#  define HEDLEY_INLINE
+#endif
+
+#if defined(HEDLEY_ALWAYS_INLINE)
+#  undef HEDLEY_ALWAYS_INLINE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(always_inline) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_ALWAYS_INLINE __attribute__((__always_inline__)) HEDLEY_INLINE
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(12,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_ALWAYS_INLINE __forceinline
+#elif defined(__cplusplus) && \
+    ( \
+      HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+      HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+      HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+      HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+      HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+      HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0) \
+    )
+#  define HEDLEY_ALWAYS_INLINE _Pragma("FUNC_ALWAYS_INLINE;")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_ALWAYS_INLINE _Pragma("inline=forced")
+#else
+#  define HEDLEY_ALWAYS_INLINE HEDLEY_INLINE
+#endif
+
+#if defined(HEDLEY_NEVER_INLINE)
+#  undef HEDLEY_NEVER_INLINE
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(noinline) || \
+  HEDLEY_GCC_VERSION_CHECK(4,0,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(10,1,0) || \
+  HEDLEY_TI_VERSION_CHECK(15,12,0) || \
+  (HEDLEY_TI_ARMCL_VERSION_CHECK(4,8,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_ARMCL_VERSION_CHECK(5,2,0) || \
+  (HEDLEY_TI_CL2000_VERSION_CHECK(6,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL2000_VERSION_CHECK(6,4,0) || \
+  (HEDLEY_TI_CL430_VERSION_CHECK(4,0,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL430_VERSION_CHECK(4,3,0) || \
+  (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) || \
+  HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+  HEDLEY_TI_CLPRU_VERSION_CHECK(2,1,0)
+#  define HEDLEY_NEVER_INLINE __attribute__((__noinline__))
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,10,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_NEVER_INLINE __declspec(noinline)
+#elif HEDLEY_PGI_VERSION_CHECK(10,2,0)
+#  define HEDLEY_NEVER_INLINE _Pragma("noinline")
+#elif HEDLEY_TI_CL6X_VERSION_CHECK(6,0,0) && defined(__cplusplus)
+#  define HEDLEY_NEVER_INLINE _Pragma("FUNC_CANNOT_INLINE;")
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_NEVER_INLINE _Pragma("inline=never")
+#elif HEDLEY_COMPCERT_VERSION_CHECK(3,2,0)
+#  define HEDLEY_NEVER_INLINE __attribute((noinline))
+#elif HEDLEY_PELLES_VERSION_CHECK(9,0,0)
+#  define HEDLEY_NEVER_INLINE __declspec(noinline)
+#else
+#  define HEDLEY_NEVER_INLINE
+#endif
+
+#if defined(HEDLEY_PRIVATE)
+#  undef HEDLEY_PRIVATE
+#endif
+#if defined(HEDLEY_PUBLIC)
+#  undef HEDLEY_PUBLIC
+#endif
+#if defined(HEDLEY_IMPORT)
+#  undef HEDLEY_IMPORT
+#endif
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  define HEDLEY_PRIVATE
+#  define HEDLEY_PUBLIC   __declspec(dllexport)
+#  define HEDLEY_IMPORT   __declspec(dllimport)
+#else
+#  if \
+    HEDLEY_HAS_ATTRIBUTE(visibility) || \
+    HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+    HEDLEY_SUNPRO_VERSION_CHECK(5,11,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    ( \
+      defined(__TI_EABI__) && \
+      ( \
+        (HEDLEY_TI_CL6X_VERSION_CHECK(7,2,0) && defined(__TI_GNU_ATTRIBUTE_SUPPORT__)) || \
+        HEDLEY_TI_CL6X_VERSION_CHECK(7,5,0) \
+      ) \
+    )
+#    define HEDLEY_PRIVATE __attribute__((__visibility__("hidden")))
+#    define HEDLEY_PUBLIC  __attribute__((__visibility__("default")))
+#  else
+#    define HEDLEY_PRIVATE
+#    define HEDLEY_PUBLIC
+#  endif
+#  define HEDLEY_IMPORT    extern
+#endif
+
+#if defined(HEDLEY_NO_THROW)
+#  undef HEDLEY_NO_THROW
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(nothrow) || \
+  HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_NO_THROW __attribute__((__nothrow__))
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(13,1,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0)
+#  define HEDLEY_NO_THROW __declspec(nothrow)
+#else
+#  define HEDLEY_NO_THROW
+#endif
+
+#if defined(HEDLEY_FALL_THROUGH)
+# undef HEDLEY_FALL_THROUGH
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(fallthrough) || \
+  HEDLEY_GCC_VERSION_CHECK(7,0,0)
+#  define HEDLEY_FALL_THROUGH __attribute__((__fallthrough__))
+#elif HEDLEY_HAS_CPP_ATTRIBUTE_NS(clang,fallthrough)
+#  define HEDLEY_FALL_THROUGH HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[clang::fallthrough]])
+#elif HEDLEY_HAS_CPP_ATTRIBUTE(fallthrough)
+#  define HEDLEY_FALL_THROUGH HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_([[fallthrough]])
+#elif defined(__fallthrough) /* SAL */
+#  define HEDLEY_FALL_THROUGH __fallthrough
+#else
+#  define HEDLEY_FALL_THROUGH
+#endif
+
+#if defined(HEDLEY_RETURNS_NON_NULL)
+#  undef HEDLEY_RETURNS_NON_NULL
+#endif
+#if \
+  HEDLEY_HAS_ATTRIBUTE(returns_nonnull) || \
+  HEDLEY_GCC_VERSION_CHECK(4,9,0)
+#  define HEDLEY_RETURNS_NON_NULL __attribute__((__returns_nonnull__))
+#elif defined(_Ret_notnull_) /* SAL */
+#  define HEDLEY_RETURNS_NON_NULL _Ret_notnull_
+#else
+#  define HEDLEY_RETURNS_NON_NULL
+#endif
+
+#if defined(HEDLEY_ARRAY_PARAM)
+#  undef HEDLEY_ARRAY_PARAM
+#endif
+#if \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+  !defined(__STDC_NO_VLA__) && \
+  !defined(__cplusplus) && \
+  !defined(HEDLEY_PGI_VERSION) && \
+  !defined(HEDLEY_TINYC_VERSION)
+#  define HEDLEY_ARRAY_PARAM(name) (name)
+#else
+#  define HEDLEY_ARRAY_PARAM(name)
+#endif
+
+#if defined(HEDLEY_IS_CONSTANT)
+#  undef HEDLEY_IS_CONSTANT
+#endif
+#if defined(HEDLEY_REQUIRE_CONSTEXPR)
+#  undef HEDLEY_REQUIRE_CONSTEXPR
+#endif
+/* HEDLEY_IS_CONSTEXPR_ is for
+   HEDLEY INTERNAL USE ONLY.  API subject to change without notice. */
+#if defined(HEDLEY_IS_CONSTEXPR_)
+#  undef HEDLEY_IS_CONSTEXPR_
+#endif
+#if \
+  HEDLEY_HAS_BUILTIN(__builtin_constant_p) || \
+  HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,19) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+  HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+  (HEDLEY_SUNPRO_VERSION_CHECK(5,10,0) && !defined(__cplusplus)) || \
+  HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+#  define HEDLEY_IS_CONSTANT(expr) __builtin_constant_p(expr)
+#endif
+#if !defined(__cplusplus)
+#  if \
+       HEDLEY_HAS_BUILTIN(__builtin_types_compatible_p) || \
+       HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+       HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+       HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+       HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+       HEDLEY_ARM_VERSION_CHECK(5,4,0) || \
+       HEDLEY_TINYC_VERSION_CHECK(0,9,24)
+#    if defined(__INTPTR_TYPE__)
+#      define HEDLEY_IS_CONSTEXPR_(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0)), int*)
+#    else
+#      include <stdint.h>
+#      define HEDLEY_IS_CONSTEXPR_(expr) __builtin_types_compatible_p(__typeof__((1 ? (void*) ((intptr_t) ((expr) * 0)) : (int*) 0)), int*)
+#    endif
+#  elif \
+       ( \
+          defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && \
+          !defined(HEDLEY_SUNPRO_VERSION) && \
+          !defined(HEDLEY_PGI_VERSION) && \
+          !defined(HEDLEY_IAR_VERSION)) || \
+       HEDLEY_HAS_EXTENSION(c_generic_selections) || \
+       HEDLEY_GCC_VERSION_CHECK(4,9,0) || \
+       HEDLEY_INTEL_VERSION_CHECK(17,0,0) || \
+       HEDLEY_IBM_VERSION_CHECK(12,1,0) || \
+       HEDLEY_ARM_VERSION_CHECK(5,3,0)
+#    if defined(__INTPTR_TYPE__)
+#      define HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((__INTPTR_TYPE__) ((expr) * 0)) : (int*) 0), int*: 1, void*: 0)
+#    else
+#      include <stdint.h>
+#      define HEDLEY_IS_CONSTEXPR_(expr) _Generic((1 ? (void*) ((intptr_t) * 0) : (int*) 0), int*: 1, void*: 0)
+#    endif
+#  elif \
+       defined(HEDLEY_GCC_VERSION) || \
+       defined(HEDLEY_INTEL_VERSION) || \
+       defined(HEDLEY_TINYC_VERSION) || \
+       defined(HEDLEY_TI_ARMCL_VERSION) || \
+       HEDLEY_TI_CL430_VERSION_CHECK(18,12,0) || \
+       defined(HEDLEY_TI_CL2000_VERSION) || \
+       defined(HEDLEY_TI_CL6X_VERSION) || \
+       defined(HEDLEY_TI_CL7X_VERSION) || \
+       defined(HEDLEY_TI_CLPRU_VERSION) || \
+       defined(__clang__)
+#    define HEDLEY_IS_CONSTEXPR_(expr) ( \
+         sizeof(void) != \
+         sizeof(*( \
+           1 ? \
+             ((void*) ((expr) * 0L) ) : \
+             ((struct { char v[sizeof(void) * 2]; } *) 1) \
+           ) \
+         ) \
+       )
+#  endif
+#endif
+#if defined(HEDLEY_IS_CONSTEXPR_)
+#  if !defined(HEDLEY_IS_CONSTANT)
+#    define HEDLEY_IS_CONSTANT(expr) HEDLEY_IS_CONSTEXPR_(expr)
+#  endif
+#  define HEDLEY_REQUIRE_CONSTEXPR(expr) (HEDLEY_IS_CONSTEXPR_(expr) ? (expr) : (-1))
+#else
+#  if !defined(HEDLEY_IS_CONSTANT)
+#    define HEDLEY_IS_CONSTANT(expr) (0)
+#  endif
+#  define HEDLEY_REQUIRE_CONSTEXPR(expr) (expr)
+#endif
+
+#if defined(HEDLEY_BEGIN_C_DECLS)
+#  undef HEDLEY_BEGIN_C_DECLS
+#endif
+#if defined(HEDLEY_END_C_DECLS)
+#  undef HEDLEY_END_C_DECLS
+#endif
+#if defined(HEDLEY_C_DECL)
+#  undef HEDLEY_C_DECL
+#endif
+#if defined(__cplusplus)
+#  define HEDLEY_BEGIN_C_DECLS extern "C" {
+#  define HEDLEY_END_C_DECLS }
+#  define HEDLEY_C_DECL extern "C"
+#else
+#  define HEDLEY_BEGIN_C_DECLS
+#  define HEDLEY_END_C_DECLS
+#  define HEDLEY_C_DECL
+#endif
+
+#if defined(HEDLEY_STATIC_ASSERT)
+#  undef HEDLEY_STATIC_ASSERT
+#endif
+#if \
+  !defined(__cplusplus) && ( \
+      (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+      (HEDLEY_HAS_FEATURE(c_static_assert) && !defined(HEDLEY_INTEL_CL_VERSION)) || \
+      HEDLEY_GCC_VERSION_CHECK(6,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      defined(_Static_assert) \
+    )
+#  define HEDLEY_STATIC_ASSERT(expr, message) _Static_assert(expr, message)
+#elif \
+  (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
+  HEDLEY_MSVC_VERSION_CHECK(16,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_STATIC_ASSERT(expr, message) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(static_assert(expr, message))
+#else
+#  define HEDLEY_STATIC_ASSERT(expr, message)
+#endif
+
+#if defined(HEDLEY_NULL)
+#  undef HEDLEY_NULL
+#endif
+#if defined(__cplusplus)
+#  if __cplusplus >= 201103L
+#    define HEDLEY_NULL HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(nullptr)
+#  elif defined(NULL)
+#    define HEDLEY_NULL NULL
+#  else
+#    define HEDLEY_NULL HEDLEY_STATIC_CAST(void*, 0)
+#  endif
+#elif defined(NULL)
+#  define HEDLEY_NULL NULL
+#else
+#  define HEDLEY_NULL ((void*) 0)
+#endif
+
+#if defined(HEDLEY_MESSAGE)
+#  undef HEDLEY_MESSAGE
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_MESSAGE(msg) \
+  HEDLEY_DIAGNOSTIC_PUSH \
+  HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+  HEDLEY_PRAGMA(message msg) \
+  HEDLEY_DIAGNOSTIC_POP
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(4,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message msg)
+#elif HEDLEY_CRAY_VERSION_CHECK(5,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(_CRI message msg)
+#elif HEDLEY_IAR_VERSION_CHECK(8,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message(msg))
+#elif HEDLEY_PELLES_VERSION_CHECK(2,0,0)
+#  define HEDLEY_MESSAGE(msg) HEDLEY_PRAGMA(message(msg))
+#else
+#  define HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(HEDLEY_WARNING)
+#  undef HEDLEY_WARNING
+#endif
+#if HEDLEY_HAS_WARNING("-Wunknown-pragmas")
+#  define HEDLEY_WARNING(msg) \
+  HEDLEY_DIAGNOSTIC_PUSH \
+  HEDLEY_DIAGNOSTIC_DISABLE_UNKNOWN_PRAGMAS \
+  HEDLEY_PRAGMA(clang warning msg) \
+  HEDLEY_DIAGNOSTIC_POP
+#elif \
+  HEDLEY_GCC_VERSION_CHECK(4,8,0) || \
+  HEDLEY_PGI_VERSION_CHECK(18,4,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#  define HEDLEY_WARNING(msg) HEDLEY_PRAGMA(GCC warning msg)
+#elif \
+  HEDLEY_MSVC_VERSION_CHECK(15,0,0) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_WARNING(msg) HEDLEY_PRAGMA(message(msg))
+#else
+#  define HEDLEY_WARNING(msg) HEDLEY_MESSAGE(msg)
+#endif
+
+#if defined(HEDLEY_REQUIRE)
+#  undef HEDLEY_REQUIRE
+#endif
+#if defined(HEDLEY_REQUIRE_MSG)
+#  undef HEDLEY_REQUIRE_MSG
+#endif
+#if HEDLEY_HAS_ATTRIBUTE(diagnose_if)
+#  if HEDLEY_HAS_WARNING("-Wgcc-compat")
+#    define HEDLEY_REQUIRE(expr) \
+       HEDLEY_DIAGNOSTIC_PUSH \
+       _Pragma("clang diagnostic ignored \"-Wgcc-compat\"") \
+       __attribute__((diagnose_if(!(expr), #expr, "error"))) \
+       HEDLEY_DIAGNOSTIC_POP
+#    define HEDLEY_REQUIRE_MSG(expr,msg) \
+       HEDLEY_DIAGNOSTIC_PUSH \
+       _Pragma("clang diagnostic ignored \"-Wgcc-compat\"") \
+       __attribute__((diagnose_if(!(expr), msg, "error"))) \
+       HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define HEDLEY_REQUIRE(expr) __attribute__((diagnose_if(!(expr), #expr, "error")))
+#    define HEDLEY_REQUIRE_MSG(expr,msg) __attribute__((diagnose_if(!(expr), msg, "error")))
+#  endif
+#else
+#  define HEDLEY_REQUIRE(expr)
+#  define HEDLEY_REQUIRE_MSG(expr,msg)
+#endif
+
+#if defined(HEDLEY_FLAGS)
+#  undef HEDLEY_FLAGS
+#endif
+#if HEDLEY_HAS_ATTRIBUTE(flag_enum)
+#  define HEDLEY_FLAGS __attribute__((__flag_enum__))
+#else
+#  define HEDLEY_FLAGS
+#endif
+
+#if defined(HEDLEY_FLAGS_CAST)
+#  undef HEDLEY_FLAGS_CAST
+#endif
+#if HEDLEY_INTEL_VERSION_CHECK(19,0,0)
+#  define HEDLEY_FLAGS_CAST(T, expr) (__extension__ ({ \
+  HEDLEY_DIAGNOSTIC_PUSH \
+      _Pragma("warning(disable:188)") \
+      ((T) (expr)); \
+      HEDLEY_DIAGNOSTIC_POP \
+    }))
+#else
+#  define HEDLEY_FLAGS_CAST(T, expr) HEDLEY_STATIC_CAST(T, expr)
+#endif
+
+#if defined(HEDLEY_EMPTY_BASES)
+#  undef HEDLEY_EMPTY_BASES
+#endif
+#if \
+  (HEDLEY_MSVC_VERSION_CHECK(19,0,23918) && !HEDLEY_MSVC_VERSION_CHECK(20,0,0)) || \
+  HEDLEY_INTEL_CL_VERSION_CHECK(2021,1,0)
+#  define HEDLEY_EMPTY_BASES __declspec(empty_bases)
+#else
+#  define HEDLEY_EMPTY_BASES
+#endif
+
+/* Remaining macros are deprecated. */
+
+#if defined(HEDLEY_GCC_NOT_CLANG_VERSION_CHECK)
+#  undef HEDLEY_GCC_NOT_CLANG_VERSION_CHECK
+#endif
+#if defined(__clang__)
+#  define HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) (0)
+#else
+#  define HEDLEY_GCC_NOT_CLANG_VERSION_CHECK(major,minor,patch) HEDLEY_GCC_VERSION_CHECK(major,minor,patch)
+#endif
+
+#if defined(HEDLEY_CLANG_HAS_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_ATTRIBUTE(attribute) HEDLEY_HAS_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_CPP_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_CPP_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_CPP_ATTRIBUTE(attribute) HEDLEY_HAS_CPP_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_BUILTIN)
+#  undef HEDLEY_CLANG_HAS_BUILTIN
+#endif
+#define HEDLEY_CLANG_HAS_BUILTIN(builtin) HEDLEY_HAS_BUILTIN(builtin)
+
+#if defined(HEDLEY_CLANG_HAS_FEATURE)
+#  undef HEDLEY_CLANG_HAS_FEATURE
+#endif
+#define HEDLEY_CLANG_HAS_FEATURE(feature) HEDLEY_HAS_FEATURE(feature)
+
+#if defined(HEDLEY_CLANG_HAS_EXTENSION)
+#  undef HEDLEY_CLANG_HAS_EXTENSION
+#endif
+#define HEDLEY_CLANG_HAS_EXTENSION(extension) HEDLEY_HAS_EXTENSION(extension)
+
+#if defined(HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE)
+#  undef HEDLEY_CLANG_HAS_DECLSPEC_DECLSPEC_ATTRIBUTE
+#endif
+#define HEDLEY_CLANG_HAS_DECLSPEC_ATTRIBUTE(attribute) HEDLEY_HAS_DECLSPEC_ATTRIBUTE(attribute)
+
+#if defined(HEDLEY_CLANG_HAS_WARNING)
+#  undef HEDLEY_CLANG_HAS_WARNING
+#endif
+#define HEDLEY_CLANG_HAS_WARNING(warning) HEDLEY_HAS_WARNING(warning)
+
+#endif /* !defined(HEDLEY_VERSION) || (HEDLEY_VERSION < X) */

--- a/2.0/simde/simde-arch.h
+++ b/2.0/simde/simde-arch.h
@@ -1,0 +1,513 @@
+/* Architecture detection
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ *   To the extent possible under law, the authors have waived all
+ *   copyright and related or neighboring rights to this code.  For
+ *   details, see the Creative Commons Zero 1.0 Universal license at
+ *   <https://creativecommons.org/publicdomain/zero/1.0/>
+ *
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * Different compilers define different preprocessor macros for the
+ * same architecture.  This is an attempt to provide a single
+ * interface which is usable on any compiler.
+ *
+ * In general, a macro named SIMDE_ARCH_* is defined for each
+ * architecture the CPU supports.  When there are multiple possible
+ * versions, we try to define the macro to the target version.  For
+ * example, if you want to check for i586+, you could do something
+ * like:
+ *
+ *   #if defined(SIMDE_ARCH_X86) && (SIMDE_ARCH_X86 >= 5)
+ *   ...
+ *   #endif
+ *
+ * You could also just check that SIMDE_ARCH_X86 >= 5 without checking
+ * if it's defined first, but some compilers may emit a warning about
+ * an undefined macro being used (e.g., GCC with -Wundef).
+ *
+ * This was originally created for SIMDe
+ * <https://github.com/simd-everywhere/simde> (hence the prefix), but this
+ * header has no dependencies and may be used anywhere.  It is
+ * originally based on information from
+ * <https://sourceforge.net/p/predef/wiki/Architectures/>, though it
+ * has been enhanced with additional information.
+ *
+ * If you improve this file, or find a bug, please file the issue at
+ * <https://github.com/simd-everywhere/simde/issues>.  If you copy this into
+ * your project, even if you change the prefix, please keep the links
+ * to SIMDe intact so others know where to report issues, submit
+ * enhancements, and find the latest version. */
+
+#if !defined(SIMDE_ARCH_H)
+#define SIMDE_ARCH_H
+
+/* Alpha
+   <https://en.wikipedia.org/wiki/DEC_Alpha> */
+#if defined(__alpha__) || defined(__alpha) || defined(_M_ALPHA)
+#  if defined(__alpha_ev6__)
+#    define SIMDE_ARCH_ALPHA 6
+#  elif defined(__alpha_ev5__)
+#    define SIMDE_ARCH_ALPHA 5
+#  elif defined(__alpha_ev4__)
+#    define SIMDE_ARCH_ALPHA 4
+#  else
+#    define SIMDE_ARCH_ALPHA 1
+#  endif
+#endif
+#if defined(SIMDE_ARCH_ALPHA)
+#  define SIMDE_ARCH_ALPHA_CHECK(version) ((version) <= SIMDE_ARCH_ALPHA)
+#else
+#  define SIMDE_ARCH_ALPHA_CHECK(version) (0)
+#endif
+
+/* Atmel AVR
+   <https://en.wikipedia.org/wiki/Atmel_AVR> */
+#if defined(__AVR_ARCH__)
+#  define SIMDE_ARCH_AVR __AVR_ARCH__
+#endif
+
+/* AMD64 / x86_64
+   <https://en.wikipedia.org/wiki/X86-64> */
+#if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X66) || defined(_M_AMD64)
+#  define SIMDE_ARCH_AMD64 1000
+#endif
+
+/* ARM
+   <https://en.wikipedia.org/wiki/ARM_architecture> */
+#if defined(__ARM_ARCH_8A__)
+#  define SIMDE_ARCH_ARM 82
+#elif defined(__ARM_ARCH_8R__)
+#  define SIMDE_ARCH_ARM 81
+#elif defined(__ARM_ARCH_8__)
+#  define SIMDE_ARCH_ARM 80
+#elif defined(__ARM_ARCH_7S__)
+#  define SIMDE_ARCH_ARM 74
+#elif defined(__ARM_ARCH_7M__)
+#  define SIMDE_ARCH_ARM 73
+#elif defined(__ARM_ARCH_7R__)
+#  define SIMDE_ARCH_ARM 72
+#elif defined(__ARM_ARCH_7A__)
+#  define SIMDE_ARCH_ARM 71
+#elif defined(__ARM_ARCH_7__)
+#  define SIMDE_ARCH_ARM 70
+#elif defined(__ARM_ARCH)
+#  define SIMDE_ARCH_ARM (__ARM_ARCH * 10)
+#elif defined(_M_ARM)
+#  define SIMDE_ARCH_ARM (_M_ARM * 10)
+#elif defined(__arm__) || defined(__thumb__) || defined(__TARGET_ARCH_ARM) || defined(_ARM) || defined(_M_ARM) || defined(_M_ARM)
+#  define SIMDE_ARCH_ARM 1
+#endif
+#if defined(SIMDE_ARCH_ARM  )
+#  define SIMDE_ARCH_ARM_CHECK(version) ((version) <= SIMDE_ARCH_ARM)
+#else
+#  define SIMDE_ARCH_ARM_CHECK(version) (0)
+#endif
+
+/* AArch64
+   <https://en.wikipedia.org/wiki/ARM_architecture> */
+#if defined(__aarch64__) || defined(_M_ARM64)
+#  define SIMDE_ARCH_AARCH64 1000
+#endif
+#if defined(SIMDE_ARCH_AARCH64)
+#  define SIMDE_ARCH_AARCH64_CHECK(version) ((version) <= SIMDE_ARCH_AARCH64)
+#else
+#  define SIMDE_ARCH_AARCH64_CHECK(version) (0)
+#endif
+
+/* ARM SIMD ISA extensions */
+#if defined(__ARM_NEON)
+#  if defined(SIMDE_ARCH_AARCH64)
+#    define SIMDE_ARCH_ARM_NEON SIMDE_ARCH_AARCH64
+#  elif defined(SIMDE_ARCH_ARM)
+#    define SIMDE_ARCH_ARM_NEON SIMDE_ARCH_ARM
+#  endif
+#endif
+#if defined(__ARM_FEATURE_SVE)
+#  define SIMDE_ARCH_ARM_SVE
+#endif
+
+/* Blackfin
+   <https://en.wikipedia.org/wiki/Blackfin> */
+#if defined(__bfin) || defined(__BFIN__) || defined(__bfin__)
+#  define SIMDE_ARCH_BLACKFIN 1
+#endif
+
+/* CRIS
+   <https://en.wikipedia.org/wiki/ETRAX_CRIS> */
+#if defined(__CRIS_arch_version)
+#  define SIMDE_ARCH_CRIS __CRIS_arch_version
+#elif defined(__cris__) || defined(__cris) || defined(__CRIS) || defined(__CRIS__)
+#  define SIMDE_ARCH_CRIS 1
+#endif
+
+/* Convex
+   <https://en.wikipedia.org/wiki/Convex_Computer> */
+#if defined(__convex_c38__)
+#  define SIMDE_ARCH_CONVEX 38
+#elif defined(__convex_c34__)
+#  define SIMDE_ARCH_CONVEX 34
+#elif defined(__convex_c32__)
+#  define SIMDE_ARCH_CONVEX 32
+#elif defined(__convex_c2__)
+#  define SIMDE_ARCH_CONVEX 2
+#elif defined(__convex__)
+#  define SIMDE_ARCH_CONVEX 1
+#endif
+#if defined(SIMDE_ARCH_CONVEX)
+#  define SIMDE_ARCH_CONVEX_CHECK(version) ((version) <= SIMDE_ARCH_CONVEX)
+#else
+#  define SIMDE_ARCH_CONVEX_CHECK(version) (0)
+#endif
+
+/* Adapteva Epiphany
+   <https://en.wikipedia.org/wiki/Adapteva_Epiphany> */
+#if defined(__epiphany__)
+#  define SIMDE_ARCH_EPIPHANY 1
+#endif
+
+/* Fujitsu FR-V
+   <https://en.wikipedia.org/wiki/FR-V_(microprocessor)> */
+#if defined(__frv__)
+#  define SIMDE_ARCH_FRV 1
+#endif
+
+/* H8/300
+   <https://en.wikipedia.org/wiki/H8_Family> */
+#if defined(__H8300__)
+#  define SIMDE_ARCH_H8300
+#endif
+
+/* HP/PA / PA-RISC
+   <https://en.wikipedia.org/wiki/PA-RISC> */
+#if defined(__PA8000__) || defined(__HPPA20__) || defined(__RISC2_0__) || defined(_PA_RISC2_0)
+#  define SIMDE_ARCH_HPPA 20
+#elif defined(__PA7100__) || defined(__HPPA11__) || defined(_PA_RISC1_1)
+#  define SIMDE_ARCH_HPPA 11
+#elif defined(_PA_RISC1_0)
+#  define SIMDE_ARCH_HPPA 10
+#elif defined(__hppa__) || defined(__HPPA__) || defined(__hppa)
+#  define SIMDE_ARCH_HPPA 1
+#endif
+#if defined(SIMDE_ARCH_HPPA)
+#  define SIMDE_ARCH_HPPA_CHECK(version) ((version) <= SIMDE_ARCH_HPPA)
+#else
+#  define SIMDE_ARCH_HPPA_CHECK(version) (0)
+#endif
+
+/* x86
+   <https://en.wikipedia.org/wiki/X86> */
+#if defined(_M_IX86)
+#  define SIMDE_ARCH_X86 (_M_IX86 / 100)
+#elif defined(__I86__)
+#  define SIMDE_ARCH_X86 __I86__
+#elif defined(i686) || defined(__i686) || defined(__i686__)
+#  define SIMDE_ARCH_X86 6
+#elif defined(i586) || defined(__i586) || defined(__i586__)
+#  define SIMDE_ARCH_X86 5
+#elif defined(i486) || defined(__i486) || defined(__i486__)
+#  define SIMDE_ARCH_X86 4
+#elif defined(i386) || defined(__i386) || defined(__i386__)
+#  define SIMDE_ARCH_X86 3
+#elif defined(_X86_) || defined(__X86__) || defined(__THW_INTEL__)
+#  define SIMDE_ARCH_X86 3
+#endif
+#if defined(SIMDE_ARCH_X86)
+#  define SIMDE_ARCH_X86_CHECK(version) ((version) <= SIMDE_ARCH_X86)
+#else
+#  define SIMDE_ARCH_X86_CHECK(version) (0)
+#endif
+
+/* SIMD ISA extensions for x86/x86_64 */
+#if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+#  if defined(_M_IX86_FP)
+#    define SIMDE_ARCH_X86_MMX
+#    if (_M_IX86_FP >= 1)
+#      define SIMDE_ARCH_X86_SSE 1
+#    endif
+#    if (_M_IX86_FP >= 2)
+#      define SIMDE_ARCH_X86_SSE2 1
+#    endif
+#  elif defined(_M_X64)
+#    define SIMDE_ARCH_X86_SSE 1
+#    define SIMDE_ARCH_X86_SSE2 1
+#  else
+#    if defined(__MMX__)
+#      define SIMDE_ARCH_X86_MMX 1
+#    endif
+#    if defined(__SSE__)
+#      define SIMDE_ARCH_X86_SSE 1
+#    endif
+#    if defined(__SSE2__)
+#      define SIMDE_ARCH_X86_SSE2 1
+#    endif
+#  endif
+#  if defined(__SSE3__)
+#    define SIMDE_ARCH_X86_SSE3 1
+#  endif
+#  if defined(__SSSE3__)
+#    define SIMDE_ARCH_X86_SSSE3 1
+#  endif
+#  if defined(__SSE4_1__)
+#    define SIMDE_ARCH_X86_SSE4_1 1
+#  endif
+#  if defined(__SSE4_2__)
+#    define SIMDE_ARCH_X86_SSE4_2 1
+#  endif
+#  if defined(__AVX__)
+#    define SIMDE_ARCH_X86_AVX 1
+#    if !defined(SIMDE_ARCH_X86_SSE3)
+#      define SIMDE_ARCH_X86_SSE3 1
+#    endif
+#    if !defined(SIMDE_ARCH_X86_SSE4_1)
+#      define SIMDE_ARCH_X86_SSE4_1 1
+#    endif
+#    if !defined(SIMDE_ARCH_X86_SSE4_1)
+#      define SIMDE_ARCH_X86_SSE4_2 1
+#    endif
+#  endif
+#  if defined(__AVX2__)
+#    define SIMDE_ARCH_X86_AVX2 1
+#  endif
+#  if defined(__FMA__)
+#    define SIMDE_ARCH_X86_FMA 1
+#    if !defined(SIMDE_ARCH_X86_AVX)
+#      define SIMDE_ARCH_X86_AVX 1
+#    endif
+#  endif
+#  if defined(__AVX512BW__)
+#    define SIMDE_ARCH_X86_AVX512BW 1
+#  endif
+#  if defined(__AVX512CD__)
+#    define SIMDE_ARCH_X86_AVX512CD 1
+#  endif
+#  if defined(__AVX512DQ__)
+#    define SIMDE_ARCH_X86_AVX512DQ 1
+#  endif
+#  if defined(__AVX512F__)
+#    define SIMDE_ARCH_X86_AVX512F 1
+#  endif
+#  if defined(__AVX512VL__)
+#    define SIMDE_ARCH_X86_AVX512VL 1
+#  endif
+#  if defined(__GFNI__)
+#    define SIMDE_ARCH_X86_GFNI 1
+#  endif
+#endif
+
+/* Itanium
+   <https://en.wikipedia.org/wiki/Itanium> */
+#if defined(__ia64__) || defined(_IA64) || defined(__IA64__) || defined(__ia64) || defined(_M_IA64) || defined(__itanium__)
+#  define SIMDE_ARCH_IA64 1
+#endif
+
+/* Renesas M32R
+   <https://en.wikipedia.org/wiki/M32R> */
+#if defined(__m32r__) || defined(__M32R__)
+#  define SIMDE_ARCH_M32R
+#endif
+
+/* Motorola 68000
+   <https://en.wikipedia.org/wiki/Motorola_68000> */
+#if defined(__mc68060__) || defined(__MC68060__)
+#  define SIMDE_ARCH_M68K 68060
+#elif defined(__mc68040__) || defined(__MC68040__)
+#  define SIMDE_ARCH_M68K 68040
+#elif defined(__mc68030__) || defined(__MC68030__)
+#  define SIMDE_ARCH_M68K 68030
+#elif defined(__mc68020__) || defined(__MC68020__)
+#  define SIMDE_ARCH_M68K 68020
+#elif defined(__mc68010__) || defined(__MC68010__)
+#  define SIMDE_ARCH_M68K 68010
+#elif defined(__mc68000__) || defined(__MC68000__)
+#  define SIMDE_ARCH_M68K 68000
+#endif
+#if defined(SIMDE_ARCH_M68K)
+#  define SIMDE_ARCH_M68K_CHECK(version) ((version) <= SIMDE_ARCH_M68K)
+#else
+#  define SIMDE_ARCH_M68K_CHECK(version) (0)
+#endif
+
+/* Xilinx MicroBlaze
+   <https://en.wikipedia.org/wiki/MicroBlaze> */
+#if defined(__MICROBLAZE__) || defined(__microblaze__)
+#  define SIMDE_ARCH_MICROBLAZE
+#endif
+
+/* MIPS
+   <https://en.wikipedia.org/wiki/MIPS_architecture> */
+#if defined(_MIPS_ISA_MIPS64R2)
+#  define SIMDE_ARCH_MIPS 642
+#elif defined(_MIPS_ISA_MIPS64)
+#  define SIMDE_ARCH_MIPS 640
+#elif defined(_MIPS_ISA_MIPS32R2)
+#  define SIMDE_ARCH_MIPS 322
+#elif defined(_MIPS_ISA_MIPS32)
+#  define SIMDE_ARCH_MIPS 320
+#elif defined(_MIPS_ISA_MIPS4)
+#  define SIMDE_ARCH_MIPS 4
+#elif defined(_MIPS_ISA_MIPS3)
+#  define SIMDE_ARCH_MIPS 3
+#elif defined(_MIPS_ISA_MIPS2)
+#  define SIMDE_ARCH_MIPS 2
+#elif defined(_MIPS_ISA_MIPS1)
+#  define SIMDE_ARCH_MIPS 1
+#elif defined(_MIPS_ISA_MIPS) || defined(__mips) || defined(__MIPS__)
+#  define SIMDE_ARCH_MIPS 1
+#endif
+#if defined(SIMDE_ARCH_MIPS)
+#  define SIMDE_ARCH_MIPS_CHECK(version) ((version) <= SIMDE_ARCH_MIPS)
+#else
+#  define SIMDE_ARCH_MIPS_CHECK(version) (0)
+#endif
+
+/* Matsushita MN10300
+   <https://en.wikipedia.org/wiki/MN103> */
+#if defined(__MN10300__) || defined(__mn10300__)
+#  define SIMDE_ARCH_MN10300 1
+#endif
+
+/* POWER
+   <https://en.wikipedia.org/wiki/IBM_POWER_Instruction_Set_Architecture> */
+#if defined(_M_PPC)
+#  define SIMDE_ARCH_POWER _M_PPC
+#elif defined(_ARCH_PWR9)
+#  define SIMDE_ARCH_POWER 900
+#elif defined(_ARCH_PWR8)
+#  define SIMDE_ARCH_POWER 800
+#elif defined(_ARCH_PWR7)
+#  define SIMDE_ARCH_POWER 700
+#elif defined(_ARCH_PWR6)
+#  define SIMDE_ARCH_POWER 600
+#elif defined(_ARCH_PWR5)
+#  define SIMDE_ARCH_POWER 500
+#elif defined(_ARCH_PWR4)
+#  define SIMDE_ARCH_POWER 400
+#elif defined(_ARCH_440) || defined(__ppc440__)
+#  define SIMDE_ARCH_POWER 440
+#elif defined(_ARCH_450) || defined(__ppc450__)
+#  define SIMDE_ARCH_POWER 450
+#elif defined(_ARCH_601) || defined(__ppc601__)
+#  define SIMDE_ARCH_POWER 601
+#elif defined(_ARCH_603) || defined(__ppc603__)
+#  define SIMDE_ARCH_POWER 603
+#elif defined(_ARCH_604) || defined(__ppc604__)
+#  define SIMDE_ARCH_POWER 604
+#elif defined(_ARCH_605) || defined(__ppc605__)
+#  define SIMDE_ARCH_POWER 605
+#elif defined(_ARCH_620) || defined(__ppc620__)
+#  define SIMDE_ARCH_POWER 620
+#elif defined(__powerpc) || defined(__powerpc__) || defined(__POWERPC__) || defined(__ppc__) || defined(__PPC__) || defined(_ARCH_PPC) || defined(__ppc)
+#  define SIMDE_ARCH_POWER 1
+#endif
+#if defined(SIMDE_ARCH_POWER)
+  #define SIMDE_ARCH_POWER_CHECK(version) ((version) <= SIMDE_ARCH_POWER)
+#else
+  #define SIMDE_ARCH_POWER_CHECK(version) (0)
+#endif
+
+#if defined(__ALTIVEC__)
+#  define SIMDE_ARCH_POWER_ALTIVEC SIMDE_ARCH_POWER
+#endif
+#if defined(SIMDE_ARCH_POWER)
+  #define SIMDE_ARCH_POWER_ALTIVEC_CHECK(version) ((version) <= SIMDE_ARCH_POWER)
+#else
+  #define SIMDE_ARCH_POWER_ALTIVEC_CHECK(version) (0)
+#endif
+
+/* SPARC
+   <https://en.wikipedia.org/wiki/SPARC> */
+#if defined(__sparc_v9__) || defined(__sparcv9)
+#  define SIMDE_ARCH_SPARC 9
+#elif defined(__sparc_v8__) || defined(__sparcv8)
+#  define SIMDE_ARCH_SPARC 8
+#elif defined(__sparc_v7__) || defined(__sparcv7)
+#  define SIMDE_ARCH_SPARC 7
+#elif defined(__sparc_v6__) || defined(__sparcv6)
+#  define SIMDE_ARCH_SPARC 6
+#elif defined(__sparc_v5__) || defined(__sparcv5)
+#  define SIMDE_ARCH_SPARC 5
+#elif defined(__sparc_v4__) || defined(__sparcv4)
+#  define SIMDE_ARCH_SPARC 4
+#elif defined(__sparc_v3__) || defined(__sparcv3)
+#  define SIMDE_ARCH_SPARC 3
+#elif defined(__sparc_v2__) || defined(__sparcv2)
+#  define SIMDE_ARCH_SPARC 2
+#elif defined(__sparc_v1__) || defined(__sparcv1)
+#  define SIMDE_ARCH_SPARC 1
+#elif defined(__sparc__) || defined(__sparc)
+#  define SIMDE_ARCH_SPARC 1
+#endif
+#if defined(SIMDE_ARCH_SPARC)
+  #define SIMDE_ARCH_SPARC_CHECK(version) ((version) <= SIMDE_ARCH_SPARC)
+#else
+  #define SIMDE_ARCH_SPARC_CHECK(version) (0)
+#endif
+
+/* SuperH
+   <https://en.wikipedia.org/wiki/SuperH> */
+#if defined(__sh5__) || defined(__SH5__)
+#  define SIMDE_ARCH_SUPERH 5
+#elif defined(__sh4__) || defined(__SH4__)
+#  define SIMDE_ARCH_SUPERH 4
+#elif defined(__sh3__) || defined(__SH3__)
+#  define SIMDE_ARCH_SUPERH 3
+#elif defined(__sh2__) || defined(__SH2__)
+#  define SIMDE_ARCH_SUPERH 2
+#elif defined(__sh1__) || defined(__SH1__)
+#  define SIMDE_ARCH_SUPERH 1
+#elif defined(__sh__) || defined(__SH__)
+#  define SIMDE_ARCH_SUPERH 1
+#endif
+
+/* IBM System z
+   <https://en.wikipedia.org/wiki/IBM_System_z> */
+#if defined(__370__) || defined(__THW_370__) || defined(__s390__) || defined(__s390x__) || defined(__zarch__) || defined(__SYSC_ZARCH__)
+#  define SIMDE_ARCH_SYSTEMZ
+#endif
+
+/* TMS320 DSP
+   <https://en.wikipedia.org/wiki/Texas_Instruments_TMS320> */
+#if defined(_TMS320C6740) || defined(__TMS320C6740__)
+#  define SIMDE_ARCH_TMS320 6740
+#elif defined(_TMS320C6700_PLUS) || defined(__TMS320C6700_PLUS__)
+#  define SIMDE_ARCH_TMS320 6701
+#elif defined(_TMS320C6700) || defined(__TMS320C6700__)
+#  define SIMDE_ARCH_TMS320 6700
+#elif defined(_TMS320C6600) || defined(__TMS320C6600__)
+#  define SIMDE_ARCH_TMS320 6600
+#elif defined(_TMS320C6400_PLUS) || defined(__TMS320C6400_PLUS__)
+#  define SIMDE_ARCH_TMS320 6401
+#elif defined(_TMS320C6400) || defined(__TMS320C6400__)
+#  define SIMDE_ARCH_TMS320 6400
+#elif defined(_TMS320C6200) || defined(__TMS320C6200__)
+#  define SIMDE_ARCH_TMS320 6200
+#elif defined(_TMS320C55X) || defined(__TMS320C55X__)
+#  define SIMDE_ARCH_TMS320 550
+#elif defined(_TMS320C54X) || defined(__TMS320C54X__)
+#  define SIMDE_ARCH_TMS320 540
+#elif defined(_TMS320C28X) || defined(__TMS320C28X__)
+#  define SIMDE_ARCH_TMS320 280
+#endif
+#if defined(SIMDE_ARCH_TMS320)
+  #define SIMDE_ARCH_TMS320_CHECK(version) ((version) <= SIMDE_ARCH_TMS320)
+#else
+  #define SIMDE_ARCH_TMS320_CHECK(version) (0)
+#endif
+
+/* WebAssembly */
+#if defined(__wasm__)
+#  define SIMDE_ARCH_WASM 1
+#endif
+
+#if defined(SIMDE_ARCH_WASM) && defined(__wasm_simd128__)
+#  define SIMDE_ARCH_WASM_SIMD128
+#endif
+
+/* Xtensa
+   <https://en.wikipedia.org/wiki/> */
+#if defined(__xtensa__) || defined(__XTENSA__)
+#  define SIMDE_ARCH_XTENSA 1
+#endif
+
+#endif /* !defined(SIMDE_ARCH_H) */

--- a/2.0/simde/simde-common.h
+++ b/2.0/simde/simde-common.h
@@ -1,0 +1,846 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_COMMON_H)
+#define SIMDE_COMMON_H
+
+#include "hedley.h"
+
+#define SIMDE_VERSION_MAJOR 0
+#define SIMDE_VERSION_MINOR 5
+#define SIMDE_VERSION_MICRO 0
+#define SIMDE_VERSION HEDLEY_VERSION_ENCODE(SIMDE_VERSION_MAJOR, SIMDE_VERSION_MINOR, SIMDE_VERSION_MICRO)
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "simde-detect-clang.h"
+#include "simde-arch.h"
+#include "simde-features.h"
+#include "simde-diagnostic.h"
+#include "simde-math.h"
+#include "simde-constify.h"
+
+/* In some situations, SIMDe has to make large performance sacrifices
+ * for small increases in how faithfully it reproduces an API, but
+ * only a relatively small number of users will actually need the API
+ * to be completely accurate.  The SIMDE_FAST_* options can be used to
+ * disable these trade-offs.
+ *
+ * They can be enabled by passing -DSIMDE_FAST_MATH to the compiler, or
+ * the individual defines (e.g., -DSIMDE_FAST_NANS) if you only want to
+ * enable some optimizations.  Using -ffast-math and/or
+ * -ffinite-math-only will also enable the relevant options.  If you
+ * don't want that you can pass -DSIMDE_NO_FAST_* to disable them. */
+
+/* Most programs avoid NaNs by never passing values which can result in
+ * a NaN; for example, if you only pass non-negative values to the sqrt
+ * functions, it won't generate a NaN.  On some platforms, similar
+ * functions handle NaNs differently; for example, the _mm_min_ps SSE
+ * function will return 0.0 if you pass it (0.0, NaN), but the NEON
+ * vminq_f32 function will return NaN.  Making them behave like one
+ * another is expensive; it requires generating a mask of all lanes
+ * with NaNs, then performing the operation (e.g., vminq_f32), then
+ * blending together the result with another vector using the mask.
+ *
+ * If you don't want SIMDe to worry about the differences between how
+ * NaNs are handled on the two platforms, define this (or pass
+ * -ffinite-math-only) */
+#if !defined(SIMDE_FAST_MATH) && !defined(SIMDE_NO_FAST_MATH) && defined(__FAST_MATH__)
+  #define SIMDE_FAST_MATH
+#endif
+
+#if !defined(SIMDE_FAST_NANS) && !defined(SIMDE_NO_FAST_NANS)
+  #if defined(SIMDE_FAST_MATH)
+    #define SIMDE_FAST_NANS
+  #elif defined(__FINITE_MATH_ONLY__)
+    #if __FINITE_MATH_ONLY__
+      #define SIMDE_FAST_NANS
+    #endif
+  #endif
+#endif
+
+/* Many functions are defined as using the current rounding mode
+ * (i.e., the SIMD version of fegetround()) when converting to
+ * an integer.  For example, _mm_cvtpd_epi32.  Unfortunately,
+ * on some platforms (such as ARMv8+ where round-to-nearest is
+ * always used, regardless of the FPSCR register) this means we
+ * have to first query the current rounding mode, then choose
+ * the proper function (rounnd
+ , ceil, floor, etc.) */
+#if !defined(SIMDE_FAST_ROUND_MODE) && !defined(SIMDE_NO_FAST_ROUND_MODE) && defined(SIMDE_FAST_MATH)
+  #define SIMDE_FAST_ROUND_MODE
+#endif
+
+/* This controls how ties are rounded.  For example, does 10.5 round to
+ * 10 or 11?  IEEE 754 specifies round-towards-even, but on ARMv7 (for
+ * example) doesn't support it and it must be emulated (which is rather
+ * slow).  If you're okay with just using the default for whatever arch
+ * you're on, you should definitely define this. */
+#if !defined(SIMDE_FAST_ROUND_TIES) && !defined(SIMDE_NO_FAST_ROUND_TIES) && defined(SIMDE_FAST_MATH)
+  #define SIMDE_FAST_ROUND_TIES
+#endif
+
+#if \
+  HEDLEY_HAS_ATTRIBUTE(aligned) || \
+  HEDLEY_GCC_VERSION_CHECK(2,95,0) || \
+  HEDLEY_CRAY_VERSION_CHECK(8,4,0) || \
+  HEDLEY_IBM_VERSION_CHECK(11,1,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_PGI_VERSION_CHECK(19,4,0) || \
+  HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+  HEDLEY_TINYC_VERSION_CHECK(0,9,24) || \
+  HEDLEY_TI_VERSION_CHECK(8,1,0)
+#  define SIMDE_ALIGN(alignment) __attribute__((aligned(alignment)))
+#elif defined(_MSC_VER) && !(defined(_M_ARM) && !defined(_M_ARM64))
+#  define SIMDE_ALIGN(alignment) __declspec(align(alignment))
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+#  define SIMDE_ALIGN(alignment) _Alignas(alignment)
+#elif defined(__cplusplus) && (__cplusplus >= 201103L)
+#  define SIMDE_ALIGN(alignment) alignas(alignment)
+#else
+#  define SIMDE_ALIGN(alignment)
+#endif
+
+#if HEDLEY_GNUC_VERSION_CHECK(2,95,0) || \
+    HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    HEDLEY_IBM_VERSION_CHECK(11,1,0)
+#  define SIMDE_ALIGN_OF(T) (__alignof__(T))
+#elif \
+  (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+  HEDLEY_HAS_FEATURE(c11_alignof)
+#  define SIMDE_ALIGN_OF(T) (_Alignof(T))
+#elif \
+  (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
+  HEDLEY_HAS_FEATURE(cxx_alignof)
+#  define SIMDE_ALIGN_OF(T) (alignof(T))
+#endif
+
+#if defined(SIMDE_ALIGN_OF)
+#  define SIMDE_ALIGN_AS(N, T) SIMDE_ALIGN(SIMDE_ALIGN_OF(T))
+#else
+#  define SIMDE_ALIGN_AS(N, T) SIMDE_ALIGN(N)
+#endif
+
+#define simde_assert_aligned(alignment, val) \
+  simde_assert_int(HEDLEY_REINTERPRET_CAST(uintptr_t, HEDLEY_REINTERPRET_CAST(const void*, (val))) % (alignment), ==, 0)
+
+#if \
+    HEDLEY_HAS_BUILTIN(__builtin_constant_p) || \
+    HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    HEDLEY_TINYC_VERSION_CHECK(0,9,19) || \
+    HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    HEDLEY_TI_CL6X_VERSION_CHECK(6,1,0) || \
+    (HEDLEY_SUNPRO_VERSION_CHECK(5,10,0) && !defined(__cplusplus)) || \
+    HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+  #define SIMDE_CHECK_CONSTANT_(expr) (__builtin_constant_p(expr))
+#elif defined(__cplusplus) && (__cplusplus > 201703L)
+  #include <type_traits>
+  #define SIMDE_CHECK_CONSTANT_(expr) (std::is_constant_evaluated())
+#endif
+
+#if !defined(SIMDE_NO_CHECK_IMMEDIATE_CONSTANT)
+  #if defined(SIMDE_CHECK_CONSTANT_) && \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(9,0,0) && \
+      (!defined(__apple_build_version__) || ((__apple_build_version__ < 11000000) || (__apple_build_version__ >= 12000000)))
+    #define SIMDE_REQUIRE_CONSTANT(arg) HEDLEY_REQUIRE_MSG(SIMDE_CHECK_CONSTANT_(arg), "`" #arg "' must be constant")
+  #else
+    #define SIMDE_REQUIRE_CONSTANT(arg)
+  #endif
+#else
+  #define SIMDE_REQUIRE_CONSTANT(arg)
+#endif
+
+#define SIMDE_REQUIRE_RANGE(arg, min, max) \
+  HEDLEY_REQUIRE_MSG((((arg) >= (min)) && ((arg) <= (max))), "'" #arg "' must be in [" #min ", " #max "]")
+
+#define SIMDE_REQUIRE_CONSTANT_RANGE(arg, min, max) \
+  SIMDE_REQUIRE_CONSTANT(arg) \
+  SIMDE_REQUIRE_RANGE(arg, min, max)
+
+/* A copy of HEDLEY_STATIC_ASSERT, except we don't define an empty
+ * fallback if we can't find an implementation; instead we have to
+ * check if SIMDE_STATIC_ASSERT is defined before using it. */
+#if \
+  !defined(__cplusplus) && ( \
+      (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)) || \
+      HEDLEY_HAS_FEATURE(c_static_assert) || \
+      HEDLEY_GCC_VERSION_CHECK(6,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      defined(_Static_assert) \
+    )
+#  define SIMDE_STATIC_ASSERT(expr, message) _Static_assert(expr, message)
+#elif \
+  (defined(__cplusplus) && (__cplusplus >= 201103L)) || \
+  HEDLEY_MSVC_VERSION_CHECK(16,0,0)
+#  define SIMDE_STATIC_ASSERT(expr, message) HEDLEY_DIAGNOSTIC_DISABLE_CPP98_COMPAT_WRAP_(static_assert(expr, message))
+#endif
+
+/* SIMDE_ASSUME_ALIGNED allows you to (try to) tell the compiler
+ * that a pointer is aligned to an `alignment`-byte boundary. */
+#if \
+    HEDLEY_HAS_BUILTIN(__builtin_assume_aligned) || \
+    HEDLEY_GCC_VERSION_CHECK(4,7,0)
+  #define SIMDE_ASSUME_ALIGNED(alignment, v) HEDLEY_REINTERPRET_CAST(__typeof__(v), __builtin_assume_aligned(v, alignment))
+#elif defined(__cplusplus) && (__cplusplus > 201703L)
+  #define SIMDE_ASSUME_ALIGNED(alignment, v) std::assume_aligned<alignment>(v)
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+  #define SIMDE_ASSUME_ALIGNED(alignment, v) (__extension__ ({ \
+      __typeof__(v) simde_assume_aligned_t_ = (v); \
+      __assume_aligned(simde_assume_aligned_t_, alignment); \
+      simde_assume_aligned_t_; \
+    }))
+#else
+  #define SIMDE_ASSUME_ALIGNED(alignment, v) (v)
+#endif
+
+#if defined(SIMDE_ALIGN_OF)
+  #define SIMDE_ASSUME_ALIGNED_AS(T, v) SIMDE_ASSUME_ALIGNED(SIMDE_ALIGN_OF(T), v)
+#else
+  #define SIMDE_ASSUME_ALIGNED_AS(T, v) (v)
+#endif
+
+/* SIMDE_ALIGN_CAST allows you to convert to a type with greater
+ * aligment requirements without triggering a warning. */
+#if HEDLEY_HAS_WARNING("-Wcast-align") || defined(__clang__) || HEDLEY_GCC_VERSION_CHECK(3,4,0)
+  #define SIMDE_ALIGN_CAST(T, v) (__extension__({ \
+      HEDLEY_DIAGNOSTIC_PUSH \
+      _Pragma("GCC diagnostic ignored \"-Wcast-align\"") \
+      T simde_r_ = HEDLEY_REINTERPRET_CAST(T, v); \
+      HEDLEY_DIAGNOSTIC_POP \
+      simde_r_; \
+    }))
+#else
+  #define SIMDE_ALIGN_CAST(T, v) HEDLEY_REINTERPRET_CAST(T, v)
+#endif
+
+#if \
+  (HEDLEY_HAS_ATTRIBUTE(may_alias) && !defined(HEDLEY_SUNPRO_VERSION)) || \
+  HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+  HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+  HEDLEY_IBM_VERSION_CHECK(13,1,0)
+#  define SIMDE_MAY_ALIAS __attribute__((__may_alias__))
+#else
+#  define SIMDE_MAY_ALIAS
+#endif
+
+/*  Lots of compilers support GCC-style vector extensions, but many
+    don't support all the features.  Define different macros depending
+    on support for
+
+    * SIMDE_VECTOR - Declaring a vector.
+    * SIMDE_VECTOR_OPS - basic operations (binary and unary).
+    * SIMDE_VECTOR_NEGATE - negating a vector
+    * SIMDE_VECTOR_SCALAR - For binary operators, the second argument
+        can be a scalar, in which case the result is as if that scalar
+        had been broadcast to all lanes of a vector.
+    * SIMDE_VECTOR_SUBSCRIPT - Supports array subscript notation for
+        extracting/inserting a single element.=
+
+    SIMDE_VECTOR can be assumed if any others are defined, the
+    others are independent. */
+#if !defined(SIMDE_NO_VECTOR)
+#  if \
+    HEDLEY_GCC_VERSION_CHECK(4,8,0)
+#    define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
+#    define SIMDE_VECTOR_OPS
+#    define SIMDE_VECTOR_NEGATE
+#    define SIMDE_VECTOR_SCALAR
+#    define SIMDE_VECTOR_SUBSCRIPT
+#  elif HEDLEY_INTEL_VERSION_CHECK(16,0,0)
+#    define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
+#    define SIMDE_VECTOR_OPS
+#    define SIMDE_VECTOR_NEGATE
+/* ICC only supports SIMDE_VECTOR_SCALAR for constants */
+#    define SIMDE_VECTOR_SUBSCRIPT
+#  elif \
+    HEDLEY_GCC_VERSION_CHECK(4,1,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+#    define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
+#    define SIMDE_VECTOR_OPS
+#  elif HEDLEY_SUNPRO_VERSION_CHECK(5,12,0)
+#    define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
+#  elif HEDLEY_HAS_ATTRIBUTE(vector_size)
+#    define SIMDE_VECTOR(size) __attribute__((__vector_size__(size)))
+#    define SIMDE_VECTOR_OPS
+#    define SIMDE_VECTOR_NEGATE
+#    define SIMDE_VECTOR_SUBSCRIPT
+#    if SIMDE_DETECT_CLANG_VERSION_CHECK(5,0,0)
+#      define SIMDE_VECTOR_SCALAR
+#    endif
+#  endif
+
+/* GCC and clang have built-in functions to handle shuffling and
+   converting of vectors, but the implementations are slightly
+   different.  This macro is just an abstraction over them.  Note that
+   elem_size is in bits but vec_size is in bytes. */
+#  if !defined(SIMDE_NO_SHUFFLE_VECTOR) && defined(SIMDE_VECTOR_SUBSCRIPT)
+     HEDLEY_DIAGNOSTIC_PUSH
+     /* We don't care about -Wvariadic-macros; all compilers that support
+      * shufflevector/shuffle support them. */
+#    if HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic")
+#      pragma clang diagnostic ignored "-Wc++98-compat-pedantic"
+#    endif
+#    if HEDLEY_HAS_WARNING("-Wvariadic-macros") || HEDLEY_GCC_VERSION_CHECK(4,0,0)
+#      pragma GCC diagnostic ignored "-Wvariadic-macros"
+#    endif
+
+#    if HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+#      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) __builtin_shufflevector(a, b, __VA_ARGS__)
+#    elif HEDLEY_GCC_HAS_BUILTIN(__builtin_shuffle,4,7,0) && !defined(__INTEL_COMPILER)
+#      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
+         int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
+           __builtin_shuffle(a, b, simde_shuffle_); \
+         }))
+#    endif
+     HEDLEY_DIAGNOSTIC_POP
+#  endif
+
+/* TODO: this actually works on XL C/C++ without SIMDE_VECTOR_SUBSCRIPT
+   but the code needs to be refactored a bit to take advantage. */
+#  if !defined(SIMDE_NO_CONVERT_VECTOR) && defined(SIMDE_VECTOR_SUBSCRIPT)
+#    if HEDLEY_HAS_BUILTIN(__builtin_convertvector) || HEDLEY_GCC_VERSION_CHECK(9,0,0)
+#      if HEDLEY_GCC_VERSION_CHECK(9,0,0) && !HEDLEY_GCC_VERSION_CHECK(9,3,0)
+         /* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93557 */
+#        define SIMDE_CONVERT_VECTOR_(to, from) ((to) = (__extension__({ \
+             __typeof__(from) from_ = (from); \
+             ((void) from_); \
+             __builtin_convertvector(from_, __typeof__(to)); \
+           })))
+#      else
+#        define SIMDE_CONVERT_VECTOR_(to, from) ((to) = __builtin_convertvector((from), __typeof__(to)))
+#      endif
+#    endif
+#  endif
+#endif
+
+/* Since we currently require SUBSCRIPT before using a vector in a
+   union, we define these as dependencies of SUBSCRIPT.  They are
+   likely to disappear in the future, once SIMDe learns how to make
+   use of vectors without using the union members.  Do not use them
+   in your code unless you're okay with it breaking when SIMDe
+   changes. */
+#if defined(SIMDE_VECTOR_SUBSCRIPT)
+#  if defined(SIMDE_VECTOR_OPS)
+#    define SIMDE_VECTOR_SUBSCRIPT_OPS
+#  endif
+#  if defined(SIMDE_VECTOR_SCALAR)
+#    define SIMDE_VECTOR_SUBSCRIPT_SCALAR
+#  endif
+#endif
+
+#if !defined(SIMDE_ENABLE_OPENMP) && ((defined(_OPENMP) && (_OPENMP >= 201307L)) || (defined(_OPENMP_SIMD) && (_OPENMP_SIMD >= 201307L)))
+#  define SIMDE_ENABLE_OPENMP
+#endif
+
+#if !defined(SIMDE_ENABLE_CILKPLUS) && (defined(__cilk) || defined(HEDLEY_INTEL_VERSION))
+#  define SIMDE_ENABLE_CILKPLUS
+#endif
+
+#if defined(SIMDE_ENABLE_OPENMP)
+#  define SIMDE_VECTORIZE HEDLEY_PRAGMA(omp simd)
+#  define SIMDE_VECTORIZE_SAFELEN(l) HEDLEY_PRAGMA(omp simd safelen(l))
+#  if defined(__clang__)
+#    define SIMDE_VECTORIZE_REDUCTION(r) \
+        HEDLEY_DIAGNOSTIC_PUSH \
+        _Pragma("clang diagnostic ignored \"-Wsign-conversion\"") \
+        HEDLEY_PRAGMA(omp simd reduction(r)) \
+        HEDLEY_DIAGNOSTIC_POP
+#  else
+#    define SIMDE_VECTORIZE_REDUCTION(r) HEDLEY_PRAGMA(omp simd reduction(r))
+#  endif
+#  define SIMDE_VECTORIZE_ALIGNED(a) HEDLEY_PRAGMA(omp simd aligned(a))
+#elif defined(SIMDE_ENABLE_CILKPLUS)
+#  define SIMDE_VECTORIZE HEDLEY_PRAGMA(simd)
+#  define SIMDE_VECTORIZE_SAFELEN(l) HEDLEY_PRAGMA(simd vectorlength(l))
+#  define SIMDE_VECTORIZE_REDUCTION(r) HEDLEY_PRAGMA(simd reduction(r))
+#  define SIMDE_VECTORIZE_ALIGNED(a) HEDLEY_PRAGMA(simd aligned(a))
+#elif defined(__clang__) && !defined(HEDLEY_IBM_VERSION)
+#  define SIMDE_VECTORIZE HEDLEY_PRAGMA(clang loop vectorize(enable))
+#  define SIMDE_VECTORIZE_SAFELEN(l) HEDLEY_PRAGMA(clang loop vectorize_width(l))
+#  define SIMDE_VECTORIZE_REDUCTION(r) SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_ALIGNED(a)
+#elif HEDLEY_GCC_VERSION_CHECK(4,9,0)
+#  define SIMDE_VECTORIZE HEDLEY_PRAGMA(GCC ivdep)
+#  define SIMDE_VECTORIZE_SAFELEN(l) SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_REDUCTION(r) SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_ALIGNED(a)
+#elif HEDLEY_CRAY_VERSION_CHECK(5,0,0)
+#  define SIMDE_VECTORIZE HEDLEY_PRAGMA(_CRI ivdep)
+#  define SIMDE_VECTORIZE_SAFELEN(l) SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_REDUCTION(r) SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_ALIGNED(a)
+#else
+#  define SIMDE_VECTORIZE
+#  define SIMDE_VECTORIZE_SAFELEN(l)
+#  define SIMDE_VECTORIZE_REDUCTION(r)
+#  define SIMDE_VECTORIZE_ALIGNED(a)
+#endif
+
+#define SIMDE_MASK_NZ_(v, mask) (((v) & (mask)) | !((v) & (mask)))
+
+/* Intended for checking coverage, you should never use this in
+   production. */
+#if defined(SIMDE_NO_INLINE)
+#  define SIMDE_FUNCTION_ATTRIBUTES HEDLEY_NEVER_INLINE static
+#else
+#  define SIMDE_FUNCTION_ATTRIBUTES HEDLEY_ALWAYS_INLINE static
+#endif
+
+#if \
+    HEDLEY_HAS_ATTRIBUTE(unused) || \
+    HEDLEY_GCC_VERSION_CHECK(2,95,0)
+#  define SIMDE_FUNCTION_POSSIBLY_UNUSED_ __attribute__((__unused__))
+#else
+#  define SIMDE_FUNCTION_POSSIBLY_UNUSED_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wused-but-marked-unused")
+#  define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED _Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"")
+#else
+#  define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED
+#endif
+
+#if defined(_MSC_VER)
+#  define SIMDE_BEGIN_DECLS_ HEDLEY_DIAGNOSTIC_PUSH __pragma(warning(disable:4996 4204)) HEDLEY_BEGIN_C_DECLS
+#  define SIMDE_END_DECLS_ HEDLEY_DIAGNOSTIC_POP HEDLEY_END_C_DECLS
+#else
+#  define SIMDE_BEGIN_DECLS_ \
+     HEDLEY_DIAGNOSTIC_PUSH \
+     SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED \
+     HEDLEY_BEGIN_C_DECLS
+#  define SIMDE_END_DECLS_ \
+     HEDLEY_END_C_DECLS \
+     HEDLEY_DIAGNOSTIC_POP
+#endif
+
+#if defined(__SIZEOF_INT128__)
+#  define SIMDE_HAVE_INT128_
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_PEDANTIC_
+typedef __int128 simde_int128;
+typedef unsigned __int128 simde_uint128;
+HEDLEY_DIAGNOSTIC_POP
+#endif
+
+#if !defined(SIMDE_ENDIAN_LITTLE)
+#  define SIMDE_ENDIAN_LITTLE 1234
+#endif
+#if !defined(SIMDE_ENDIAN_BIG)
+#  define SIMDE_ENDIAN_BIG 4321
+#endif
+
+#if !defined(SIMDE_ENDIAN_ORDER)
+/* GCC (and compilers masquerading as GCC) define  __BYTE_ORDER__. */
+#  if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#  elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+/* TI defines _BIG_ENDIAN or _LITTLE_ENDIAN */
+#  elif defined(_BIG_ENDIAN)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+#  elif defined(_LITTLE_ENDIAN)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+/* We know the endianness of some common architectures.  Common
+ * architectures not listed (ARM, POWER, MIPS, etc.) here are
+ * bi-endian. */
+#  elif defined(__amd64) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#  elif defined(__s390x__) || defined(__zarch__)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+/* Looks like we'll have to rely on the platform.  If we're missing a
+ * platform, please let us know. */
+#  elif defined(_WIN32)
+#    define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#  elif defined(sun) || defined(__sun) /* Solaris */
+#    include <sys/byteorder.h>
+#    if defined(_LITTLE_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#    elif defined(_BIG_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+#    endif
+#  elif defined(__APPLE__)
+#    include <libkern/OSByteOrder.h>
+#    if defined(__LITTLE_ENDIAN__)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#    elif defined(__BIG_ENDIAN__)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+#    endif
+#  elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__) || defined(BSD)
+#    include <machine/endian.h>
+#    if defined(__BYTE_ORDER) && (__BYTE_ORDER == __LITTLE_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#    elif defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+#    endif
+#  elif defined(__linux__) || defined(__linux) || defined(__gnu_linux__)
+#    include <endian.h>
+#    if defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && (__BYTE_ORDER == __LITTLE_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_LITTLE
+#    elif defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && (__BYTE_ORDER == __BIG_ENDIAN)
+#      define SIMDE_ENDIAN_ORDER SIMDE_ENDIAN_BIG
+#    endif
+#  endif
+#endif
+
+#if \
+    HEDLEY_HAS_BUILTIN(__builtin_bswap64) || \
+    HEDLEY_GCC_VERSION_CHECK(4,3,0) || \
+    HEDLEY_IBM_VERSION_CHECK(13,1,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+  #define simde_bswap64(v) __builtin_bswap64(v)
+#elif HEDLEY_MSVC_VERSION_CHECK(13,10,0)
+  #define simde_bswap64(v) _byteswap_uint64(v)
+#else
+  SIMDE_FUNCTION_ATTRIBUTES
+  uint64_t
+  simde_bswap64(uint64_t v) {
+    return
+      ((v & (((uint64_t) 0xff) << 56)) >> 56) |
+      ((v & (((uint64_t) 0xff) << 48)) >> 40) |
+      ((v & (((uint64_t) 0xff) << 40)) >> 24) |
+      ((v & (((uint64_t) 0xff) << 32)) >>  8) |
+      ((v & (((uint64_t) 0xff) << 24)) <<  8) |
+      ((v & (((uint64_t) 0xff) << 16)) << 24) |
+      ((v & (((uint64_t) 0xff) <<  8)) << 40) |
+      ((v & (((uint64_t) 0xff)      )) << 56);
+  }
+#endif
+
+#if !defined(SIMDE_ENDIAN_ORDER)
+#  error Unknown byte order; please file a bug
+#else
+#  if SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE
+#    define simde_endian_bswap64_be(value) simde_bswap64(value)
+#    define simde_endian_bswap64_le(value) (value)
+#  elif SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG
+#    define simde_endian_bswap64_be(value) (value)
+#    define simde_endian_bswap64_le(value) simde_bswap64(value)
+#  endif
+#endif
+
+/* TODO: we should at least make an attempt to detect the correct
+   types for simde_float32/float64 instead of just assuming float and
+   double. */
+
+#if !defined(SIMDE_FLOAT32_TYPE)
+#  define SIMDE_FLOAT32_TYPE float
+#  define SIMDE_FLOAT32_C(value) value##f
+#else
+#  define SIMDE_FLOAT32_C(value) ((SIMDE_FLOAT32_TYPE) value)
+#endif
+typedef SIMDE_FLOAT32_TYPE simde_float32;
+
+#if !defined(SIMDE_FLOAT64_TYPE)
+#  define SIMDE_FLOAT64_TYPE double
+#  define SIMDE_FLOAT64_C(value) value
+#else
+#  define SIMDE_FLOAT32_C(value) ((SIMDE_FLOAT64_TYPE) value)
+#endif
+typedef SIMDE_FLOAT64_TYPE simde_float64;
+
+#if HEDLEY_HAS_WARNING("-Wbad-function-cast")
+#  define SIMDE_CONVERT_FTOI(T,v) \
+    HEDLEY_DIAGNOSTIC_PUSH \
+    _Pragma("clang diagnostic ignored \"-Wbad-function-cast\"") \
+    HEDLEY_STATIC_CAST(T, (v)) \
+    HEDLEY_DIAGNOSTIC_POP
+#else
+#  define SIMDE_CONVERT_FTOI(T,v) ((T) (v))
+#endif
+
+/* TODO: detect compilers which support this outside of C11 mode */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+  #define SIMDE_CHECKED_REINTERPRET_CAST(to, from, value) _Generic((value), to: (value), default: (_Generic((value), from: ((to) (value)))))
+  #define SIMDE_CHECKED_STATIC_CAST(to, from, value) _Generic((value), to: (value), default: (_Generic((value), from: ((to) (value)))))
+#else
+  #define SIMDE_CHECKED_REINTERPRET_CAST(to, from, value) HEDLEY_REINTERPRET_CAST(to, value)
+  #define SIMDE_CHECKED_STATIC_CAST(to, from, value) HEDLEY_STATIC_CAST(to, value)
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wfloat-equal")
+#  define SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL _Pragma("clang diagnostic ignored \"-Wfloat-equal\"")
+#elif HEDLEY_GCC_VERSION_CHECK(3,0,0)
+#  define SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#else
+#  define SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL
+#endif
+
+/* Some functions can trade accuracy for speed.  For those functions
+   you can control the trade-off using this macro.  Possible values:
+
+   0: prefer speed
+   1: reasonable trade-offs
+   2: prefer accuracy */
+#if !defined(SIMDE_ACCURACY_PREFERENCE)
+#  define SIMDE_ACCURACY_PREFERENCE 1
+#endif
+
+#if defined(__STDC_HOSTED__)
+#  define SIMDE_STDC_HOSTED __STDC_HOSTED__
+#else
+#  if \
+     defined(HEDLEY_PGI_VERSION) || \
+     defined(HEDLEY_MSVC_VERSION)
+#    define SIMDE_STDC_HOSTED 1
+#  else
+#    define SIMDE_STDC_HOSTED 0
+#  endif
+#endif
+
+/* Try to deal with environments without a standard library. */
+#if !defined(simde_memcpy)
+  #if HEDLEY_HAS_BUILTIN(__builtin_memcpy)
+    #define simde_memcpy(dest, src, n) __builtin_memcpy(dest, src, n)
+  #endif
+#endif
+#if !defined(simde_memset)
+  #if HEDLEY_HAS_BUILTIN(__builtin_memset)
+    #define simde_memset(s, c, n) __builtin_memset(s, c, n)
+  #endif
+#endif
+#if !defined(simde_memcmp)
+  #if HEDLEY_HAS_BUILTIN(__builtin_memcmp)
+    #define simde_memcmp(s1, s2, n) __builtin_memcmp(s1, s2, n)
+  #endif
+#endif
+
+#if !defined(simde_memcpy) || !defined(simde_memset) || !defined(simde_memcmp)
+  #if !defined(SIMDE_NO_STRING_H)
+    #if defined(__has_include)
+      #if !__has_include(<string.h>)
+        #define SIMDE_NO_STRING_H
+      #endif
+    #elif (SIMDE_STDC_HOSTED == 0)
+      #define SIMDE_NO_STRING_H
+    #endif
+  #endif
+
+  #if !defined(SIMDE_NO_STRING_H)
+    #include <string.h>
+    #if !defined(simde_memcpy)
+      #define simde_memcpy(dest, src, n) memcpy(dest, src, n)
+    #endif
+    #if !defined(simde_memset)
+      #define simde_memset(s, c, n) memset(s, c, n)
+    #endif
+    #if !defined(simde_memcmp)
+      #define simde_memcmp(s1, s2, n) memcmp(s1, s2, n)
+    #endif
+  #else
+    /* These are meant to be portable, not fast.  If you're hitting them you
+     * should think about providing your own (by defining the simde_memcpy
+     * macro prior to including any SIMDe files) or submitting a patch to
+     * SIMDe so we can detect your system-provided memcpy/memset, like by
+     * adding your compiler to the checks for __builtin_memcpy and/or
+     * __builtin_memset. */
+    #if !defined(simde_memcpy)
+      SIMDE_FUNCTION_ATTRIBUTES
+      void
+      simde_memcpy_(void* dest, const void* src, size_t len) {
+        char* dest_ = HEDLEY_STATIC_CAST(char*, dest);
+        char* src_ = HEDLEY_STATIC_CAST(const char*, src);
+        for (size_t i = 0 ; i < len ; i++) {
+          dest_[i] = src_[i];
+        }
+      }
+      #define simde_memcpy(dest, src, n) simde_memcpy_(dest, src, n)
+    #endif
+
+    #if !defined(simde_memset)
+      SIMDE_FUNCTION_ATTRIBUTES
+      void
+      simde_memset_(void* s, int c, size_t len) {
+        char* s_ = HEDLEY_STATIC_CAST(char*, s);
+        char c_ = HEDLEY_STATIC_CAST(char, c);
+        for (size_t i = 0 ; i < len ; i++) {
+          s_[i] = c_[i];
+        }
+      }
+      #define simde_memset(s, c, n) simde_memset_(s, c, n)
+    #endif
+
+    #if !defined(simde_memcmp)
+      SIMDE_FUCTION_ATTRIBUTES
+      int
+      simde_memcmp_(const void *s1, const void *s2, size_t n) {
+        unsigned char* s1_ = HEDLEY_STATIC_CAST(unsigned char*, s1);
+        unsigned char* s2_ = HEDLEY_STATIC_CAST(unsigned char*, s2);
+        for (size_t i = 0 ; i < len ; i++) {
+          if (s1_[i] != s2_[i]) {
+            return (int) (s1_[i] - s2_[i]);
+          }
+        }
+        return 0;
+      }
+    #define simde_memcmp(s1, s2, n) simde_memcmp_(s1, s2, n)
+    #endif
+  #endif
+#endif
+
+#if defined(FE_ALL_EXCEPT)
+  #define SIMDE_HAVE_FENV_H
+#elif defined(__has_include)
+  #if __has_include(<fenv.h>)
+    #include <fenv.h>
+    #define SIMDE_HAVE_FENV_H
+  #endif
+#elif SIMDE_STDC_HOSTED == 1
+  #include <fenv.h>
+  #define SIMDE_HAVE_FENV_H
+#endif
+
+#if defined(EXIT_FAILURE)
+  #define SIMDE_HAVE_STDLIB_H
+#elif defined(__has_include)
+  #if __has_include(<stdlib.h>)
+    #include <stdlib.h>
+    #define SIMDE_HAVE_STDLIB_H
+  #endif
+#elif SIMDE_STDC_HOSTED == 1
+  #include <stdlib.h>
+  #define SIMDE_HAVE_STDLIB_H
+#endif
+
+#if defined(__has_include)
+#  if defined(__cplusplus) && (__cplusplus >= 201103L) && __has_include(<cfenv>)
+#    include <cfenv>
+#  elif __has_include(<fenv.h>)
+#    include <fenv.h>
+#  endif
+#  if __has_include(<stdlib.h>)
+#    include <stdlib.h>
+#  endif
+#elif SIMDE_STDC_HOSTED == 1
+#  include <stdlib.h>
+#  include <fenv.h>
+#endif
+
+#include "check.h"
+
+/* Sometimes we run into problems with specific versions of compilers
+   which make the native versions unusable for us.  Often this is due
+   to missing functions, sometimes buggy implementations, etc.  These
+   macros are how we check for specific bugs.  As they are fixed we'll
+   start only defining them for problematic compiler versions. */
+
+#if !defined(SIMDE_IGNORE_COMPILER_BUGS)
+#  if defined(HEDLEY_GCC_VERSION)
+#    if !HEDLEY_GCC_VERSION_CHECK(4,9,0)
+#      define SIMDE_BUG_GCC_REV_208793
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(5,0,0)
+#      define SIMDE_BUG_GCC_BAD_MM_SRA_EPI32 /* TODO: find relevant bug or commit */
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(4,6,0)
+#      define SIMDE_BUG_GCC_BAD_MM_EXTRACT_EPI8 /* TODO: find relevant bug or commit */
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(8,0,0)
+#      define SIMDE_BUG_GCC_REV_247851
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(10,0,0)
+#      define SIMDE_BUG_GCC_REV_274313
+#      define SIMDE_BUG_GCC_91341
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(9,0,0) && defined(SIMDE_ARCH_AARCH64)
+#      define SIMDE_BUG_GCC_ARM_SHIFT_SCALAR
+#    endif
+#    if defined(SIMDE_ARCH_X86) && !defined(SIMDE_ARCH_AMD64)
+#      define SIMDE_BUG_GCC_94482
+#    endif
+#    if (defined(SIMDE_ARCH_X86) && !defined(SIMDE_ARCH_AMD64)) || defined(SIMDE_ARCH_SYSTEMZ)
+#      define SIMDE_BUG_GCC_53784
+#    endif
+#    if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+#      if HEDLEY_GCC_VERSION_CHECK(4,3,0) /* -Wsign-conversion */
+#        define SIMDE_BUG_GCC_95144
+#      endif
+#    endif
+#    if !HEDLEY_GCC_VERSION_CHECK(9,4,0) && defined(SIMDE_ARCH_AARCH64)
+#      define SIMDE_BUG_GCC_94488
+#    endif
+#    if defined(SIMDE_ARCH_ARM)
+#      define SIMDE_BUG_GCC_95399
+#      define SIMDE_BUG_GCC_95471
+#    elif defined(SIMDE_ARCH_POWER)
+#      define SIMDE_BUG_GCC_95227
+#      define SIMDE_BUG_GCC_95782
+#    elif defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+#      if !HEDLEY_GCC_VERSION_CHECK(10,2,0) && !defined(__OPTIMIZE__)
+#        define SIMDE_BUG_GCC_96174
+#      endif
+#    endif
+#    define SIMDE_BUG_GCC_95399
+#  elif defined(__clang__)
+#    if defined(SIMDE_ARCH_AARCH64)
+#      define SIMDE_BUG_CLANG_45541
+#      define SIMDE_BUG_CLANG_46844
+#    endif
+#    if defined(SIMDE_ARCH_POWER)
+#      define SIMDE_BUG_CLANG_46770
+#    endif
+#    if defined(SIMDE_ARCH_X86) || defined(SIMDE_ARCH_AMD64)
+#      if HEDLEY_HAS_WARNING("-Wsign-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(11,0,0)
+#        define SIMDE_BUG_CLANG_45931
+#      endif
+#    endif
+#    define SIMDE_BUG_CLANG_45959
+#  elif defined(HEDLEY_MSVC_VERSION)
+#    if defined(SIMDE_ARCH_X86)
+#      define SIMDE_BUG_MSVC_ROUND_EXTRACT
+#    endif
+#  elif defined(HEDLEY_INTEL_VERSION)
+#    define SIMDE_BUG_INTEL_857088
+#  endif
+#  if defined(HEDLEY_EMSCRIPTEN_VERSION)
+#    define SIMDE_BUG_EMSCRIPTEN_MISSING_IMPL /* Placeholder for (as yet) unfiled issues. */
+#    define SIMDE_BUG_EMSCRIPTEN_5242
+#  endif
+#endif
+
+/* GCC and Clang both have the same issue:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95144
+ * https://bugs.llvm.org/show_bug.cgi?id=45931
+ * This is just an easy way to work around it.
+ */
+#if \
+    (HEDLEY_HAS_WARNING("-Wsign-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(11,0,0)) || \
+    HEDLEY_GCC_VERSION_CHECK(4,3,0)
+#  define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr) (__extension__ ({ \
+       HEDLEY_DIAGNOSTIC_PUSH  \
+       HEDLEY_DIAGNOSTIC_POP  \
+       _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"") \
+       __typeof__(expr) simde_bug_ignore_sign_conversion_v_= (expr); \
+       HEDLEY_DIAGNOSTIC_PUSH  \
+       simde_bug_ignore_sign_conversion_v_; \
+     }))
+#else
+#  define SIMDE_BUG_IGNORE_SIGN_CONVERSION(expr) (expr)
+#endif
+
+#endif /* !defined(SIMDE_COMMON_H) */

--- a/2.0/simde/simde-constify.h
+++ b/2.0/simde/simde-constify.h
@@ -1,0 +1,397 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+/* Constify macros.  For internal use only.
+ *
+ * These are used to make it possible to call a function which takes
+ * an Integer Constant Expression (ICE) using a compile time constant.
+ * Technically it would also be possible to use a value not trivially
+ * known by the compiler, but there would be a siginficant performance
+ * hit (a switch switch is used).
+ *
+ * The basic idea is pretty simple; we just emit a do while loop which
+ * contains a switch with a case for every possible value of the
+ * constant.
+ *
+ * As long as the value you pass to the function in constant, pretty
+ * much any copmiler shouldn't have a problem generating exactly the
+ * same code as if you had used an ICE.
+ *
+ * This is intended to be used in the SIMDe implementations of
+ * functions the compilers require to be an ICE, but the other benefit
+ * is that if we also disable the warnings from
+ * SIMDE_REQUIRE_CONSTANT_RANGE we can actually just allow the tests
+ * to use non-ICE parameters
+ */
+
+#if !defined(SIMDE_CONSTIFY_H)
+#define SIMDE_CONSTIFY_H
+
+#include "simde-diagnostic.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_VARIADIC_MACROS_
+SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
+
+#define SIMDE_CONSTIFY_2_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: result = func_name(__VA_ARGS__, 0); break; \
+      case 1: result = func_name(__VA_ARGS__, 1); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_4_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: result = func_name(__VA_ARGS__, 0); break; \
+      case 1: result = func_name(__VA_ARGS__, 1); break; \
+      case 2: result = func_name(__VA_ARGS__, 2); break; \
+      case 3: result = func_name(__VA_ARGS__, 3); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_8_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: result = func_name(__VA_ARGS__, 0); break; \
+      case 1: result = func_name(__VA_ARGS__, 1); break; \
+      case 2: result = func_name(__VA_ARGS__, 2); break; \
+      case 3: result = func_name(__VA_ARGS__, 3); break; \
+      case 4: result = func_name(__VA_ARGS__, 4); break; \
+      case 5: result = func_name(__VA_ARGS__, 5); break; \
+      case 6: result = func_name(__VA_ARGS__, 6); break; \
+      case 7: result = func_name(__VA_ARGS__, 7); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_16_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: result = func_name(__VA_ARGS__,  0); break; \
+      case  1: result = func_name(__VA_ARGS__,  1); break; \
+      case  2: result = func_name(__VA_ARGS__,  2); break; \
+      case  3: result = func_name(__VA_ARGS__,  3); break; \
+      case  4: result = func_name(__VA_ARGS__,  4); break; \
+      case  5: result = func_name(__VA_ARGS__,  5); break; \
+      case  6: result = func_name(__VA_ARGS__,  6); break; \
+      case  7: result = func_name(__VA_ARGS__,  7); break; \
+      case  8: result = func_name(__VA_ARGS__,  8); break; \
+      case  9: result = func_name(__VA_ARGS__,  9); break; \
+      case 10: result = func_name(__VA_ARGS__, 10); break; \
+      case 11: result = func_name(__VA_ARGS__, 11); break; \
+      case 12: result = func_name(__VA_ARGS__, 12); break; \
+      case 13: result = func_name(__VA_ARGS__, 13); break; \
+      case 14: result = func_name(__VA_ARGS__, 14); break; \
+      case 15: result = func_name(__VA_ARGS__, 15); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_32_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: result = func_name(__VA_ARGS__,  0); break; \
+      case  1: result = func_name(__VA_ARGS__,  1); break; \
+      case  2: result = func_name(__VA_ARGS__,  2); break; \
+      case  3: result = func_name(__VA_ARGS__,  3); break; \
+      case  4: result = func_name(__VA_ARGS__,  4); break; \
+      case  5: result = func_name(__VA_ARGS__,  5); break; \
+      case  6: result = func_name(__VA_ARGS__,  6); break; \
+      case  7: result = func_name(__VA_ARGS__,  7); break; \
+      case  8: result = func_name(__VA_ARGS__,  8); break; \
+      case  9: result = func_name(__VA_ARGS__,  9); break; \
+      case 10: result = func_name(__VA_ARGS__, 10); break; \
+      case 11: result = func_name(__VA_ARGS__, 11); break; \
+      case 12: result = func_name(__VA_ARGS__, 12); break; \
+      case 13: result = func_name(__VA_ARGS__, 13); break; \
+      case 14: result = func_name(__VA_ARGS__, 14); break; \
+      case 15: result = func_name(__VA_ARGS__, 15); break; \
+      case 16: result = func_name(__VA_ARGS__, 16); break; \
+      case 17: result = func_name(__VA_ARGS__, 17); break; \
+      case 18: result = func_name(__VA_ARGS__, 18); break; \
+      case 19: result = func_name(__VA_ARGS__, 19); break; \
+      case 20: result = func_name(__VA_ARGS__, 20); break; \
+      case 21: result = func_name(__VA_ARGS__, 21); break; \
+      case 22: result = func_name(__VA_ARGS__, 22); break; \
+      case 23: result = func_name(__VA_ARGS__, 23); break; \
+      case 24: result = func_name(__VA_ARGS__, 24); break; \
+      case 25: result = func_name(__VA_ARGS__, 25); break; \
+      case 26: result = func_name(__VA_ARGS__, 26); break; \
+      case 27: result = func_name(__VA_ARGS__, 27); break; \
+      case 28: result = func_name(__VA_ARGS__, 28); break; \
+      case 29: result = func_name(__VA_ARGS__, 29); break; \
+      case 30: result = func_name(__VA_ARGS__, 30); break; \
+      case 31: result = func_name(__VA_ARGS__, 31); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_64_(func_name, result, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: result = func_name(__VA_ARGS__,  0); break; \
+      case  1: result = func_name(__VA_ARGS__,  1); break; \
+      case  2: result = func_name(__VA_ARGS__,  2); break; \
+      case  3: result = func_name(__VA_ARGS__,  3); break; \
+      case  4: result = func_name(__VA_ARGS__,  4); break; \
+      case  5: result = func_name(__VA_ARGS__,  5); break; \
+      case  6: result = func_name(__VA_ARGS__,  6); break; \
+      case  7: result = func_name(__VA_ARGS__,  7); break; \
+      case  8: result = func_name(__VA_ARGS__,  8); break; \
+      case  9: result = func_name(__VA_ARGS__,  9); break; \
+      case 10: result = func_name(__VA_ARGS__, 10); break; \
+      case 11: result = func_name(__VA_ARGS__, 11); break; \
+      case 12: result = func_name(__VA_ARGS__, 12); break; \
+      case 13: result = func_name(__VA_ARGS__, 13); break; \
+      case 14: result = func_name(__VA_ARGS__, 14); break; \
+      case 15: result = func_name(__VA_ARGS__, 15); break; \
+      case 16: result = func_name(__VA_ARGS__, 16); break; \
+      case 17: result = func_name(__VA_ARGS__, 17); break; \
+      case 18: result = func_name(__VA_ARGS__, 18); break; \
+      case 19: result = func_name(__VA_ARGS__, 19); break; \
+      case 20: result = func_name(__VA_ARGS__, 20); break; \
+      case 21: result = func_name(__VA_ARGS__, 21); break; \
+      case 22: result = func_name(__VA_ARGS__, 22); break; \
+      case 23: result = func_name(__VA_ARGS__, 23); break; \
+      case 24: result = func_name(__VA_ARGS__, 24); break; \
+      case 25: result = func_name(__VA_ARGS__, 25); break; \
+      case 26: result = func_name(__VA_ARGS__, 26); break; \
+      case 27: result = func_name(__VA_ARGS__, 27); break; \
+      case 28: result = func_name(__VA_ARGS__, 28); break; \
+      case 29: result = func_name(__VA_ARGS__, 29); break; \
+      case 30: result = func_name(__VA_ARGS__, 30); break; \
+      case 31: result = func_name(__VA_ARGS__, 31); break; \
+      case 32: result = func_name(__VA_ARGS__, 32); break; \
+      case 33: result = func_name(__VA_ARGS__, 33); break; \
+      case 34: result = func_name(__VA_ARGS__, 34); break; \
+      case 35: result = func_name(__VA_ARGS__, 35); break; \
+      case 36: result = func_name(__VA_ARGS__, 36); break; \
+      case 37: result = func_name(__VA_ARGS__, 37); break; \
+      case 38: result = func_name(__VA_ARGS__, 38); break; \
+      case 39: result = func_name(__VA_ARGS__, 39); break; \
+      case 40: result = func_name(__VA_ARGS__, 40); break; \
+      case 41: result = func_name(__VA_ARGS__, 41); break; \
+      case 42: result = func_name(__VA_ARGS__, 42); break; \
+      case 43: result = func_name(__VA_ARGS__, 43); break; \
+      case 44: result = func_name(__VA_ARGS__, 44); break; \
+      case 45: result = func_name(__VA_ARGS__, 45); break; \
+      case 46: result = func_name(__VA_ARGS__, 46); break; \
+      case 47: result = func_name(__VA_ARGS__, 47); break; \
+      case 48: result = func_name(__VA_ARGS__, 48); break; \
+      case 49: result = func_name(__VA_ARGS__, 49); break; \
+      case 50: result = func_name(__VA_ARGS__, 50); break; \
+      case 51: result = func_name(__VA_ARGS__, 51); break; \
+      case 52: result = func_name(__VA_ARGS__, 52); break; \
+      case 53: result = func_name(__VA_ARGS__, 53); break; \
+      case 54: result = func_name(__VA_ARGS__, 54); break; \
+      case 55: result = func_name(__VA_ARGS__, 55); break; \
+      case 56: result = func_name(__VA_ARGS__, 56); break; \
+      case 57: result = func_name(__VA_ARGS__, 57); break; \
+      case 58: result = func_name(__VA_ARGS__, 58); break; \
+      case 59: result = func_name(__VA_ARGS__, 59); break; \
+      case 60: result = func_name(__VA_ARGS__, 60); break; \
+      case 61: result = func_name(__VA_ARGS__, 61); break; \
+      case 62: result = func_name(__VA_ARGS__, 62); break; \
+      case 63: result = func_name(__VA_ARGS__, 63); break; \
+      default: result = default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_2_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: func_name(__VA_ARGS__, 0); break; \
+      case 1: func_name(__VA_ARGS__, 1); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_4_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: func_name(__VA_ARGS__, 0); break; \
+      case 1: func_name(__VA_ARGS__, 1); break; \
+      case 2: func_name(__VA_ARGS__, 2); break; \
+      case 3: func_name(__VA_ARGS__, 3); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_8_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case 0: func_name(__VA_ARGS__, 0); break; \
+      case 1: func_name(__VA_ARGS__, 1); break; \
+      case 2: func_name(__VA_ARGS__, 2); break; \
+      case 3: func_name(__VA_ARGS__, 3); break; \
+      case 4: func_name(__VA_ARGS__, 4); break; \
+      case 5: func_name(__VA_ARGS__, 5); break; \
+      case 6: func_name(__VA_ARGS__, 6); break; \
+      case 7: func_name(__VA_ARGS__, 7); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_16_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: func_name(__VA_ARGS__,  0); break; \
+      case  1: func_name(__VA_ARGS__,  1); break; \
+      case  2: func_name(__VA_ARGS__,  2); break; \
+      case  3: func_name(__VA_ARGS__,  3); break; \
+      case  4: func_name(__VA_ARGS__,  4); break; \
+      case  5: func_name(__VA_ARGS__,  5); break; \
+      case  6: func_name(__VA_ARGS__,  6); break; \
+      case  7: func_name(__VA_ARGS__,  7); break; \
+      case  8: func_name(__VA_ARGS__,  8); break; \
+      case  9: func_name(__VA_ARGS__,  9); break; \
+      case 10: func_name(__VA_ARGS__, 10); break; \
+      case 11: func_name(__VA_ARGS__, 11); break; \
+      case 12: func_name(__VA_ARGS__, 12); break; \
+      case 13: func_name(__VA_ARGS__, 13); break; \
+      case 14: func_name(__VA_ARGS__, 14); break; \
+      case 15: func_name(__VA_ARGS__, 15); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_32_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: func_name(__VA_ARGS__,  0); break; \
+      case  1: func_name(__VA_ARGS__,  1); break; \
+      case  2: func_name(__VA_ARGS__,  2); break; \
+      case  3: func_name(__VA_ARGS__,  3); break; \
+      case  4: func_name(__VA_ARGS__,  4); break; \
+      case  5: func_name(__VA_ARGS__,  5); break; \
+      case  6: func_name(__VA_ARGS__,  6); break; \
+      case  7: func_name(__VA_ARGS__,  7); break; \
+      case  8: func_name(__VA_ARGS__,  8); break; \
+      case  9: func_name(__VA_ARGS__,  9); break; \
+      case 10: func_name(__VA_ARGS__, 10); break; \
+      case 11: func_name(__VA_ARGS__, 11); break; \
+      case 12: func_name(__VA_ARGS__, 12); break; \
+      case 13: func_name(__VA_ARGS__, 13); break; \
+      case 14: func_name(__VA_ARGS__, 14); break; \
+      case 15: func_name(__VA_ARGS__, 15); break; \
+      case 16: func_name(__VA_ARGS__, 16); break; \
+      case 17: func_name(__VA_ARGS__, 17); break; \
+      case 18: func_name(__VA_ARGS__, 18); break; \
+      case 19: func_name(__VA_ARGS__, 19); break; \
+      case 20: func_name(__VA_ARGS__, 20); break; \
+      case 21: func_name(__VA_ARGS__, 21); break; \
+      case 22: func_name(__VA_ARGS__, 22); break; \
+      case 23: func_name(__VA_ARGS__, 23); break; \
+      case 24: func_name(__VA_ARGS__, 24); break; \
+      case 25: func_name(__VA_ARGS__, 25); break; \
+      case 26: func_name(__VA_ARGS__, 26); break; \
+      case 27: func_name(__VA_ARGS__, 27); break; \
+      case 28: func_name(__VA_ARGS__, 28); break; \
+      case 29: func_name(__VA_ARGS__, 29); break; \
+      case 30: func_name(__VA_ARGS__, 30); break; \
+      case 31: func_name(__VA_ARGS__, 31); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+#define SIMDE_CONSTIFY_64_NO_RESULT_(func_name, default_case, imm, ...) \
+  do { \
+    switch(imm) { \
+      case  0: func_name(__VA_ARGS__,  0); break; \
+      case  1: func_name(__VA_ARGS__,  1); break; \
+      case  2: func_name(__VA_ARGS__,  2); break; \
+      case  3: func_name(__VA_ARGS__,  3); break; \
+      case  4: func_name(__VA_ARGS__,  4); break; \
+      case  5: func_name(__VA_ARGS__,  5); break; \
+      case  6: func_name(__VA_ARGS__,  6); break; \
+      case  7: func_name(__VA_ARGS__,  7); break; \
+      case  8: func_name(__VA_ARGS__,  8); break; \
+      case  9: func_name(__VA_ARGS__,  9); break; \
+      case 10: func_name(__VA_ARGS__, 10); break; \
+      case 11: func_name(__VA_ARGS__, 11); break; \
+      case 12: func_name(__VA_ARGS__, 12); break; \
+      case 13: func_name(__VA_ARGS__, 13); break; \
+      case 14: func_name(__VA_ARGS__, 14); break; \
+      case 15: func_name(__VA_ARGS__, 15); break; \
+      case 16: func_name(__VA_ARGS__, 16); break; \
+      case 17: func_name(__VA_ARGS__, 17); break; \
+      case 18: func_name(__VA_ARGS__, 18); break; \
+      case 19: func_name(__VA_ARGS__, 19); break; \
+      case 20: func_name(__VA_ARGS__, 20); break; \
+      case 21: func_name(__VA_ARGS__, 21); break; \
+      case 22: func_name(__VA_ARGS__, 22); break; \
+      case 23: func_name(__VA_ARGS__, 23); break; \
+      case 24: func_name(__VA_ARGS__, 24); break; \
+      case 25: func_name(__VA_ARGS__, 25); break; \
+      case 26: func_name(__VA_ARGS__, 26); break; \
+      case 27: func_name(__VA_ARGS__, 27); break; \
+      case 28: func_name(__VA_ARGS__, 28); break; \
+      case 29: func_name(__VA_ARGS__, 29); break; \
+      case 30: func_name(__VA_ARGS__, 30); break; \
+      case 31: func_name(__VA_ARGS__, 31); break; \
+      case 32: func_name(__VA_ARGS__, 32); break; \
+      case 33: func_name(__VA_ARGS__, 33); break; \
+      case 34: func_name(__VA_ARGS__, 34); break; \
+      case 35: func_name(__VA_ARGS__, 35); break; \
+      case 36: func_name(__VA_ARGS__, 36); break; \
+      case 37: func_name(__VA_ARGS__, 37); break; \
+      case 38: func_name(__VA_ARGS__, 38); break; \
+      case 39: func_name(__VA_ARGS__, 39); break; \
+      case 40: func_name(__VA_ARGS__, 40); break; \
+      case 41: func_name(__VA_ARGS__, 41); break; \
+      case 42: func_name(__VA_ARGS__, 42); break; \
+      case 43: func_name(__VA_ARGS__, 43); break; \
+      case 44: func_name(__VA_ARGS__, 44); break; \
+      case 45: func_name(__VA_ARGS__, 45); break; \
+      case 46: func_name(__VA_ARGS__, 46); break; \
+      case 47: func_name(__VA_ARGS__, 47); break; \
+      case 48: func_name(__VA_ARGS__, 48); break; \
+      case 49: func_name(__VA_ARGS__, 49); break; \
+      case 50: func_name(__VA_ARGS__, 50); break; \
+      case 51: func_name(__VA_ARGS__, 51); break; \
+      case 52: func_name(__VA_ARGS__, 52); break; \
+      case 53: func_name(__VA_ARGS__, 53); break; \
+      case 54: func_name(__VA_ARGS__, 54); break; \
+      case 55: func_name(__VA_ARGS__, 55); break; \
+      case 56: func_name(__VA_ARGS__, 56); break; \
+      case 57: func_name(__VA_ARGS__, 57); break; \
+      case 58: func_name(__VA_ARGS__, 58); break; \
+      case 59: func_name(__VA_ARGS__, 59); break; \
+      case 60: func_name(__VA_ARGS__, 60); break; \
+      case 61: func_name(__VA_ARGS__, 61); break; \
+      case 62: func_name(__VA_ARGS__, 62); break; \
+      case 63: func_name(__VA_ARGS__, 63); break; \
+      default: default_case; break; \
+    } \
+  } while (0)
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif

--- a/2.0/simde/simde-detect-clang.h
+++ b/2.0/simde/simde-detect-clang.h
@@ -1,0 +1,107 @@
+/* Detect Clang Version
+ * Created by Evan Nemerson <evan@nemerson.com>
+ *
+ * To the extent possible under law, the author(s) have dedicated all
+ * copyright and related and neighboring rights to this software to
+ * the public domain worldwide. This software is distributed without
+ * any warranty.
+ *
+ * For details, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+/* This file was originally part of SIMDe
+ * (<https://github.com/simd-everywhere/simde>).  You're free to do with it as
+ * you please, but I do have a few small requests:
+ *
+ *  * If you make improvements, please submit them back to SIMDe
+ *    (at <https://github.com/simd-everywhere/simde/issues>) so others can
+ *    benefit from them.
+ *  * Please keep a link to SIMDe intact so people know where to submit
+ *    improvements.
+ *  * If you expose it publicly, please change the SIMDE_ prefix to
+ *    something specific to your project.
+ *
+ * The version numbers clang exposes (in the ___clang_major__,
+ * __clang_minor__, and __clang_patchlevel__ macros) are unreliable.
+ * Vendors such as Apple will define these values to their version
+ * numbers; for example, "Apple Clang 4.0" is really clang 3.1, but
+ * __clang_major__ and __clang_minor__ are defined to 4 and 0
+ * respectively, instead of 3 and 1.
+ *
+ * The solution is *usually* to use clang's feature detection macros
+ * (<https://clang.llvm.org/docs/LanguageExtensions.html#feature-checking-macros>)
+ * to determine if the feature you're interested in is available.  This
+ * generally works well, and it should probably be the first thing you
+ * try.  Unfortunately, it's not possible to check for everything.  In
+ * particular, compiler bugs.
+ *
+ * This file just uses the feature checking macros to detect features
+ * added in specific versions of clang to identify which version of
+ * clang the compiler is based on.
+ *
+ * Right now it only goes back to 3.6, but I'm happy to accept patches
+ * to go back further.  And, of course, newer versions are welcome if
+ * they're not already present, and if you find a way to detect a point
+ * release that would be great, too!
+ */
+
+#if !defined(SIMDE_DETECT_CLANG_H)
+#define SIMDE_DETECT_CLANG_H 1
+
+/* Attempt to detect the upstream clang version number.  I usually only
+ * worry about major version numbers (at least for 4.0+), but if you
+ * need more resolution I'm happy to accept patches that are able to
+ * detect minor versions as well.  That said, you'll probably have a
+ * hard time with detection since AFAIK most minor releases don't add
+ * anything we can detect. */
+
+#if defined(__clang__) && !defined(SIMDE_DETECT_CLANG_VERSION)
+#  if __has_warning("-Wimplicit-const-int-float-conversion")
+#    define SIMDE_DETECT_CLANG_VERSION 110000
+#  elif __has_warning("-Wmisleading-indentation")
+#    define SIMDE_DETECT_CLANG_VERSION 100000
+#  elif defined(__FILE_NAME__)
+#    define SIMDE_DETECT_CLANG_VERSION 90000
+#  elif __has_warning("-Wextra-semi-stmt") || __has_builtin(__builtin_rotateleft32)
+#    define SIMDE_DETECT_CLANG_VERSION 80000
+#  elif __has_warning("-Wc++98-compat-extra-semi")
+#    define SIMDE_DETECT_CLANG_VERSION 70000
+#  elif __has_warning("-Wpragma-pack")
+#    define SIMDE_DETECT_CLANG_VERSION 60000
+#  elif __has_warning("-Wbitfield-enum-conversion")
+#    define SIMDE_DETECT_CLANG_VERSION 50000
+#  elif __has_attribute(diagnose_if)
+#    define SIMDE_DETECT_CLANG_VERSION 40000
+#  elif __has_warning("-Wcast-calling-convention")
+#    define SIMDE_DETECT_CLANG_VERSION 30900
+#  elif __has_warning("-WCL4")
+#    define SIMDE_DETECT_CLANG_VERSION 30800
+#  elif __has_warning("-WIndependentClass-attribute")
+#    define SIMDE_DETECT_CLANG_VERSION 30700
+#  elif __has_warning("-Wambiguous-ellipsis")
+#    define SIMDE_DETECT_CLANG_VERSION 30600
+#  else
+#    define SIMDE_DETECT_CLANG_VERSION 1
+#  endif
+#endif /* defined(__clang__) && !defined(SIMDE_DETECT_CLANG_VERSION) */
+
+/* The SIMDE_DETECT_CLANG_VERSION_CHECK macro is pretty
+ * straightforward; it returns true if the compiler is a derivative
+ * of clang >= the specified version.
+ *
+ * Since this file is often (primarily?) useful for working around bugs
+ * it is also helpful to have a macro which returns true if only if the
+ * compiler is a version of clang *older* than the specified version to
+ * make it a bit easier to ifdef regions to add code for older versions,
+ * such as pragmas to disable a specific warning. */
+
+#if defined(SIMDE_DETECT_CLANG_VERSION)
+#  define SIMDE_DETECT_CLANG_VERSION_CHECK(major, minor, revision) (SIMDE_DETECT_CLANG_VERSION >= ((major * 10000) + (minor * 1000) + (revision)))
+#  define SIMDE_DETECT_CLANG_VERSION_NOT(major, minor, revision) (SIMDE_DETECT_CLANG_VERSION < ((major * 10000) + (minor * 1000) + (revision)))
+#else
+#  define SIMDE_DETECT_CLANG_VERSION_CHECK(major, minor, revision) (0)
+#  define SIMDE_DETECT_CLANG_VERSION_NOT(major, minor, revision) (1)
+#endif
+
+#endif /* !defined(SIMDE_DETECT_CLANG_H) */

--- a/2.0/simde/simde-diagnostic.h
+++ b/2.0/simde/simde-diagnostic.h
@@ -1,0 +1,379 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+/* SIMDe targets a very wide range of standards and compilers, and our
+ * goal is to compile cleanly even with extremely aggressive warnings
+ * (i.e., -Weverything in clang, -Wextra in GCC, /W4 for MSVC, etc.)
+ * treated as errors.
+ *
+ * While our preference is to resolve the underlying issue a given
+ * diagnostic is warning us about, sometimes that's not possible.
+ * Fixing a warning in one compiler may cause problems in another.
+ * Sometimes a warning doesn't really apply to us (false positives),
+ * and sometimes adhering to a warning would mean dropping a feature
+ * we *know* the compiler supports since we have tested specifically
+ * for the compiler or feature.
+ *
+ * When practical, warnings are only disabled for specific code.  For
+ * a list of warnings which are enabled by default in all SIMDe code,
+ * see SIMDE_DISABLE_UNWANTED_DIAGNOSTICS.  Note that we restore the
+ * warning stack when SIMDe is done parsing, so code which includes
+ * SIMDe is not deprived of these warnings.
+ */
+
+#if !defined(SIMDE_DIAGNOSTIC_H)
+#define SIMDE_DIAGNOSTIC_H
+
+#include "hedley.h"
+#include "simde-detect-clang.h"
+
+/* This is only to help us implement functions like _mm_undefined_ps. */
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  #undef SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+#if HEDLEY_HAS_WARNING("-Wuninitialized")
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("clang diagnostic ignored \"-Wuninitialized\"")
+#elif HEDLEY_GCC_VERSION_CHECK(4,2,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("GCC diagnostic ignored \"-Wuninitialized\"")
+#elif HEDLEY_PGI_VERSION_CHECK(19,10,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("diag_suppress 549")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,14,0) && defined(__cplusplus)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("error_messages(off,SEC_UNINITIALIZED_MEM_READ,SEC_UNDEFINED_RETURN_VALUE,unassigned)")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,14,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("error_messages(off,SEC_UNINITIALIZED_MEM_READ,SEC_UNDEFINED_RETURN_VALUE)")
+#elif HEDLEY_SUNPRO_VERSION_CHECK(5,12,0) && defined(__cplusplus)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("error_messages(off,unassigned)")
+#elif \
+     HEDLEY_TI_VERSION_CHECK(16,9,9) || \
+     HEDLEY_TI_CL6X_VERSION_CHECK(8,0,0) || \
+     HEDLEY_TI_CL7X_VERSION_CHECK(1,2,0) || \
+     HEDLEY_TI_CLPRU_VERSION_CHECK(2,3,2)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("diag_suppress 551")
+#elif HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ _Pragma("warning(disable:592)")
+#elif HEDLEY_MSVC_VERSION_CHECK(19,0,0) && !defined(__MSVC_RUNTIME_CHECKS)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_ __pragma(warning(disable:4700))
+#endif
+
+/* GCC emits a lot of "notes" about the ABI being different for things
+ * in newer versions of GCC.  We don't really care because all our
+ * functions are inlined and don't generate ABI. */
+#if HEDLEY_GCC_VERSION_CHECK(7,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_PSABI_ _Pragma("GCC diagnostic ignored \"-Wpsabi\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_PSABI_
+#endif
+
+/* Since MMX uses x87 FP registers, you're supposed to call _mm_empty()
+ * after each MMX function before any floating point instructions.
+ * Some compilers warn about functions which use MMX functions but
+ * don't call _mm_empty().  However, since SIMDe is implementyng the
+ * MMX API we shouldn't be calling _mm_empty(); we leave it to the
+ * caller to invoke simde_mm_empty(). */
+#if HEDLEY_INTEL_VERSION_CHECK(19,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_NO_EMMS_INSTRUCTION_ _Pragma("warning(disable:13200 13203)")
+#elif defined(HEDLEY_MSVC_VERSION)
+  #define SIMDE_DIAGNOSTIC_DISABLE_NO_EMMS_INSTRUCTION_ __pragma(warning(disable:4799))
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_NO_EMMS_INSTRUCTION_
+#endif
+
+/* Intel is pushing people to use OpenMP SIMD instead of Cilk+, so they
+ * emit a diagnostic if you use #pragma simd instead of
+ * #pragma omp simd.  SIMDe supports OpenMP SIMD, you just need to
+ * compile with -qopenmp or -qopenmp-simd and define
+ * SIMDE_ENABLE_OPENMP.  Cilk+ is just a fallback. */
+#if HEDLEY_INTEL_VERSION_CHECK(18,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_SIMD_PRAGMA_DEPRECATED_ _Pragma("warning(disable:3948)")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_SIMD_PRAGMA_DEPRECATED_
+#endif
+
+/* MSVC emits a diagnostic when we call a function (like
+ * simde_mm_set_epi32) while initializing a struct.  We currently do
+ * this a *lot* in the tests. */
+#if \
+  defined(HEDLEY_MSVC_VERSION)
+  #define SIMDE_DIAGNOSTIC_DISABLE_NON_CONSTANT_AGGREGATE_INITIALIZER_ __pragma(warning(disable:4204))
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_NON_CONSTANT_AGGREGATE_INITIALIZER_
+#endif
+
+/* This warning needs a lot of work.  It is triggered if all you do is
+ * pass the value to memcpy/__builtin_memcpy, or if you initialize a
+ * member of the union, even if that member takes up the entire union.
+ * Last tested with clang-10, hopefully things will improve in the
+ * future; if clang fixes this I'd love to enable it. */
+#if \
+  HEDLEY_HAS_WARNING("-Wconditional-uninitialized")
+  #define SIMDE_DIAGNOSTIC_DISABLE_CONDITIONAL_UNINITIALIZED_ _Pragma("clang diagnostic ignored \"-Wconditional-uninitialized\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_CONDITIONAL_UNINITIALIZED_
+#endif
+
+/* This warning is meant to catch things like `0.3 + 0.4 == 0.7`, which
+ * will is false.  However, SIMDe uses these operations exclusively
+ * for things like _mm_cmpeq_ps, for which we really do want to check
+ * for equality (or inequality).
+ *
+ * If someone wants to put together a SIMDE_FLOAT_EQUAL(a, op, b) macro
+ * which just wraps a check in some code do disable this diagnostic I'd
+ * be happy to accept it. */
+#if \
+  HEDLEY_HAS_WARNING("-Wfloat-equal") || \
+  HEDLEY_GCC_VERSION_CHECK(3,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_ _Pragma("GCC diagnostic ignored \"-Wfloat-equal\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_
+#endif
+
+/* This is because we use HEDLEY_STATIC_ASSERT for static assertions.
+ * If Hedley can't find an implementation it will preprocess to
+ * nothing, which means there will be a trailing semi-colon. */
+#if HEDLEY_HAS_WARNING("-Wextra-semi")
+  #define SIMDE_DIAGNOSTIC_DISABLE_EXTRA_SEMI_ _Pragma("clang diagnostic ignored \"-Wextra-semi\"")
+#elif HEDLEY_GCC_VERSION_CHECK(8,1,0) && defined(__cplusplus)
+  #define SIMDE_DIAGNOSTIC_DISABLE_EXTRA_SEMI_ _Pragma("GCC diagnostic ignored \"-Wextra-semi\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_EXTRA_SEMI_
+#endif
+
+/* We do use a few variadic macros, which technically aren't available
+ * until C99 and C++11, but every compiler I'm aware of has supported
+ * them for much longer.  That said, usage is isolated to the test
+ * suite and compilers known to support them. */
+#if HEDLEY_HAS_WARNING("-Wvariadic-macros") || HEDLEY_GCC_VERSION_CHECK(4,0,0)
+  #if HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic")
+    #define SIMDE_DIAGNOSTIC_DISABLE_VARIADIC_MACROS_ \
+      _Pragma("clang diagnostic ignored \"-Wvariadic-macros\"") \
+      _Pragma("clang diagnostic ignored \"-Wc++98-compat-pedantic\"")
+  #else
+    #define SIMDE_DIAGNOSTIC_DISABLE_VARIADIC_MACROS_ _Pragma("GCC diagnostic ignored \"-Wvariadic-macros\"")
+  #endif
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_VARIADIC_MACROS_
+#endif
+
+/* emscripten requires us to use a __wasm_unimplemented_simd128__ macro
+ * before we can access certain SIMD intrinsics, but this diagnostic
+ * warns about it being a reserved name.  It is a reserved name, but
+ * it's reserved for the compiler and we are using it to convey
+ * information to the compiler. */
+#if HEDLEY_HAS_WARNING("-Wdouble-promotion")
+  #define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_ _Pragma("clang diagnostic ignored \"-Wreserved-id-macro\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_
+#endif
+
+/* clang 3.8 warns about the packed attribute being unnecessary when
+ * used in the _mm_loadu_* functions.  That *may* be true for version
+ * 3.8, but for later versions it is crucial in order to make unaligned
+ * access safe. */
+#if HEDLEY_HAS_WARNING("-Wpacked")
+  #define SIMDE_DIAGNOSTIC_DISABLE_PACKED_ _Pragma("clang diagnostic ignored \"-Wpacked\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+#endif
+
+/* Triggered when assigning a float to a double implicitly.  We use
+ * explicit casts in SIMDe, this is only used in the test suite. */
+#if HEDLEY_HAS_WARNING("-Wdouble-promotion")
+  #define SIMDE_DIAGNOSTIC_DISABLE_DOUBLE_PROMOTION_ _Pragma("clang diagnostic ignored \"-Wdouble-promotion\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_DOUBLE_PROMOTION_
+#endif
+
+/* Several compilers treat conformant array parameters as VLAs.  We
+ * test to make sure we're in C mode (C++ doesn't support CAPs), and
+ * that the version of the standard supports CAPs.  We also reject
+ * some buggy compilers like MSVC (the logic is in Hedley if you want
+ * to take a look), but with certain warnings enabled some compilers
+ * still like to emit a diagnostic. */
+#if HEDLEY_HAS_WARNING("-Wvla")
+  #define SIMDE_DIAGNOSTIC_DISABLE_VLA_ _Pragma("clang diagnostic ignored \"-Wvla\"")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_VLA_ _Pragma("GCC diagnostic ignored \"-Wvla\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_VLA_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wused-but-marked-unused")
+  #define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ _Pragma("clang diagnostic ignored \"-Wused-but-marked-unused\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wunused-function")
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ _Pragma("clang diagnostic ignored \"-Wunused-function\"")
+#elif HEDLEY_GCC_VERSION_CHECK(3,4,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(19,0,0) /* Likely goes back further */
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ __pragma(warning(disable:4505))
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wpass-failed")
+  #define SIMDE_DIAGNOSTIC_DISABLE_PASS_FAILED_ _Pragma("clang diagnostic ignored \"-Wpass-failed\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_PASS_FAILED_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wpadded")
+  #define SIMDE_DIAGNOSTIC_DISABLE_PADDED_ _Pragma("clang diagnostic ignored \"-Wpadded\"")
+#elif HEDLEY_MSVC_VERSION_CHECK(19,0,0) /* Likely goes back further */
+  #define SIMDE_DIAGNOSTIC_DISABLE_PADDED_ __pragma(warning(disable:4324))
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_PADDED_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wzero-as-null-pointer-constant")
+  #define SIMDE_DIAGNOSTIC_DISABLE_ZERO_AS_NULL_POINTER_CONSTANT_ _Pragma("clang diagnostic ignored \"-Wzero-as-null-pointer-constant\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_ZERO_AS_NULL_POINTER_CONSTANT_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wold-style-cast")
+  #define SIMDE_DIAGNOSTIC_DISABLE_OLD_STYLE_CAST_ _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_OLD_STYLE_CAST_
+#endif
+
+#if HEDLEY_HAS_WARNING("-Wcast-function-type") || HEDLEY_GCC_VERSION_CHECK(8,0,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_CAST_FUNCTION_TYPE_ _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_CAST_FUNCTION_TYPE_
+#endif
+
+/* clang will emit this warning when we use C99 extensions whan not in
+ * C99 mode, even though it does support this.  In such cases we check
+ * the compiler and version first, so we know it's not a problem. */
+#if HEDLEY_HAS_WARNING("-Wc99-extensions")
+  #define SIMDE_DIAGNOSTIC_DISABLE_C99_EXTENSIONS_ _Pragma("clang diagnostic ignored \"-Wc99-extensions\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_C99_EXTENSIONS_
+#endif
+
+/* https://github.com/simd-everywhere/simde/issues/277 */
+#if defined(HEDLEY_GCC_VERSION) && HEDLEY_GCC_VERSION_CHECK(4,6,0) && !HEDLEY_GCC_VERSION_CHECK(6,4,0) && defined(__cplusplus)
+  #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_ _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_
+#endif
+
+/* This is the warning that you normally define _CRT_SECURE_NO_WARNINGS
+ * to silence, but you have to do that before including anything and
+ * that would require reordering includes. */
+#if defined(_MSC_VER)
+  #define SIMDE_DIAGNOSTIC_DISABLE_ANNEX_K_ __pragma(warning(disable:4996))
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_ANNEX_K_
+#endif
+
+/* Some compilers, such as clang, may use `long long` for 64-bit
+ * integers, but `long long` triggers a diagnostic with
+ * -Wc++98-compat-pedantic which says 'long long' is incompatible with
+ * C++98. */
+#if HEDLEY_HAS_WARNING("-Wc++98-compat-pedantic")
+  #define SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_ _Pragma("clang diagnostic ignored \"-Wc++98-compat-pedantic\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_
+#endif
+
+/* Some problem as above */
+#if HEDLEY_HAS_WARNING("-Wc++11-long-long")
+  #define SIMDE_DIAGNOSTIC_DISABLE_CPP11_LONG_LONG_ _Pragma("clang diagnostic ignored \"-Wc++11-long-long\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_CPP11_LONG_LONG_
+#endif
+
+/* emscripten emits this whenever stdin/stdout/stderr is used in a
+ * macro. */
+#if HEDLEY_HAS_WARNING("-Wdisabled-macro-expansion")
+  #define SIMDE_DIAGNOSTIC_DISABLE_DISABLED_MACRO_EXPANSION_ _Pragma("clang diagnostic ignored \"-Wdisabled-macro-expansion\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_DISABLED_MACRO_EXPANSION_
+#endif
+
+/* Clang uses C11 generic selections to implement some AltiVec
+ * functions, which triggers this diagnostic when not compiling
+ * in C11 mode */
+#if HEDLEY_HAS_WARNING("-Wc11-extensions")
+  #define SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_ _Pragma("clang diagnostic ignored \"-Wc11-extensions\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
+#endif
+
+/* Clang sometimes triggers this warning in macros in the AltiVec and
+ * NEON headers, or due to missing functions. */
+#if HEDLEY_HAS_WARNING("-Wvector-conversion")
+  #define SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_ _Pragma("clang diagnostic ignored \"-Wvector-conversion\"")
+  /* For NEON, the situation with -Wvector-conversion in clang < 10 is
+   * bad enough that we just disable the warning altogether. */
+  #if defined(__arm__) && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+    #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_ SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+  #endif
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+#endif
+#if !defined(SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_)
+  #define SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_
+#endif
+
+/* SLEEF triggers this a *lot* in their headers */
+#if HEDLEY_HAS_WARNING("-Wignored-qualifiers")
+  #define SIMDE_DIAGNOSTIC_DISABLE_IGNORED_QUALIFIERS_ _Pragma("clang diagnostic ignored \"-Wignored-qualifiers\"")
+#elif HEDLEY_GCC_VERSION_CHECK(4,3,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_IGNORED_QUALIFIERS_ _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_IGNORED_QUALIFIERS_
+#endif
+
+/* GCC emits this under some circumstances when using __int128 */
+#if HEDLEY_GCC_VERSION_CHECK(4,8,0)
+  #define SIMDE_DIAGNOSTIC_DISABLE_PEDANTIC_ _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#else
+  #define SIMDE_DIAGNOSTIC_DISABLE_PEDANTIC_
+#endif
+
+#define SIMDE_DISABLE_UNWANTED_DIAGNOSTICS \
+  SIMDE_DIAGNOSTIC_DISABLE_PSABI_ \
+  SIMDE_DIAGNOSTIC_DISABLE_NO_EMMS_INSTRUCTION_ \
+  SIMDE_DIAGNOSTIC_DISABLE_SIMD_PRAGMA_DEPRECATED_ \
+  SIMDE_DIAGNOSTIC_DISABLE_CONDITIONAL_UNINITIALIZED_ \
+  SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_ \
+  SIMDE_DIAGNOSTIC_DISABLE_NON_CONSTANT_AGGREGATE_INITIALIZER_ \
+  SIMDE_DIAGNOSTIC_DISABLE_EXTRA_SEMI_ \
+  SIMDE_DIAGNOSTIC_DISABLE_VLA_ \
+  SIMDE_DIAGNOSTIC_DISABLE_USED_BUT_MARKED_UNUSED_ \
+  SIMDE_DIAGNOSTIC_DISABLE_UNUSED_FUNCTION_ \
+  SIMDE_DIAGNOSTIC_DISABLE_PASS_FAILED_ \
+  SIMDE_DIAGNOSTIC_DISABLE_CPP98_COMPAT_PEDANTIC_ \
+  SIMDE_DIAGNOSTIC_DISABLE_CPP11_LONG_LONG_ \
+  SIMDE_DIAGNOSTIC_DISABLE_BUGGY_UNUSED_BUT_SET_VARIBALE_ \
+  SIMDE_DIAGNOSTIC_DISABLE_BUGGY_VECTOR_CONVERSION_
+
+#endif /* !defined(SIMDE_DIAGNOSTIC_H) */

--- a/2.0/simde/simde-features.h
+++ b/2.0/simde/simde-features.h
@@ -1,0 +1,462 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+/* simde-arch.h is used to determine which features are available according
+   to the compiler.  However, we want to make it possible to forcibly enable
+   or disable APIs */
+
+#if !defined(SIMDE_FEATURES_H)
+#define SIMDE_FEATURES_H
+
+#include "simde-arch.h"
+#include "simde-diagnostic.h"
+
+#if !defined(SIMDE_X86_SVML_NATIVE) && !defined(SIMDE_X86_SVML_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SVML)
+    #define SIMDE_X86_SVML_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SVML_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+  #define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512CD_NATIVE) && !defined(SIMDE_X86_AVX512CD_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX512CD)
+    #define SIMDE_X86_AVX512CD_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512CD_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+  #define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512DQ_NATIVE) && !defined(SIMDE_X86_AVX512DQ_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX512DQ)
+    #define SIMDE_X86_AVX512DQ_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512DQ_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+  #define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_X86_AVX512VL_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX512VL)
+    #define SIMDE_X86_AVX512VL_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512VL_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+  #define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_X86_AVX512BW_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX512BW)
+    #define SIMDE_X86_AVX512BW_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512BW_NATIVE) && !defined(SIMDE_X86_AVX512F_NATIVE)
+  #define SIMDE_X86_AVX512F_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX512F_NATIVE) && !defined(SIMDE_X86_AVX512F_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX512F)
+    #define SIMDE_X86_AVX512F_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX512F_NATIVE) && !defined(SIMDE_X86_AVX2_NATIVE)
+  #define SIMDE_X86_AVX2_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_FMA_NATIVE) && !defined(SIMDE_X86_FMA_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_FMA)
+    #define SIMDE_X86_FMA_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_FMA_NATIVE) && !defined(SIMDE_X86_AVX_NATIVE)
+  #define SIMDE_X86_AVX_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX2_NATIVE) && !defined(SIMDE_X86_AVX2_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX2)
+    #define SIMDE_X86_AVX2_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_NATIVE) && !defined(SIMDE_X86_AVX_NATIVE)
+  #define SIMDE_X86_AVX_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_AVX_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_AVX)
+    #define SIMDE_X86_AVX_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_X86_SSE4_1_NATIVE)
+  #define SIMDE_X86_SSE4_2_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSE4_2_NATIVE) && !defined(SIMDE_X86_SSE4_2_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSE4_2)
+    #define SIMDE_X86_SSE4_2_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SSE4_2_NATIVE) && !defined(SIMDE_X86_SSE4_1_NATIVE)
+  #define SIMDE_X86_SSE4_1_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(SIMDE_X86_SSE4_1_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSE4_1)
+    #define SIMDE_X86_SSE4_1_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(SIMDE_X86_SSSE3_NATIVE)
+  #define SIMDE_X86_SSSE3_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSSE3_NATIVE) && !defined(SIMDE_X86_SSSE3_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSSE3)
+    #define SIMDE_X86_SSSE3_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SSSE3_NATIVE) && !defined(SIMDE_X86_SSE3_NATIVE)
+  #define SIMDE_X86_SSE3_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSE3_NATIVE) && !defined(SIMDE_X86_SSE3_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSE3)
+    #define SIMDE_X86_SSE3_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SSE3_NATIVE) && !defined(SIMDE_X86_SSE2_NATIVE)
+  #define SIMDE_X86_SSE2_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_X86_SSE2_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSE2)
+    #define SIMDE_X86_SSE2_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_X86_SSE_NATIVE)
+  #define SIMDE_X86_SSE_NATIVE
+#endif
+
+#if !defined(SIMDE_X86_SSE_NATIVE) && !defined(SIMDE_X86_SSE_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_SSE)
+    #define SIMDE_X86_SSE_NATIVE
+  #endif
+#endif
+
+#if !defined(SIMDE_X86_MMX_NATIVE) && !defined(SIMDE_X86_MMX_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_MMX)
+    #define SIMDE_X86_MMX_NATIVE
+  #endif
+#endif
+
+#if !defined(SIMDE_X86_GFNI_NATIVE) && !defined(SIMDE_X86_GFNI_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_X86_GFNI)
+    #define SIMDE_X86_GFNI_NATIVE
+  #endif
+#endif
+
+#if !defined(SIMDE_X86_SVML_NATIVE) && !defined(SIMDE_X86_SVML_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(__INTEL_COMPILER)
+    #define SIMDE_X86_SVML_NATIVE
+  #endif
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION)
+  #pragma warning(push)
+  #pragma warning(disable:4799)
+#endif
+
+#if \
+    defined(SIMDE_X86_AVX_NATIVE) || \
+    defined(SIMDE_X86_GFNI_NATIVE) || \
+    defined(SIMDE_X86_SVML_NATIVE)
+  #include <immintrin.h>
+#elif defined(SIMDE_X86_SSE4_2_NATIVE)
+  #include <nmmintrin.h>
+#elif defined(SIMDE_X86_SSE4_1_NATIVE)
+  #include <smmintrin.h>
+#elif defined(SIMDE_X86_SSSE3_NATIVE)
+  #include <tmmintrin.h>
+#elif defined(SIMDE_X86_SSE3_NATIVE)
+  #include <pmmintrin.h>
+#elif defined(SIMDE_X86_SSE2_NATIVE)
+  #include <emmintrin.h>
+#elif defined(SIMDE_X86_SSE_NATIVE)
+  #include <xmmintrin.h>
+#elif defined(SIMDE_X86_MMX_NATIVE)
+  #include <mmintrin.h>
+#endif
+
+#if defined(HEDLEY_MSVC_VERSION)
+  #pragma warning(pop)
+#endif
+
+#if !defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_ARM_NEON_A64V8_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_ARM_NEON) && defined(SIMDE_ARCH_AARCH64) && SIMDE_ARCH_ARM_CHECK(80)
+    #define SIMDE_ARM_NEON_A64V8_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && !defined(SIMDE_ARM_NEON_A32V8_NATIVE)
+  #define SIMDE_ARM_NEON_A32V8_NATIVE
+#endif
+
+#if !defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_ARM_NEON_A32V8_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(80)
+    #define SIMDE_ARM_NEON_A32V8_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define SIMDE_ARM_NEON_A32V7_NATIVE
+#endif
+
+#if !defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(SIMDE_ARM_NEON_A32V7_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_ARM_NEON) && SIMDE_ARCH_ARM_CHECK(70)
+    #define SIMDE_ARM_NEON_A32V7_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #include <arm_neon.h>
+#endif
+
+#if !defined(SIMDE_ARM_SVE_NATIVE) && !defined(SIMDE_ARM_SVE_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_ARM_SVE)
+    #define SIMDE_ARM_SVE_NATIVE
+    #include <arm_sve.h>
+  #endif
+#endif
+
+#if !defined(SIMDE_WASM_SIMD128_NATIVE) && !defined(SIMDE_WASM_SIMD128_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if defined(SIMDE_ARCH_WASM_SIMD128)
+    #define SIMDE_WASM_SIMD128_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_WASM_SIMD128_NATIVE)
+  #if !defined(__wasm_unimplemented_simd128__)
+    HEDLEY_DIAGNOSTIC_PUSH
+    SIMDE_DIAGNOSTIC_DISABLE_RESERVED_ID_MACRO_
+    #define __wasm_unimplemented_simd128__
+    HEDLEY_DIAGNOSTIC_POP
+  #endif
+  #include <wasm_simd128.h>
+#endif
+
+#if !defined(SIMDE_POWER_ALTIVEC_P9_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P9_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if SIMDE_ARCH_POWER_ALTIVEC_CHECK(900)
+    #define SIMDE_POWER_ALTIVEC_P9_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_POWER_ALTIVEC_P9_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P8)
+  #define SIMDE_POWER_ALTIVEC_P8_NATIVE
+#endif
+
+#if !defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P8_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if SIMDE_ARCH_POWER_ALTIVEC_CHECK(800)
+    #define SIMDE_POWER_ALTIVEC_P8_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P7)
+  #define SIMDE_POWER_ALTIVEC_P7_NATIVE
+#endif
+
+#if !defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P7_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if SIMDE_ARCH_POWER_ALTIVEC_CHECK(700)
+    #define SIMDE_POWER_ALTIVEC_P7_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P6)
+  #define SIMDE_POWER_ALTIVEC_P6_NATIVE
+#endif
+
+#if !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P6_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if SIMDE_ARCH_POWER_ALTIVEC_CHECK(600)
+    #define SIMDE_POWER_ALTIVEC_P6_NATIVE
+  #endif
+#endif
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P5)
+  #define SIMDE_POWER_ALTIVEC_P5_NATIVE
+#endif
+
+#if !defined(SIMDE_POWER_ALTIVEC_P5_NATIVE) && !defined(SIMDE_POWER_ALTIVEC_P5_NO_NATIVE) && !defined(SIMDE_NO_NATIVE)
+  #if SIMDE_ARCH_POWER_ALTIVEC_CHECK(500)
+    #define SIMDE_POWER_ALTIVEC_P5_NATIVE
+  #endif
+#endif
+
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  /* AltiVec conflicts with lots of stuff.  The bool keyword conflicts
+   * with the bool keyword in C++ and the bool macro in C99+ (defined
+   * in stdbool.h).  The vector keyword conflicts with std::vector in
+   * C++ if you are `using std;`.
+   *
+   * Luckily AltiVec allows you to use `__vector`/`__bool`/`__pixel`
+   * instead, but altivec.h will unconditionally define
+   * `vector`/`bool`/`pixel` so we need to work around that.
+   *
+   * Unfortunately this means that if your code uses AltiVec directly
+   * it may break.  If this is the case you'll want to define
+   * `SIMDE_POWER_ALTIVEC_NO_UNDEF` before including SIMDe.  Or, even
+   * better, port your code to use the double-underscore versions. */
+  #if defined(bool)
+    #undef bool
+  #endif
+
+  #include <altivec.h>
+
+  #if !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF)
+    #if defined(vector)
+      #undef vector
+    #endif
+    #if defined(pixel)
+      #undef pixel
+    #endif
+    #if defined(bool)
+      #undef bool
+    #endif
+  #endif /* !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF) */
+
+  /* Use these intsead of vector/pixel/bool in SIMDe. */
+  #define SIMDE_POWER_ALTIVEC_VECTOR(T) __vector T
+  #define SIMDE_POWER_ALTIVEC_PIXEL __pixel
+  #define SIMDE_POWER_ALTIVEC_BOOL __bool
+
+  /* Re-define bool if we're using stdbool.h */
+  #if !defined(__cplusplus) && defined(__bool_true_false_are_defined) && !defined(SIMDE_POWER_ALTIVEC_NO_UNDEF)
+    #define bool _Bool
+  #endif
+#endif
+
+/* This is used to determine whether or not to fall back on a vector
+ * function in an earlier ISA extensions, as well as whether
+ * we expected any attempts at vectorization to be fruitful or if we
+ * expect to always be running serial code. */
+
+#if !defined(SIMDE_NATURAL_VECTOR_SIZE)
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    #define SIMDE_NATURAL_VECTOR_SIZE (512)
+  #elif defined(SIMDE_X86_AVX_NATIVE)
+    #define SIMDE_NATURAL_VECTOR_SIZE (256)
+  #elif \
+      defined(SIMDE_X86_SSE_NATIVE) || \
+      defined(SIMDE_ARM_NEON_A32V7_NATIVE) || \
+      defined(SIMDE_WASM_SIMD128_NATIVE) || \
+      defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+    #define SIMDE_NATURAL_VECTOR_SIZE (128)
+  #endif
+
+  #if !defined(SIMDE_NATURAL_VECTOR_SIZE)
+    #define SIMDE_NATURAL_VECTOR_SIZE (0)
+  #endif
+#endif
+
+#define SIMDE_NATURAL_VECTOR_SIZE_LE(x) (SIMDE_NATURAL_VECTOR_SIZE <= (x))
+#define SIMDE_NATURAL_VECTOR_SIZE_GE(x) (SIMDE_NATURAL_VECTOR_SIZE >= (x))
+
+/* Native aliases */
+#if defined(SIMDE_ENABLE_NATIVE_ALIASES)
+  #if !defined(SIMDE_X86_MMX_NATIVE)
+    #define SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSE_NATIVE)
+    #define SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSE2_NATIVE)
+    #define SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSE3_NATIVE)
+    #define SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSSE3_NATIVE)
+    #define SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSE4_1_NATIVE)
+    #define SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_SSE4_2_NATIVE)
+    #define SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX_NATIVE)
+    #define SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX2_NATIVE)
+    #define SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_FMA_NATIVE)
+    #define SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX512F_NATIVE)
+    #define SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX512VL_NATIVE)
+    #define SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX512BW_NATIVE)
+    #define SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX512DQ_NATIVE)
+    #define SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_AVX512CD_NATIVE)
+    #define SIMDE_X86_AVX512CD_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_X86_GFNI_NATIVE)
+    #define SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES
+  #endif
+
+  #if !defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #define SIMDE_ARM_NEON_A32V7_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_ARM_NEON_A32V8_NATIVE)
+    #define SIMDE_ARM_NEON_A32V8_ENABLE_NATIVE_ALIASES
+  #endif
+  #if !defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    #define SIMDE_ARM_NEON_A64V8_ENABLE_NATIVE_ALIASES
+  #endif
+#endif
+
+/* Are floating point values stored using IEEE 754?  Knowing
+ * this at during preprocessing is a bit tricky, mostly because what
+ * we're curious about is how values are stored and not whether the
+ * implementation is fully conformant in terms of rounding, NaN
+ * handling, etc.
+ *
+ * For example, if you use -ffast-math or -Ofast on
+ * GCC or clang IEEE 754 isn't strictly followed, therefore IEE 754
+ * support is not advertised (by defining __STDC_IEC_559__).
+ *
+ * However, what we care about is whether it is safe to assume that
+ * floating point values are stored in IEEE 754 format, in which case
+ * we can provide faster implementations of some functions.
+ *
+ * Luckily every vaugely modern architecture I'm aware of uses IEEE 754-
+ * so we just assume IEEE 754 for now.  There is a test which verifies
+ * this, if that test fails sowewhere please let us know and we'll add
+ * an exception for that platform.  Meanwhile, you can define
+ * SIMDE_NO_IEEE754_STORAGE. */
+#if !defined(SIMDE_IEEE754_STORAGE) && !defined(SIMDE_NO_IEE754_STORAGE)
+  #define SIMDE_IEEE754_STORAGE
+#endif
+
+#endif /* !defined(SIMDE_FEATURES_H) */

--- a/2.0/simde/simde-math.h
+++ b/2.0/simde/simde-math.h
@@ -1,0 +1,1568 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+/* Attempt to find math functions.  Functions may be in <cmath>,
+ * <math.h>, compiler built-ins/intrinsics, or platform/architecture
+ * specific headers.  In some cases, especially those not built in to
+ * libm, we may need to define our own implementations. */
+
+#if !defined(SIMDE_MATH_H)
+
+#include "hedley.h"
+#include "simde-features.h"
+
+/* SLEEF support
+ * https://sleef.org/
+ *
+ * If you include <sleef.h> prior to including SIMDe, SIMDe will use
+ * SLEEF.  You can also define SIMDE_MATH_SLEEF_ENABLE prior to
+ * including SIMDe to force the issue.
+ *
+ * Note that SLEEF does requires linking to libsleef.
+ *
+ * By default, SIMDe will use the 1 ULP functions, but if you use
+ * SIMDE_ACCURACY_PREFERENCE of 0 we will use up to 4 ULP.  This is
+ * only the case for the simde_math_* functions; for code in other
+ * SIMDe headers which calls SLEEF directly we may use functions with
+ * greater error if the API we're implementing is less precise (for
+ * example, SVML guarantees 4 ULP, so we will generally use the 3.5
+ * ULP functions from SLEEF). */
+#if !defined(SIMDE_MATH_SLEEF_DISABLE)
+  #if defined(__SLEEF_H__)
+    #define SIMDE_MATH_SLEEF_ENABLE
+  #endif
+#endif
+
+#if defined(SIMDE_MATH_SLEEF_ENABLE) && !defined(__SLEEF_H__)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_IGNORED_QUALIFIERS_
+  #include <sleef.h>
+  HEDLEY_DIAGNOSTIC_POP
+#endif
+
+#if defined(SIMDE_MATH_SLEEF_ENABLE) && defined(__SLEEF_H__)
+  #if defined(SLEEF_VERSION_MAJOR)
+    #define SIMDE_MATH_SLEEF_VERSION_CHECK(major, minor, patch) (HEDLEY_VERSION_ENCODE(SLEEF_VERSION_MAJOR, SLEEF_VERSION_MINOR, SLEEF_VERSION_PATCHLEVEL) >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+  #else
+    #define SIMDE_MATH_SLEEF_VERSION_CHECK(major, minor, patch) (HEDLEY_VERSION_ENCODE(3,0,0) >= HEDLEY_VERSION_ENCODE(major, minor, patch))
+  #endif
+#else
+  #define SIMDE_MATH_SLEEF_VERSION_CHECK(major, minor, patch) (0)
+#endif
+
+#if defined(__has_builtin)
+  #define SIMDE_MATH_BUILTIN_LIBM(func) __has_builtin(__builtin_##func)
+#elif \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+    HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+    HEDLEY_GCC_VERSION_CHECK(4,4,0)
+  #define SIMDE_MATH_BUILTIN_LIBM(func) (1)
+#else
+  #define SIMDE_MATH_BUILTIN_LIBM(func) (0)
+#endif
+
+#if defined(HUGE_VAL)
+  /* Looks like <math.h> or <cmath> has already been included. */
+
+  /* The math.h from libc++ (yes, the C header from the C++ standard
+   * library) will define an isnan function, but not an isnan macro
+   * like the C standard requires.  So we detect the header guards
+   * macro libc++ uses. */
+  #if defined(isnan) || (defined(_LIBCPP_MATH_H) && !defined(_LIBCPP_CMATH))
+    #define SIMDE_MATH_HAVE_MATH_H
+  #elif defined(__cplusplus)
+    #define SIMDE_MATH_HAVE_CMATH
+  #endif
+#elif defined(__has_include)
+  #if defined(__cplusplus) && (__cplusplus >= 201103L) && __has_include(<cmath>)
+    #define SIMDE_MATH_HAVE_CMATH
+    #include <cmath>
+  #elif __has_include(<math.h>)
+    #define SIMDE_MATH_HAVE_MATH_H
+    #include <math.h>
+  #elif !defined(SIMDE_MATH_NO_LIBM)
+    #define SIMDE_MATH_NO_LIBM
+  #endif
+#elif !defined(SIMDE_MATH_NO_LIBM)
+  #if defined(__cplusplus) && (__cplusplus >= 201103L)
+    #define SIMDE_MATH_HAVE_CMATH
+    HEDLEY_DIAGNOSTIC_PUSH
+    #if defined(HEDLEY_MSVC_VERSION)
+      /* VS 14 emits this diagnostic about noexcept being used on a
+       * <cmath> function, which we can't do anything about. */
+      #pragma warning(disable:4996)
+    #endif
+    #include <cmath>
+    HEDLEY_DIAGNOSTIC_POP
+  #else
+    #define SIMDE_MATH_HAVE_MATH_H
+    #include <math.h>
+  #endif
+#endif
+
+/* Try to avoid including <complex> since it pulls in a *lot* of code. */
+#if \
+    HEDLEY_HAS_BUILTIN(__builtin_creal) || \
+    HEDLEY_GCC_VERSION_CHECK(4,7,0) || \
+    HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_C99_EXTENSIONS_
+    typedef __complex__ float simde_cfloat32;
+    typedef __complex__ double simde_cfloat64;
+  HEDLEY_DIAGNOSTIC_POP
+  #define SIMDE_MATH_CMPLX(x, y) (HEDLEY_STATIC_CAST(double, x) + HEDLEY_STATIC_CAST(double, y) * (__extension__ 1.0j))
+  #define SIMDE_MATH_CMPLXF(x, y) (HEDLEY_STATIC_CAST(float, x) + HEDLEY_STATIC_CAST(float, y) * (__extension__ 1.0fj))
+
+  #if !defined(simde_math_creal)
+    #define simde_math_crealf(z) __builtin_crealf(z)
+  #endif
+  #if !defined(simde_math_crealf)
+    #define simde_math_creal(z) __builtin_creal(z)
+  #endif
+  #if !defined(simde_math_cimag)
+    #define simde_math_cimagf(z) __builtin_cimagf(z)
+  #endif
+  #if !defined(simde_math_cimagf)
+    #define simde_math_cimag(z) __builtin_cimag(z)
+  #endif
+#elif !defined(__cplusplus)
+  #include <complex.h>
+
+  #if !defined(HEDLEY_MSVC_VERSION)
+    typedef float _Complex simde_cfloat32;
+    typedef double _Complex simde_cfloat64;
+  #else
+    typedef _Fcomplex simde_cfloat32;
+    typedef _Dcomplex simde_cfloat64;
+  #endif
+
+  #if defined(HEDLEY_MSVC_VERSION)
+    #define SIMDE_MATH_CMPLX(x, y) ((simde_cfloat64) { (x), (y) })
+    #define SIMDE_MATH_CMPLXF(x, y) ((simde_cfloat32) { (x), (y) })
+  #elif defined(CMPLX) && defined(CMPLXF)
+    #define SIMDE_MATH_CMPLX(x, y) CMPLX(x, y)
+    #define SIMDE_MATH_CMPLXF(x, y) CMPLXF(x, y)
+  #else
+    #define SIMDE_MATH_CMPLX(x, y) (HEDLEY_STATIC_CAST(double, x) + HEDLEY_STATIC_CAST(double, y) * I)
+    #define SIMDE_MATH_CMPLXF(x, y) (HEDLEY_STATIC_CAST(float, x) + HEDLEY_STATIC_CAST(float, y) * I)
+  #endif
+
+  #if !defined(simde_math_creal)
+    #define simde_math_creal(z) creal(z)
+  #endif
+  #if !defined(simde_math_crealf)
+    #define simde_math_crealf(z) crealf(z)
+  #endif
+  #if !defined(simde_math_cimag)
+    #define simde_math_cimag(z) cimag(z)
+  #endif
+  #if !defined(simde_math_cimagf)
+    #define simde_math_cimagf(z) cimagf(z)
+  #endif
+#else
+  HEDLEY_DIAGNOSTIC_PUSH
+  #if defined(HEDLEY_MSVC_VERSION)
+    #pragma warning(disable:4530)
+  #endif
+  #include <complex>
+  HEDLEY_DIAGNOSTIC_POP
+
+  typedef std::complex<float> simde_cfloat32;
+  typedef std::complex<double> simde_cfloat64;
+  #define SIMDE_MATH_CMPLX(x, y) (std::complex<double>(x, y))
+  #define SIMDE_MATH_CMPLXF(x, y) (std::complex<float>(x, y))
+
+  #if !defined(simde_math_creal)
+    #define simde_math_creal(z) ((z).real())
+  #endif
+  #if !defined(simde_math_crealf)
+    #define simde_math_crealf(z) ((z).real())
+  #endif
+  #if !defined(simde_math_cimag)
+    #define simde_math_cimag(z) ((z).imag())
+  #endif
+  #if !defined(simde_math_cimagf)
+    #define simde_math_cimagf(z) ((z).imag())
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_INFINITY)
+  #if \
+      HEDLEY_HAS_BUILTIN(__builtin_inf) || \
+      HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+      HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+    #define SIMDE_MATH_INFINITY (__builtin_inf())
+  #elif defined(INFINITY)
+    #define SIMDE_MATH_INFINITY INFINITY
+  #endif
+#endif
+
+#if !defined(SIMDE_INFINITYF)
+  #if \
+      HEDLEY_HAS_BUILTIN(__builtin_inff) || \
+      HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+      HEDLEY_IBM_VERSION_CHECK(13,1,0)
+    #define SIMDE_MATH_INFINITYF (__builtin_inff())
+  #elif defined(INFINITYF)
+    #define SIMDE_MATH_INFINITYF INFINITYF
+  #elif defined(SIMDE_MATH_INFINITY)
+    #define SIMDE_MATH_INFINITYF HEDLEY_STATIC_CAST(float, SIMDE_MATH_INFINITY)
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_NAN)
+  #if \
+      HEDLEY_HAS_BUILTIN(__builtin_nan) || \
+      HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+      HEDLEY_CRAY_VERSION_CHECK(8,1,0) || \
+      HEDLEY_IBM_VERSION_CHECK(13,1,0)
+    #define SIMDE_MATH_NAN (__builtin_nan(""))
+  #elif defined(NAN)
+    #define SIMDE_MATH_NAN NAN
+  #endif
+#endif
+
+#if !defined(SIMDE_NANF)
+  #if \
+      HEDLEY_HAS_BUILTIN(__builtin_nanf) || \
+      HEDLEY_GCC_VERSION_CHECK(3,3,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+      HEDLEY_CRAY_VERSION_CHECK(8,1,0)
+    #define SIMDE_MATH_NANF (__builtin_nanf(""))
+  #elif defined(NANF)
+    #define SIMDE_MATH_NANF NANF
+  #elif defined(SIMDE_MATH_NAN)
+    #define SIMDE_MATH_NANF HEDLEY_STATIC_CAST(float, SIMDE_MATH_NAN)
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_PI)
+  #if defined(M_PI)
+    #define SIMDE_MATH_PI M_PI
+  #else
+    #define SIMDE_MATH_PI 3.14159265358979323846
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_PIF)
+  #if defined(M_PI)
+    #define SIMDE_MATH_PIF HEDLEY_STATIC_CAST(float, M_PI)
+  #else
+    #define SIMDE_MATH_PIF 3.14159265358979323846f
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_PI_OVER_180)
+  #define SIMDE_MATH_PI_OVER_180 0.0174532925199432957692369076848861271344287188854172545609719144
+#endif
+
+#if !defined(SIMDE_MATH_PI_OVER_180F)
+  #define SIMDE_MATH_PI_OVER_180F 0.0174532925199432957692369076848861271344287188854172545609719144f
+#endif
+
+#if !defined(SIMDE_MATH_180_OVER_PI)
+  #define SIMDE_MATH_180_OVER_PI 57.295779513082320876798154814105170332405472466564321549160243861
+#endif
+
+#if !defined(SIMDE_MATH_180_OVER_PIF)
+  #define SIMDE_MATH_180_OVER_PIF 57.295779513082320876798154814105170332405472466564321549160243861f
+#endif
+
+#if !defined(SIMDE_MATH_FLT_MIN)
+  #if defined(FLT_MIN)
+    #define SIMDE_MATH_FLT_MIN FLT_MIN
+  #elif defined(__FLT_MIN__)
+    #define SIMDE_MATH_FLT_MIN __FLT_MIN__
+  #elif defined(__cplusplus)
+    #include <cfloat>
+    #define SIMDE_MATH_FLT_MIN FLT_MIN
+  #else
+    #include <float.h>
+    #define SIMDE_MATH_FLT_MIN FLT_MIN
+  #endif
+#endif
+
+#if !defined(SIMDE_MATH_DBL_MIN)
+  #if defined(DBL_MIN)
+    #define SIMDE_MATH_DBL_MIN DBL_MIN
+  #elif defined(__DBL_MIN__)
+    #define SIMDE_MATH_DBL_MIN __DBL_MIN__
+  #elif defined(__cplusplus)
+    #include <cfloat>
+    #define SIMDE_MATH_DBL_MIN DBL_MIN
+  #else
+    #include <float.h>
+    #define SIMDE_MATH_DBL_MIN DBL_MIN
+  #endif
+#endif
+
+/*** Classification macros from C99 ***/
+
+#if !defined(simde_math_isinf)
+  #if SIMDE_MATH_BUILTIN_LIBM(isinf)
+    #define simde_math_isinf(v) __builtin_isinf(v)
+  #elif defined(isinf) || defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_isinf(v) isinf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isinf(v) std::isinf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_isinff)
+  #if HEDLEY_HAS_BUILTIN(__builtin_isinff) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0)
+    #define simde_math_isinff(v) __builtin_isinff(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isinff(v) std::isinf(v)
+  #elif defined(simde_math_isinf)
+    #define simde_math_isinff(v) simde_math_isinf(HEDLEY_STATIC_CAST(double, v))
+  #endif
+#endif
+
+#if !defined(simde_math_isnan)
+  #if SIMDE_MATH_BUILTIN_LIBM(isnan)
+    #define simde_math_isnan(v) __builtin_isnan(v)
+  #elif defined(isnan) || defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_isnan(v) isnan(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isnan(v) std::isnan(v)
+  #endif
+#endif
+
+#if !defined(simde_math_isnanf)
+  #if HEDLEY_HAS_BUILTIN(__builtin_isnanf) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0)
+    /* XL C/C++ has __builtin_isnan but not __builtin_isnanf */
+    #define simde_math_isnanf(v) __builtin_isnanf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isnanf(v) std::isnan(v)
+  #elif defined(simde_math_isnan)
+    #define simde_math_isnanf(v) simde_math_isnan(HEDLEY_STATIC_CAST(double, v))
+  #endif
+#endif
+
+#if !defined(simde_math_isnormal)
+  #if SIMDE_MATH_BUILTIN_LIBM(isnormal)
+    #define simde_math_isnormal(v) __builtin_isnormal(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_isnormal(v) isnormal(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isnormal(v) std::isnormal(v)
+  #endif
+#endif
+
+#if !defined(simde_math_isnormalf)
+  #if HEDLEY_HAS_BUILTIN(__builtin_isnormalf)
+    #define simde_math_isnormalf(v) __builtin_isnormalf(v)
+  #elif SIMDE_MATH_BUILTIN_LIBM(isnormal)
+    #define simde_math_isnormalf(v) __builtin_isnormal(v)
+  #elif defined(isnormalf)
+    #define simde_math_isnormalf(v) isnormalf(v)
+  #elif defined(isnormal) || defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_isnormalf(v) isnormal(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_isnormalf(v) std::isnormal(v)
+  #elif defined(simde_math_isnormal)
+    #define simde_math_isnormalf(v) simde_math_isnormal(v)
+  #endif
+#endif
+
+/*** Manipulation functions ***/
+
+#if !defined(simde_math_nextafter)
+  #if \
+      (HEDLEY_HAS_BUILTIN(__builtin_nextafter) && !defined(HEDLEY_IBM_VERSION)) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+      HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define simde_math_nextafter(x, y) __builtin_nextafter(x, y)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_nextafter(x, y) std::nextafter(x, y)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_nextafter(x, y) nextafter(x, y)
+  #endif
+#endif
+
+#if !defined(simde_math_nextafterf)
+  #if \
+      (HEDLEY_HAS_BUILTIN(__builtin_nextafterf) && !defined(HEDLEY_IBM_VERSION)) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) || \
+      HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0)
+    #define simde_math_nextafterf(x, y) __builtin_nextafterf(x, y)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_nextafterf(x, y) std::nextafter(x, y)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_nextafterf(x, y) nextafterf(x, y)
+  #endif
+#endif
+
+/*** Functions from C99 ***/
+
+#if !defined(simde_math_abs)
+  #if SIMDE_MATH_BUILTIN_LIBM(abs)
+    #define simde_math_abs(v) __builtin_abs(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_abs(v) std::abs(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_abs(v) abs(v)
+  #endif
+#endif
+
+#if !defined(simde_math_absf)
+  #if SIMDE_MATH_BUILTIN_LIBM(absf)
+    #define simde_math_absf(v) __builtin_absf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_absf(v) std::abs(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_absf(v) absf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_acos)
+  #if SIMDE_MATH_BUILTIN_LIBM(acos)
+    #define simde_math_acos(v) __builtin_acos(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_acos(v) std::acos(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_acos(v) acos(v)
+  #endif
+#endif
+
+#if !defined(simde_math_acosf)
+  #if SIMDE_MATH_BUILTIN_LIBM(acosf)
+    #define simde_math_acosf(v) __builtin_acosf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_acosf(v) std::acos(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_acosf(v) acosf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_acosh)
+  #if SIMDE_MATH_BUILTIN_LIBM(acosh)
+    #define simde_math_acosh(v) __builtin_acosh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_acosh(v) std::acosh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_acosh(v) acosh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_acoshf)
+  #if SIMDE_MATH_BUILTIN_LIBM(acoshf)
+    #define simde_math_acoshf(v) __builtin_acoshf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_acoshf(v) std::acosh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_acoshf(v) acoshf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_asin)
+  #if SIMDE_MATH_BUILTIN_LIBM(asin)
+    #define simde_math_asin(v) __builtin_asin(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_asin(v) std::asin(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_asin(v) asin(v)
+  #endif
+#endif
+
+#if !defined(simde_math_asinf)
+  #if SIMDE_MATH_BUILTIN_LIBM(asinf)
+    #define simde_math_asinf(v) __builtin_asinf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_asinf(v) std::asin(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_asinf(v) asinf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_asinh)
+  #if SIMDE_MATH_BUILTIN_LIBM(asinh)
+    #define simde_math_asinh(v) __builtin_asinh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_asinh(v) std::asinh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_asinh(v) asinh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_asinhf)
+  #if SIMDE_MATH_BUILTIN_LIBM(asinhf)
+    #define simde_math_asinhf(v) __builtin_asinhf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_asinhf(v) std::asinh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_asinhf(v) asinhf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_atan)
+  #if SIMDE_MATH_BUILTIN_LIBM(atan)
+    #define simde_math_atan(v) __builtin_atan(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atan(v) std::atan(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atan(v) atan(v)
+  #endif
+#endif
+
+#if !defined(simde_math_atan2)
+  #if SIMDE_MATH_BUILTIN_LIBM(atan2)
+    #define simde_math_atan2(y, x) __builtin_atan2(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atan2(y, x) std::atan2(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atan2(y, x) atan2(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_atan2f)
+  #if SIMDE_MATH_BUILTIN_LIBM(atan2f)
+    #define simde_math_atan2f(y, x) __builtin_atan2f(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atan2f(y, x) std::atan2(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atan2f(y, x) atan2f(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_atanf)
+  #if SIMDE_MATH_BUILTIN_LIBM(atanf)
+    #define simde_math_atanf(v) __builtin_atanf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atanf(v) std::atan(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atanf(v) atanf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_atanh)
+  #if SIMDE_MATH_BUILTIN_LIBM(atanh)
+    #define simde_math_atanh(v) __builtin_atanh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atanh(v) std::atanh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atanh(v) atanh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_atanhf)
+  #if SIMDE_MATH_BUILTIN_LIBM(atanhf)
+    #define simde_math_atanhf(v) __builtin_atanhf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_atanhf(v) std::atanh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_atanhf(v) atanhf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_cbrt)
+  #if SIMDE_MATH_BUILTIN_LIBM(cbrt)
+    #define simde_math_cbrt(v) __builtin_cbrt(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_cbrt(v) std::cbrt(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cbrt(v) cbrt(v)
+  #endif
+#endif
+
+#if !defined(simde_math_cbrtf)
+  #if SIMDE_MATH_BUILTIN_LIBM(cbrtf)
+    #define simde_math_cbrtf(v) __builtin_cbrtf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_cbrtf(v) std::cbrt(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cbrtf(v) cbrtf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_ceil)
+  #if SIMDE_MATH_BUILTIN_LIBM(ceil)
+    #define simde_math_ceil(v) __builtin_ceil(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_ceil(v) std::ceil(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_ceil(v) ceil(v)
+  #endif
+#endif
+
+#if !defined(simde_math_ceilf)
+  #if SIMDE_MATH_BUILTIN_LIBM(ceilf)
+    #define simde_math_ceilf(v) __builtin_ceilf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_ceilf(v) std::ceil(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_ceilf(v) ceilf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_copysign)
+  #if SIMDE_MATH_BUILTIN_LIBM(copysign)
+    #define simde_math_copysign(x, y) __builtin_copysign(x, y)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_copysign(x, y) std::copysign(x, y)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_copysign(x, y) copysign(x, y)
+  #endif
+#endif
+
+#if !defined(simde_math_copysignf)
+  #if SIMDE_MATH_BUILTIN_LIBM(copysignf)
+    #define simde_math_copysignf(x, y) __builtin_copysignf(x, y)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_copysignf(x, y) std::copysignf(x, y)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_copysignf(x, y) copysignf(x, y)
+  #endif
+#endif
+
+#if !defined(simde_math_cos)
+  #if SIMDE_MATH_BUILTIN_LIBM(cos)
+    #define simde_math_cos(v) __builtin_cos(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_cos(v) std::cos(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cos(v) cos(v)
+  #endif
+#endif
+
+#if !defined(simde_math_cosf)
+  #if defined(SIMDE_MATH_SLEEF_ENABLE)
+    #if SIMDE_ACCURACY_PREFERENCE < 1
+      #define simde_math_cosf(v) Sleef_cosf_u35(v)
+    #else
+      #define simde_math_cosf(v) Sleef_cosf_u10(v)
+    #endif
+  #elif SIMDE_MATH_BUILTIN_LIBM(cosf)
+    #define simde_math_cosf(v) __builtin_cosf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_cosf(v) std::cos(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cosf(v) cosf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_cosh)
+  #if SIMDE_MATH_BUILTIN_LIBM(cosh)
+    #define simde_math_cosh(v) __builtin_cosh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_cosh(v) std::cosh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cosh(v) cosh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_coshf)
+  #if SIMDE_MATH_BUILTIN_LIBM(coshf)
+    #define simde_math_coshf(v) __builtin_coshf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_coshf(v) std::cosh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_coshf(v) coshf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_erf)
+  #if SIMDE_MATH_BUILTIN_LIBM(erf)
+    #define simde_math_erf(v) __builtin_erf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_erf(v) std::erf(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_erf(v) erf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_erff)
+  #if SIMDE_MATH_BUILTIN_LIBM(erff)
+    #define simde_math_erff(v) __builtin_erff(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_erff(v) std::erf(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_erff(v) erff(v)
+  #endif
+#endif
+
+#if !defined(simde_math_erfc)
+  #if SIMDE_MATH_BUILTIN_LIBM(erfc)
+    #define simde_math_erfc(v) __builtin_erfc(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_erfc(v) std::erfc(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_erfc(v) erfc(v)
+  #endif
+#endif
+
+#if !defined(simde_math_erfcf)
+  #if SIMDE_MATH_BUILTIN_LIBM(erfcf)
+    #define simde_math_erfcf(v) __builtin_erfcf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_erfcf(v) std::erfc(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_erfcf(v) erfcf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_exp)
+  #if SIMDE_MATH_BUILTIN_LIBM(exp)
+    #define simde_math_exp(v) __builtin_exp(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_exp(v) std::exp(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_exp(v) exp(v)
+  #endif
+#endif
+
+#if !defined(simde_math_expf)
+  #if SIMDE_MATH_BUILTIN_LIBM(expf)
+    #define simde_math_expf(v) __builtin_expf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_expf(v) std::exp(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_expf(v) expf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_expm1)
+  #if SIMDE_MATH_BUILTIN_LIBM(expm1)
+    #define simde_math_expm1(v) __builtin_expm1(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_expm1(v) std::expm1(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_expm1(v) expm1(v)
+  #endif
+#endif
+
+#if !defined(simde_math_expm1f)
+  #if SIMDE_MATH_BUILTIN_LIBM(expm1f)
+    #define simde_math_expm1f(v) __builtin_expm1f(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_expm1f(v) std::expm1(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_expm1f(v) expm1f(v)
+  #endif
+#endif
+
+#if !defined(simde_math_exp2)
+  #if SIMDE_MATH_BUILTIN_LIBM(exp2)
+    #define simde_math_exp2(v) __builtin_exp2(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_exp2(v) std::exp2(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_exp2(v) exp2(v)
+  #endif
+#endif
+
+#if !defined(simde_math_exp2f)
+  #if SIMDE_MATH_BUILTIN_LIBM(exp2f)
+    #define simde_math_exp2f(v) __builtin_exp2f(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_exp2f(v) std::exp2(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_exp2f(v) exp2f(v)
+  #endif
+#endif
+
+#if HEDLEY_HAS_BUILTIN(__builtin_exp10) ||  HEDLEY_GCC_VERSION_CHECK(3,4,0)
+  #  define simde_math_exp10(v) __builtin_exp10(v)
+#else
+#  define simde_math_exp10(v) pow(10.0, (v))
+#endif
+
+#if HEDLEY_HAS_BUILTIN(__builtin_exp10f) ||  HEDLEY_GCC_VERSION_CHECK(3,4,0)
+  #  define simde_math_exp10f(v) __builtin_exp10f(v)
+#else
+#  define simde_math_exp10f(v) powf(10.0f, (v))
+#endif
+
+#if !defined(simde_math_fabs)
+  #if SIMDE_MATH_BUILTIN_LIBM(fabs)
+    #define simde_math_fabs(v) __builtin_fabs(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_fabs(v) std::fabs(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_fabs(v) fabs(v)
+  #endif
+#endif
+
+#if !defined(simde_math_fabsf)
+  #if SIMDE_MATH_BUILTIN_LIBM(fabsf)
+    #define simde_math_fabsf(v) __builtin_fabsf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_fabsf(v) std::fabs(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_fabsf(v) fabsf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_floor)
+  #if SIMDE_MATH_BUILTIN_LIBM(floor)
+    #define simde_math_floor(v) __builtin_floor(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_floor(v) std::floor(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_floor(v) floor(v)
+  #endif
+#endif
+
+#if !defined(simde_math_floorf)
+  #if SIMDE_MATH_BUILTIN_LIBM(floorf)
+    #define simde_math_floorf(v) __builtin_floorf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_floorf(v) std::floor(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_floorf(v) floorf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_fma)
+  #if SIMDE_MATH_BUILTIN_LIBM(fma)
+    #define simde_math_fma(x, y, z) __builtin_fma(x, y, z)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_fma(x, y, z) std::fma(x, y, z)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_fma(x, y, z) fma(x, y, z)
+  #endif
+#endif
+
+#if !defined(simde_math_fmaf)
+  #if SIMDE_MATH_BUILTIN_LIBM(fmaf)
+    #define simde_math_fmaf(x, y, z) __builtin_fmaf(x, y, z)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_fmaf(x, y, z) std::fma(x, y, z)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_fmaf(x, y, z) fmaf(x, y, z)
+  #endif
+#endif
+
+#if !defined(simde_math_hypot)
+  #if SIMDE_MATH_BUILTIN_LIBM(hypot)
+    #define simde_math_hypot(y, x) __builtin_hypot(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_hypot(y, x) std::hypot(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_hypot(y, x) hypot(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_hypotf)
+  #if SIMDE_MATH_BUILTIN_LIBM(hypotf)
+    #define simde_math_hypotf(y, x) __builtin_hypotf(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_hypotf(y, x) std::hypot(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_hypotf(y, x) hypotf(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_log)
+  #if SIMDE_MATH_BUILTIN_LIBM(log)
+    #define simde_math_log(v) __builtin_log(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log(v) std::log(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log(v) log(v)
+  #endif
+#endif
+
+#if !defined(simde_math_logf)
+  #if SIMDE_MATH_BUILTIN_LIBM(logf)
+    #define simde_math_logf(v) __builtin_logf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_logf(v) std::log(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_logf(v) logf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_logb)
+  #if SIMDE_MATH_BUILTIN_LIBM(logb)
+    #define simde_math_logb(v) __builtin_logb(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_logb(v) std::logb(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_logb(v) logb(v)
+  #endif
+#endif
+
+#if !defined(simde_math_logbf)
+  #if SIMDE_MATH_BUILTIN_LIBM(logbf)
+    #define simde_math_logbf(v) __builtin_logbf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_logbf(v) std::logb(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_logbf(v) logbf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log1p)
+  #if SIMDE_MATH_BUILTIN_LIBM(log1p)
+    #define simde_math_log1p(v) __builtin_log1p(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log1p(v) std::log1p(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log1p(v) log1p(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log1pf)
+  #if SIMDE_MATH_BUILTIN_LIBM(log1pf)
+    #define simde_math_log1pf(v) __builtin_log1pf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log1pf(v) std::log1p(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log1pf(v) log1pf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log2)
+  #if SIMDE_MATH_BUILTIN_LIBM(log2)
+    #define simde_math_log2(v) __builtin_log2(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log2(v) std::log2(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log2(v) log2(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log2f)
+  #if SIMDE_MATH_BUILTIN_LIBM(log2f)
+    #define simde_math_log2f(v) __builtin_log2f(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log2f(v) std::log2(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log2f(v) log2f(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log10)
+  #if SIMDE_MATH_BUILTIN_LIBM(log10)
+    #define simde_math_log10(v) __builtin_log10(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log10(v) std::log10(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log10(v) log10(v)
+  #endif
+#endif
+
+#if !defined(simde_math_log10f)
+  #if SIMDE_MATH_BUILTIN_LIBM(log10f)
+    #define simde_math_log10f(v) __builtin_log10f(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_log10f(v) std::log10(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_log10f(v) log10f(v)
+  #endif
+#endif
+
+#if !defined(simde_math_nearbyint)
+  #if SIMDE_MATH_BUILTIN_LIBM(nearbyint)
+    #define simde_math_nearbyint(v) __builtin_nearbyint(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_nearbyint(v) std::nearbyint(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_nearbyint(v) nearbyint(v)
+  #endif
+#endif
+
+#if !defined(simde_math_nearbyintf)
+  #if SIMDE_MATH_BUILTIN_LIBM(nearbyintf)
+    #define simde_math_nearbyintf(v) __builtin_nearbyintf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_nearbyintf(v) std::nearbyint(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_nearbyintf(v) nearbyintf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_pow)
+  #if SIMDE_MATH_BUILTIN_LIBM(pow)
+    #define simde_math_pow(y, x) __builtin_pow(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_pow(y, x) std::pow(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_pow(y, x) pow(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_powf)
+  #if SIMDE_MATH_BUILTIN_LIBM(powf)
+    #define simde_math_powf(y, x) __builtin_powf(y, x)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_powf(y, x) std::pow(y, x)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_powf(y, x) powf(y, x)
+  #endif
+#endif
+
+#if !defined(simde_math_rint)
+  #if SIMDE_MATH_BUILTIN_LIBM(rint)
+    #define simde_math_rint(v) __builtin_rint(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_rint(v) std::rint(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_rint(v) rint(v)
+  #endif
+#endif
+
+#if !defined(simde_math_rintf)
+  #if SIMDE_MATH_BUILTIN_LIBM(rintf)
+    #define simde_math_rintf(v) __builtin_rintf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_rintf(v) std::rint(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_rintf(v) rintf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_round)
+  #if SIMDE_MATH_BUILTIN_LIBM(round)
+    #define simde_math_round(v) __builtin_round(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_round(v) std::round(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_round(v) round(v)
+  #endif
+#endif
+
+#if !defined(simde_math_roundf)
+  #if SIMDE_MATH_BUILTIN_LIBM(roundf)
+    #define simde_math_roundf(v) __builtin_roundf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_roundf(v) std::round(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_roundf(v) roundf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sin)
+  #if SIMDE_MATH_BUILTIN_LIBM(sin)
+    #define simde_math_sin(v) __builtin_sin(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sin(v) std::sin(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sin(v) sin(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sinf)
+  #if SIMDE_MATH_BUILTIN_LIBM(sinf)
+    #define simde_math_sinf(v) __builtin_sinf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sinf(v) std::sin(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sinf(v) sinf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sinh)
+  #if SIMDE_MATH_BUILTIN_LIBM(sinh)
+    #define simde_math_sinh(v) __builtin_sinh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sinh(v) std::sinh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sinh(v) sinh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sinhf)
+  #if SIMDE_MATH_BUILTIN_LIBM(sinhf)
+    #define simde_math_sinhf(v) __builtin_sinhf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sinhf(v) std::sinh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sinhf(v) sinhf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sqrt)
+  #if SIMDE_MATH_BUILTIN_LIBM(sqrt)
+    #define simde_math_sqrt(v) __builtin_sqrt(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sqrt(v) std::sqrt(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sqrt(v) sqrt(v)
+  #endif
+#endif
+
+#if !defined(simde_math_sqrtf)
+  #if SIMDE_MATH_BUILTIN_LIBM(sqrtf)
+    #define simde_math_sqrtf(v) __builtin_sqrtf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_sqrtf(v) std::sqrt(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_sqrtf(v) sqrtf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_tan)
+  #if SIMDE_MATH_BUILTIN_LIBM(tan)
+    #define simde_math_tan(v) __builtin_tan(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_tan(v) std::tan(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_tan(v) tan(v)
+  #endif
+#endif
+
+#if !defined(simde_math_tanf)
+  #if SIMDE_MATH_BUILTIN_LIBM(tanf)
+    #define simde_math_tanf(v) __builtin_tanf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_tanf(v) std::tan(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_tanf(v) tanf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_tanh)
+  #if SIMDE_MATH_BUILTIN_LIBM(tanh)
+    #define simde_math_tanh(v) __builtin_tanh(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_tanh(v) std::tanh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_tanh(v) tanh(v)
+  #endif
+#endif
+
+#if !defined(simde_math_tanhf)
+  #if SIMDE_MATH_BUILTIN_LIBM(tanhf)
+    #define simde_math_tanhf(v) __builtin_tanhf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_tanhf(v) std::tanh(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_tanhf(v) tanhf(v)
+  #endif
+#endif
+
+#if !defined(simde_math_trunc)
+  #if SIMDE_MATH_BUILTIN_LIBM(trunc)
+    #define simde_math_trunc(v) __builtin_trunc(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_trunc(v) std::trunc(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_trunc(v) trunc(v)
+  #endif
+#endif
+
+#if !defined(simde_math_truncf)
+  #if SIMDE_MATH_BUILTIN_LIBM(truncf)
+    #define simde_math_truncf(v) __builtin_truncf(v)
+  #elif defined(SIMDE_MATH_HAVE_CMATH)
+    #define simde_math_truncf(v) std::trunc(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_truncf(v) truncf(v)
+  #endif
+#endif
+
+/***  Complex functions ***/
+
+#if !defined(simde_math_cexp)
+  #if SIMDE_MATH_BUILTIN_LIBM(cexp)
+    #define simde_math_cexp(v) __builtin_cexp(v)
+  #elif defined(__cplusplus)
+    #define simde_math_cexp(v) std::cexp(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cexp(v) cexp(v)
+  #endif
+#endif
+
+#if !defined(simde_math_cexpf)
+  #if SIMDE_MATH_BUILTIN_LIBM(cexpf)
+    #define simde_math_cexpf(v) __builtin_cexpf(v)
+  #elif defined(__cplusplus)
+    #define simde_math_cexpf(v) std::exp(v)
+  #elif defined(SIMDE_MATH_HAVE_MATH_H)
+    #define simde_math_cexpf(v) cexpf(v)
+  #endif
+#endif
+
+/*** Additional functions not in libm ***/
+
+#if defined(simde_math_fabs) && defined(simde_math_sqrt) && defined(simde_math_exp)
+  static HEDLEY_INLINE
+  double
+  simde_math_cdfnorm(double x) {
+    /* https://www.johndcook.com/blog/cpp_phi/
+    * Public Domain */
+    static const double a1 =  0.254829592;
+    static const double a2 = -0.284496736;
+    static const double a3 =  1.421413741;
+    static const double a4 = -1.453152027;
+    static const double a5 =  1.061405429;
+    static const double p  =  0.3275911;
+
+    const int sign = x < 0;
+    x = simde_math_fabs(x) / simde_math_sqrt(2.0);
+
+    /* A&S formula 7.1.26 */
+    double t = 1.0 / (1.0 + p * x);
+    double y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * simde_math_exp(-x * x);
+
+    return 0.5 * (1.0 + (sign ? -y : y));
+  }
+  #define simde_math_cdfnorm simde_math_cdfnorm
+#endif
+
+#if defined(simde_math_fabsf) && defined(simde_math_sqrtf) && defined(simde_math_expf)
+  static HEDLEY_INLINE
+  float
+  simde_math_cdfnormf(float x) {
+    /* https://www.johndcook.com/blog/cpp_phi/
+    * Public Domain */
+    static const float a1 =  0.254829592f;
+    static const float a2 = -0.284496736f;
+    static const float a3 =  1.421413741f;
+    static const float a4 = -1.453152027f;
+    static const float a5 =  1.061405429f;
+    static const float p  =  0.3275911f;
+
+    const int sign = x < 0;
+    x = simde_math_fabsf(x) / simde_math_sqrtf(2.0f);
+
+    /* A&S formula 7.1.26 */
+    float t = 1.0f / (1.0f + p * x);
+    float y = 1.0f - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * simde_math_expf(-x * x);
+
+    return 0.5f * (1.0f + (sign ? -y : y));
+  }
+  #define simde_math_cdfnormf simde_math_cdfnormf
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL_
+
+#if !defined(simde_math_cdfnorminv) && defined(simde_math_log) && defined(simde_math_sqrt)
+  /*https://web.archive.org/web/20150910081113/http://home.online.no/~pjacklam/notes/invnorm/impl/sprouse/ltqnorm.c*/
+  static HEDLEY_INLINE
+  double
+  simde_math_cdfnorminv(double p) {
+    static const double a[] = {
+      -3.969683028665376e+01,
+       2.209460984245205e+02,
+      -2.759285104469687e+02,
+       1.383577518672690e+02,
+      -3.066479806614716e+01,
+       2.506628277459239e+00
+    };
+
+    static const double b[] = {
+      -5.447609879822406e+01,
+       1.615858368580409e+02,
+      -1.556989798598866e+02,
+       6.680131188771972e+01,
+      -1.328068155288572e+01
+    };
+
+    static const double c[] = {
+      -7.784894002430293e-03,
+      -3.223964580411365e-01,
+      -2.400758277161838e+00,
+      -2.549732539343734e+00,
+       4.374664141464968e+00,
+       2.938163982698783e+00
+    };
+
+    static const double d[] = {
+      7.784695709041462e-03,
+      3.224671290700398e-01,
+      2.445134137142996e+00,
+      3.754408661907416e+00
+    };
+
+    static const double low  = 0.02425;
+    static const double high = 0.97575;
+    double q, r;
+
+    if (p < 0 || p > 1) {
+      return 0.0;
+    } else if (p == 0) {
+      return -SIMDE_MATH_INFINITY;
+    } else if (p == 1) {
+      return SIMDE_MATH_INFINITY;
+    } else if (p < low) {
+      q = simde_math_sqrt(-2.0 * simde_math_log(p));
+      return
+        (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+        (((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1));
+    } else if (p > high) {
+      q = simde_math_sqrt(-2.0 * simde_math_log(1.0 - p));
+      return
+        -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+         (((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1));
+    } else {
+      q = p - 0.5;
+      r = q * q;
+      return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) *
+        q / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+    }
+}
+#define simde_math_cdfnorminv simde_math_cdfnorminv
+#endif
+
+#if !defined(simde_math_cdfnorminvf) && defined(simde_math_logf) && defined(simde_math_sqrtf)
+  static HEDLEY_INLINE
+  float
+  simde_math_cdfnorminvf(float p) {
+    static const float a[] = {
+      -3.969683028665376e+01f,
+       2.209460984245205e+02f,
+      -2.759285104469687e+02f,
+       1.383577518672690e+02f,
+      -3.066479806614716e+01f,
+       2.506628277459239e+00f
+    };
+    static const float b[] = {
+      -5.447609879822406e+01f,
+       1.615858368580409e+02f,
+      -1.556989798598866e+02f,
+       6.680131188771972e+01f,
+      -1.328068155288572e+01f
+    };
+    static const float c[] = {
+      -7.784894002430293e-03f,
+      -3.223964580411365e-01f,
+      -2.400758277161838e+00f,
+      -2.549732539343734e+00f,
+       4.374664141464968e+00f,
+       2.938163982698783e+00f
+    };
+    static const float d[] = {
+      7.784695709041462e-03f,
+      3.224671290700398e-01f,
+      2.445134137142996e+00f,
+      3.754408661907416e+00f
+    };
+    static const float low  = 0.02425f;
+    static const float high = 0.97575f;
+    float q, r;
+
+    if (p < 0 || p > 1) {
+      return 0.0f;
+    } else if (p == 0) {
+      return -SIMDE_MATH_INFINITYF;
+    } else if (p == 1) {
+      return SIMDE_MATH_INFINITYF;
+    } else if (p < low) {
+      q = simde_math_sqrtf(-2.0f * simde_math_logf(p));
+      return
+        (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+        (((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1));
+    } else if (p > high) {
+      q = simde_math_sqrtf(-2.0f * simde_math_logf(1.0f - p));
+      return
+        -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) /
+         (((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1));
+    } else {
+      q = p - 0.5f;
+      r = q * q;
+      return (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) *
+         q / (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1);
+    }
+  }
+  #define simde_math_cdfnorminvf simde_math_cdfnorminvf
+#endif
+
+#if !defined(simde_math_erfinv) && defined(simde_math_log) && defined(simde_math_copysign) && defined(simde_math_sqrt)
+  static HEDLEY_INLINE
+  double
+  simde_math_erfinv(double x) {
+    /* https://stackoverflow.com/questions/27229371/inverse-error-function-in-c
+     *
+     * The original answer on SO uses a constant of 0.147, but in my
+     * testing 0.14829094707965850830078125 gives a lower average absolute error
+     * (0.0001410958211636170744895935 vs. 0.0001465479290345683693885803).
+     * That said, if your goal is to minimize the *maximum* absolute
+     * error, 0.15449436008930206298828125 provides significantly better
+     * results; 0.0009250640869140625000000000 vs ~ 0.005. */
+    double tt1, tt2, lnx;
+    double sgn = simde_math_copysign(1.0, x);
+
+    x = (1.0 - x) * (1.0 + x);
+    lnx = simde_math_log(x);
+
+    tt1 = 2.0 / (SIMDE_MATH_PI * 0.14829094707965850830078125) + 0.5 * lnx;
+    tt2 = (1.0 / 0.14829094707965850830078125) * lnx;
+
+    return sgn * simde_math_sqrt(-tt1 + simde_math_sqrt(tt1 * tt1 - tt2));
+  }
+  #define simde_math_erfinv simde_math_erfinv
+#endif
+
+#if !defined(simde_math_erfinvf) && defined(simde_math_logf) && defined(simde_math_copysignf) && defined(simde_math_sqrtf)
+  static HEDLEY_INLINE
+  float
+  simde_math_erfinvf(float x) {
+    float tt1, tt2, lnx;
+    float sgn = simde_math_copysignf(1.0f, x);
+
+    x = (1.0f - x) * (1.0f + x);
+    lnx = simde_math_logf(x);
+
+    tt1 = 2.0f / (SIMDE_MATH_PIF * 0.14829094707965850830078125f) + 0.5f * lnx;
+    tt2 = (1.0f / 0.14829094707965850830078125f) * lnx;
+
+    return sgn * simde_math_sqrtf(-tt1 + simde_math_sqrtf(tt1 * tt1 - tt2));
+  }
+  #define simde_math_erfinvf simde_math_erfinvf
+#endif
+
+#if !defined(simde_math_erfcinv) && defined(simde_math_erfinv) && defined(simde_math_log) && defined(simde_math_sqrt)
+  static HEDLEY_INLINE
+  double
+  simde_math_erfcinv(double x) {
+    if(x >= 0.0625 && x < 2.0) {
+      return simde_math_erfinv(1.0 - x);
+    } else if (x < 0.0625 && x >= 1.0e-100) {
+      double p[6] = {
+        0.1550470003116,
+        1.382719649631,
+        0.690969348887,
+        -1.128081391617,
+        0.680544246825,
+        -0.16444156791
+      };
+      double q[3] = {
+        0.155024849822,
+        1.385228141995,
+        1.000000000000
+      };
+
+      const double t = 1.0 / simde_math_sqrt(-simde_math_log(x));
+      return (p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) /
+            (q[0] + t * (q[1] + t * (q[2])));
+    } else if (x < 1.0e-100 && x >= SIMDE_MATH_DBL_MIN) {
+      double p[4] = {
+        0.00980456202915,
+        0.363667889171,
+        0.97302949837,
+        -0.5374947401
+      };
+      double q[3] = {
+        0.00980451277802,
+        0.363699971544,
+        1.000000000000
+      };
+
+      const double t = 1.0 / simde_math_sqrt(-simde_math_log(x));
+      return (p[0] / t + p[1] + t * (p[2] + t * p[3])) /
+             (q[0] + t * (q[1] + t * (q[2])));
+    } else if (!simde_math_isnormal(x)) {
+      return SIMDE_MATH_INFINITY;
+    } else {
+      return -SIMDE_MATH_INFINITY;
+    }
+  }
+
+  #define simde_math_erfcinv simde_math_erfcinv
+#endif
+
+#if !defined(simde_math_erfcinvf) && defined(simde_math_erfinvf) && defined(simde_math_logf) && defined(simde_math_sqrtf)
+  static HEDLEY_INLINE
+  float
+  simde_math_erfcinvf(float x) {
+    if(x >= 0.0625f && x < 2.0f) {
+      return simde_math_erfinvf(1.0f - x);
+    } else if (x < 0.0625f && x >= SIMDE_MATH_FLT_MIN) {
+      static const float p[6] = {
+         0.1550470003116f,
+         1.382719649631f,
+         0.690969348887f,
+        -1.128081391617f,
+         0.680544246825f
+        -0.164441567910f
+      };
+      static const float q[3] = {
+        0.155024849822f,
+        1.385228141995f,
+        1.000000000000f
+      };
+
+      const float t = 1.0f / simde_math_sqrtf(-simde_math_logf(x));
+      return (p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) /
+             (q[0] + t * (q[1] + t * (q[2])));
+    } else if (x < SIMDE_MATH_FLT_MIN && simde_math_isnormalf(x)) {
+      static const float p[4] = {
+        0.00980456202915f,
+        0.36366788917100f,
+        0.97302949837000f,
+        -0.5374947401000f
+      };
+      static const float q[3] = {
+        0.00980451277802f,
+        0.36369997154400f,
+        1.00000000000000f
+      };
+
+      const float t = 1.0f / simde_math_sqrtf(-simde_math_logf(x));
+      return (p[0] / t + p[1] + t * (p[2] + t * p[3])) /
+             (q[0] + t * (q[1] + t * (q[2])));
+    } else {
+      return simde_math_isnormalf(x) ? -SIMDE_MATH_INFINITYF : SIMDE_MATH_INFINITYF;
+    }
+  }
+
+  #define simde_math_erfcinvf simde_math_erfcinvf
+#endif
+
+HEDLEY_DIAGNOSTIC_POP
+
+static HEDLEY_INLINE
+double
+simde_math_rad2deg(double radians) {
+ return radians * SIMDE_MATH_180_OVER_PI;
+}
+
+static HEDLEY_INLINE
+float
+simde_math_rad2degf(float radians) {
+    return radians * SIMDE_MATH_180_OVER_PIF;
+}
+
+static HEDLEY_INLINE
+double
+simde_math_deg2rad(double degrees) {
+  return degrees * SIMDE_MATH_PI_OVER_180;
+}
+
+static HEDLEY_INLINE
+float
+simde_math_deg2radf(float degrees) {
+    return degrees * (SIMDE_MATH_PI_OVER_180F);
+}
+
+#endif /* !defined(SIMDE_MATH_H) */

--- a/2.0/simde/x86/avx.h
+++ b/2.0/simde/x86/avx.h
@@ -1,0 +1,6240 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2018-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#include "sse.h"
+#if !defined(SIMDE_X86_AVX_H)
+#define SIMDE_X86_AVX_H
+
+#include "sse4.2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(32) int8_t          i8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int16_t        i16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int32_t        i32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int64_t        i64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint8_t         u8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint16_t       u16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint32_t       u32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint64_t       u64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_uint128 u128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_float64  f64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int_fast32_t  i32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint_fast32_t u32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(32) int8_t          i8[32];
+    SIMDE_ALIGN(32) int16_t        i16[16];
+    SIMDE_ALIGN(32) int32_t        i32[8];
+    SIMDE_ALIGN(32) int64_t        i64[4];
+    SIMDE_ALIGN(32) uint8_t         u8[32];
+    SIMDE_ALIGN(32) uint16_t       u16[16];
+    SIMDE_ALIGN(32) uint32_t       u32[8];
+    SIMDE_ALIGN(32) uint64_t       u64[4];
+    SIMDE_ALIGN(32) int_fast32_t  i32f[32 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(32) uint_fast32_t u32f[32 / sizeof(uint_fast32_t)];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128[2];
+    SIMDE_ALIGN(32) simde_uint128 u128[2];
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32[8];
+    SIMDE_ALIGN(32) simde_float64  f64[4];
+  #endif
+
+    SIMDE_ALIGN(32) simde__m128_private m128_private[2];
+    SIMDE_ALIGN(32) simde__m128         m128[2];
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    SIMDE_ALIGN(32) __m256         n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(int)                altivec_i32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[2];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(long long)          altivec_i64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[2];
+    #endif
+  #endif
+} simde__m256_private;
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(32) int8_t          i8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int16_t        i16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int32_t        i32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int64_t        i64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint8_t         u8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint16_t       u16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint32_t       u32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint64_t       u64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_uint128 u128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_float64  f64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int_fast32_t  i32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint_fast32_t u32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(32) int8_t          i8[32];
+    SIMDE_ALIGN(32) int16_t        i16[16];
+    SIMDE_ALIGN(32) int32_t        i32[8];
+    SIMDE_ALIGN(32) int64_t        i64[4];
+    SIMDE_ALIGN(32) uint8_t         u8[32];
+    SIMDE_ALIGN(32) uint16_t       u16[16];
+    SIMDE_ALIGN(32) uint32_t       u32[8];
+    SIMDE_ALIGN(32) uint64_t       u64[4];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128[2];
+    SIMDE_ALIGN(32) simde_uint128 u128[2];
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32[8];
+    SIMDE_ALIGN(32) simde_float64  f64[4];
+    SIMDE_ALIGN(32) int_fast32_t  i32f[32 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(32) uint_fast32_t u32f[32 / sizeof(uint_fast32_t)];
+  #endif
+
+    SIMDE_ALIGN(32) simde__m128d_private m128d_private[2];
+    SIMDE_ALIGN(32) simde__m128d         m128d[2];
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    SIMDE_ALIGN(32) __m256d        n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[2];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[2];
+    #endif
+  #endif
+} simde__m256d_private;
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(32) int8_t          i8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int16_t        i16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int32_t        i32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int64_t        i64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint8_t         u8 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint16_t       u16 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint32_t       u32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint64_t       u64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_uint128 u128 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) simde_float64  f64 SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) int_fast32_t  i32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(32) uint_fast32_t u32f SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(32) int8_t          i8[32];
+    SIMDE_ALIGN(32) int16_t        i16[16];
+    SIMDE_ALIGN(32) int32_t        i32[8];
+    SIMDE_ALIGN(32) int64_t        i64[4];
+    SIMDE_ALIGN(32) uint8_t         u8[32];
+    SIMDE_ALIGN(32) uint16_t       u16[16];
+    SIMDE_ALIGN(32) uint32_t       u32[8];
+    SIMDE_ALIGN(32) uint64_t       u64[4];
+    SIMDE_ALIGN(32) int_fast32_t  i32f[32 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(32) uint_fast32_t u32f[32 / sizeof(uint_fast32_t)];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(32) simde_int128  i128[2];
+    SIMDE_ALIGN(32) simde_uint128 u128[2];
+    #endif
+    SIMDE_ALIGN(32) simde_float32  f32[8];
+    SIMDE_ALIGN(32) simde_float64  f64[4];
+  #endif
+
+    SIMDE_ALIGN(32) simde__m128i_private m128i_private[2];
+    SIMDE_ALIGN(32) simde__m128i         m128i[2];
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    SIMDE_ALIGN(32) __m256i        n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32[2];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[2];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64[2];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[2];
+    #endif
+  #endif
+} simde__m256i_private;
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  typedef __m256 simde__m256;
+  typedef __m256i simde__m256i;
+  typedef __m256d simde__m256d;
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+  typedef simde_float32 simde__m256  SIMDE_ALIGN(32) SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+  typedef int_fast32_t  simde__m256i SIMDE_ALIGN(32) SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+  typedef simde_float64 simde__m256d SIMDE_ALIGN(32) SIMDE_VECTOR(32) SIMDE_MAY_ALIAS;
+#else
+  typedef simde__m256_private  simde__m256;
+  typedef simde__m256i_private simde__m256i;
+  typedef simde__m256d_private simde__m256d;
+#endif
+
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #if !defined(HEDLEY_INTEL_VERSION)
+    typedef simde__m256 __m256;
+    typedef simde__m256i __m256i;
+    typedef simde__m256d __m256d;
+  #else
+    #define __m256 simde__m256
+    #define __m256i simde__m256i
+    #define __m256d simde__m256d
+  #endif
+#endif
+
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256), "simde__m256 size incorrect");
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256_private), "simde__m256_private size incorrect");
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256i), "simde__m256i size incorrect");
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256i_private), "simde__m256i_private size incorrect");
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256d), "simde__m256d size incorrect");
+HEDLEY_STATIC_ASSERT(32 == sizeof(simde__m256d_private), "simde__m256d_private size incorrect");
+#if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256) == 32, "simde__m256 is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256_private) == 32, "simde__m256_private is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256i) == 32, "simde__m256i is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256i_private) == 32, "simde__m256i_private is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256d) == 32, "simde__m256d is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m256d_private) == 32, "simde__m256d_private is not 32-byte aligned");
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde__m256_from_private(simde__m256_private v) {
+  simde__m256 r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256_private
+simde__m256_to_private(simde__m256 v) {
+  simde__m256_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde__m256i_from_private(simde__m256i_private v) {
+  simde__m256i r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i_private
+simde__m256i_to_private(simde__m256i v) {
+  simde__m256i_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde__m256d_from_private(simde__m256d_private v) {
+  simde__m256d r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d_private
+simde__m256d_to_private(simde__m256d v) {
+  simde__m256d_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+#define SIMDE_CMP_EQ_OQ     0
+#define SIMDE_CMP_LT_OS     1
+#define SIMDE_CMP_LE_OS     2
+#define SIMDE_CMP_UNORD_Q   3
+#define SIMDE_CMP_NEQ_UQ    4
+#define SIMDE_CMP_NLT_US    5
+#define SIMDE_CMP_NLE_US    6
+#define SIMDE_CMP_ORD_Q     7
+#define SIMDE_CMP_EQ_UQ     8
+#define SIMDE_CMP_NGE_US    9
+#define SIMDE_CMP_NGT_US   10
+#define SIMDE_CMP_FALSE_OQ 11
+#define SIMDE_CMP_NEQ_OQ   12
+#define SIMDE_CMP_GE_OS    13
+#define SIMDE_CMP_GT_OS    14
+#define SIMDE_CMP_TRUE_UQ  15
+#define SIMDE_CMP_EQ_OS    16
+#define SIMDE_CMP_LT_OQ    17
+#define SIMDE_CMP_LE_OQ    18
+#define SIMDE_CMP_UNORD_S  19
+#define SIMDE_CMP_NEQ_US   20
+#define SIMDE_CMP_NLT_UQ   21
+#define SIMDE_CMP_NLE_UQ   22
+#define SIMDE_CMP_ORD_S    23
+#define SIMDE_CMP_EQ_US    24
+#define SIMDE_CMP_NGE_UQ   25
+#define SIMDE_CMP_NGT_UQ   26
+#define SIMDE_CMP_FALSE_OS 27
+#define SIMDE_CMP_NEQ_OS   28
+#define SIMDE_CMP_GE_OQ    29
+#define SIMDE_CMP_GT_OQ    30
+#define SIMDE_CMP_TRUE_US  31
+
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES) && !defined(_CMP_EQ_OQ)
+#define _CMP_EQ_OQ SIMDE_CMP_EQ_OQ
+#define _CMP_LT_OS SIMDE_CMP_LT_OS
+#define _CMP_LE_OS SIMDE_CMP_LE_OS
+#define _CMP_UNORD_Q SIMDE_CMP_UNORD_Q
+#define _CMP_NEQ_UQ SIMDE_CMP_NEQ_UQ
+#define _CMP_NLT_US SIMDE_CMP_NLT_US
+#define _CMP_NLE_US SIMDE_CMP_NLE_US
+#define _CMP_ORD_Q SIMDE_CMP_ORD_Q
+#define _CMP_EQ_UQ SIMDE_CMP_EQ_UQ
+#define _CMP_NGE_US SIMDE_CMP_NGE_US
+#define _CMP_NGT_US SIMDE_CMP_NGT_US
+#define _CMP_FALSE_OQ SIMDE_CMP_FALSE_OQ
+#define _CMP_NEQ_OQ SIMDE_CMP_NEQ_OQ
+#define _CMP_GE_OS SIMDE_CMP_GE_OS
+#define _CMP_GT_OS SIMDE_CMP_GT_OS
+#define _CMP_TRUE_UQ SIMDE_CMP_TRUE_UQ
+#define _CMP_EQ_OS SIMDE_CMP_EQ_OS
+#define _CMP_LT_OQ SIMDE_CMP_LT_OQ
+#define _CMP_LE_OQ SIMDE_CMP_LE_OQ
+#define _CMP_UNORD_S SIMDE_CMP_UNORD_S
+#define _CMP_NEQ_US SIMDE_CMP_NEQ_US
+#define _CMP_NLT_UQ SIMDE_CMP_NLT_UQ
+#define _CMP_NLE_UQ SIMDE_CMP_NLE_UQ
+#define _CMP_ORD_S SIMDE_CMP_ORD_S
+#define _CMP_EQ_US SIMDE_CMP_EQ_US
+#define _CMP_NGE_UQ SIMDE_CMP_NGE_UQ
+#define _CMP_NGT_UQ SIMDE_CMP_NGT_UQ
+#define _CMP_FALSE_OS SIMDE_CMP_FALSE_OS
+#define _CMP_NEQ_OS SIMDE_CMP_NEQ_OS
+#define _CMP_GE_OQ SIMDE_CMP_GE_OQ
+#define _CMP_GT_OQ SIMDE_CMP_GT_OQ
+#define _CMP_TRUE_US SIMDE_CMP_TRUE_US
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_castps_pd (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castps_pd(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256d*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castps_pd
+  #define _mm256_castps_pd(a) simde_mm256_castps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_castps_si256 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castps_si256(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256i*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castps_si256
+  #define _mm256_castps_si256(a) simde_mm256_castps_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_castsi256_pd (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castsi256_pd(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256d*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castsi256_pd
+  #define _mm256_castsi256_pd(a) simde_mm256_castsi256_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_castsi256_ps (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castsi256_ps(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castsi256_ps
+  #define _mm256_castsi256_ps(a) simde_mm256_castsi256_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_castpd_ps (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castpd_ps(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castpd_ps
+  #define _mm256_castpd_ps(a) simde_mm256_castpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_castpd_si256 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castpd_si256(a);
+  #else
+    return *HEDLEY_REINTERPRET_CAST(simde__m256i*, &a);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castpd_si256
+  #define _mm256_castpd_si256(a) simde_mm256_castpd_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setzero_si256 (void) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setzero_si256();
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_setzero_si128();
+      r_.m128i[1] = simde_mm_setzero_si128();
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = 0;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setzero_si256
+  #define _mm256_setzero_si256() simde_mm256_setzero_si256()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_setzero_ps (void) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setzero_ps();
+  #else
+    return simde_mm256_castsi256_ps(simde_mm256_setzero_si256());
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setzero_ps
+  #define _mm256_setzero_ps() simde_mm256_setzero_ps()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_setzero_pd (void) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setzero_pd();
+  #else
+    return simde_mm256_castsi256_pd(simde_mm256_setzero_si256());
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setzero_pd
+  #define _mm256_setzero_pd() simde_mm256_setzero_pd()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_not_ps(simde__m256 a) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i32 = ~a_.i32;
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+      r_.m128[i] = simde_x_mm_not_ps(a_.m128[i]);
+    }
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ~(a_.i32[i]);
+    }
+  #endif
+
+  return simde__m256_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_select_ps(simde__m256 a, simde__m256 b, simde__m256 mask) {
+  /* This function is for when you want to blend two elements together
+   * according to a mask.  It is similar to _mm256_blendv_ps, except that
+   * it is undefined whether the blend is based on the highest bit in
+   * each lane (like blendv) or just bitwise operations.  This allows
+   * us to implement the function efficiently everywhere.
+   *
+   * Basically, you promise that all the lanes in mask are either 0 or
+   * ~0. */
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_blendv_ps(a, b, mask);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      mask_ = simde__m256_to_private(mask);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 ^ ((a_.i32 ^ b_.i32) & mask_.i32);
+    #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_x_mm_select_ps(a_.m128[i], b_.m128[i], mask_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] ^ ((a_.i32[i] ^ b_.i32[i]) & mask_.i32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_not_pd(simde__m256d a) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i64 = ~a_.i64;
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+      r_.m128d[i] = simde_x_mm_not_pd(a_.m128d[i]);
+    }
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ~(a_.i64[i]);
+    }
+  #endif
+
+  return simde__m256d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_select_pd(simde__m256d a, simde__m256d b, simde__m256d mask) {
+  /* This function is for when you want to blend two elements together
+   * according to a mask.  It is similar to _mm256_blendv_pd, except that
+   * it is undefined whether the blend is based on the highest bit in
+   * each lane (like blendv) or just bitwise operations.  This allows
+   * us to implement the function efficiently everywhere.
+   *
+   * Basically, you promise that all the lanes in mask are either 0 or
+   * ~0. */
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_blendv_pd(a, b, mask);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b),
+      mask_ = simde__m256d_to_private(mask);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
+    #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_x_mm_select_pd(a_.m128d[i], b_.m128d[i], mask_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] ^ ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_setone_si256 (void) {
+  simde__m256i_private r_;
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+  __typeof__(r_.i32f) rv = { 0, };
+  r_.i32f = ~rv;
+#elif defined(SIMDE_X86_AVX2_NATIVE)
+  __m256i t = _mm256_setzero_si256();
+  r_.n = _mm256_cmpeq_epi32(t, t);
+#else
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+    r_.i32f[i] = ~HEDLEY_STATIC_CAST(int_fast32_t, 0);
+  }
+#endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_setone_ps (void) {
+  return simde_mm256_castsi256_ps(simde_x_mm256_setone_si256());
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_setone_pd (void) {
+  return simde_mm256_castsi256_pd(simde_x_mm256_setone_si256());
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set_epi8 (int8_t e31, int8_t e30, int8_t e29, int8_t e28,
+                      int8_t e27, int8_t e26, int8_t e25, int8_t e24,
+                      int8_t e23, int8_t e22, int8_t e21, int8_t e20,
+                      int8_t e19, int8_t e18, int8_t e17, int8_t e16,
+                      int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+                      int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+                      int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
+                      int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_epi8(e31, e30, e29, e28, e27, e26, e25, e24,
+                           e23, e22, e21, e20, e19, e18, e17, e16,
+                           e15, e14, e13, e12, e11, e10,  e9,  e8,
+                            e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set_epi8(
+        e15, e14, e13, e12, e11, e10,  e9,  e8,
+        e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+      r_.m128i[1] = simde_mm_set_epi8(
+        e31, e30, e29, e28, e27, e26, e25, e24,
+        e23, e22, e21, e20, e19, e18, e17, e16);
+    #else
+      r_.i8[ 0] =  e0;
+      r_.i8[ 1] =  e1;
+      r_.i8[ 2] =  e2;
+      r_.i8[ 3] =  e3;
+      r_.i8[ 4] =  e4;
+      r_.i8[ 5] =  e5;
+      r_.i8[ 6] =  e6;
+      r_.i8[ 7] =  e7;
+      r_.i8[ 8] =  e8;
+      r_.i8[ 9] =  e9;
+      r_.i8[10] = e10;
+      r_.i8[11] = e11;
+      r_.i8[12] = e12;
+      r_.i8[13] = e13;
+      r_.i8[14] = e14;
+      r_.i8[15] = e15;
+      r_.i8[16] = e16;
+      r_.i8[17] = e17;
+      r_.i8[18] = e18;
+      r_.i8[19] = e19;
+      r_.i8[20] = e20;
+      r_.i8[21] = e21;
+      r_.i8[22] = e22;
+      r_.i8[23] = e23;
+      r_.i8[24] = e24;
+      r_.i8[25] = e25;
+      r_.i8[26] = e26;
+      r_.i8[27] = e27;
+      r_.i8[28] = e28;
+      r_.i8[29] = e29;
+      r_.i8[30] = e30;
+      r_.i8[31] = e31;
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_epi8
+  #define _mm256_set_epi8(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) \
+  simde_mm256_set_epi8(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set_epi16 (int16_t e15, int16_t e14, int16_t e13, int16_t e12,
+                       int16_t e11, int16_t e10, int16_t  e9, int16_t  e8,
+                       int16_t  e7, int16_t  e6, int16_t  e5, int16_t  e4,
+                       int16_t  e3, int16_t  e2, int16_t  e1, int16_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_epi16(e15, e14, e13, e12, e11, e10,  e9,  e8,
+                            e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set_epi16( e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+      r_.m128i[1] = simde_mm_set_epi16(e15, e14, e13, e12, e11, e10,  e9,  e8);
+    #else
+      r_.i16[ 0] =  e0;
+      r_.i16[ 1] =  e1;
+      r_.i16[ 2] =  e2;
+      r_.i16[ 3] =  e3;
+      r_.i16[ 4] =  e4;
+      r_.i16[ 5] =  e5;
+      r_.i16[ 6] =  e6;
+      r_.i16[ 7] =  e7;
+      r_.i16[ 8] =  e8;
+      r_.i16[ 9] =  e9;
+      r_.i16[10] = e10;
+      r_.i16[11] = e11;
+      r_.i16[12] = e12;
+      r_.i16[13] = e13;
+      r_.i16[14] = e14;
+      r_.i16[15] = e15;
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_epi16
+  #define _mm256_set_epi16(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) \
+  simde_mm256_set_epi16(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set_epi32 (int32_t e7, int32_t e6, int32_t e5, int32_t e4,
+                       int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_epi32(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set_epi32(e3, e2, e1, e0);
+      r_.m128i[1] = simde_mm_set_epi32(e7, e6, e5, e4);
+    #else
+      r_.i32[ 0] =  e0;
+      r_.i32[ 1] =  e1;
+      r_.i32[ 2] =  e2;
+      r_.i32[ 3] =  e3;
+      r_.i32[ 4] =  e4;
+      r_.i32[ 5] =  e5;
+      r_.i32[ 6] =  e6;
+      r_.i32[ 7] =  e7;
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_epi32
+  #define _mm256_set_epi32(e7, e6, e5, e4, e3, e2, e1, e0) \
+  simde_mm256_set_epi32(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set_epi64x (int64_t  e3, int64_t  e2, int64_t  e1, int64_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_epi64x(e3, e2, e1, e0);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set_epi64x(e1, e0);
+      r_.m128i[1] = simde_mm_set_epi64x(e3, e2);
+    #else
+      r_.i64[0] = e0;
+      r_.i64[1] = e1;
+      r_.i64[2] = e2;
+      r_.i64[3] = e3;
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_epi64x
+  #define _mm256_set_epi64x(e3, e2, e1, e0) simde_mm256_set_epi64x(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_set_epu8 (uint8_t e31, uint8_t e30, uint8_t e29, uint8_t e28,
+                        uint8_t e27, uint8_t e26, uint8_t e25, uint8_t e24,
+                        uint8_t e23, uint8_t e22, uint8_t e21, uint8_t e20,
+                        uint8_t e19, uint8_t e18, uint8_t e17, uint8_t e16,
+                        uint8_t e15, uint8_t e14, uint8_t e13, uint8_t e12,
+                        uint8_t e11, uint8_t e10, uint8_t  e9, uint8_t  e8,
+                        uint8_t  e7, uint8_t  e6, uint8_t  e5, uint8_t  e4,
+                        uint8_t  e3, uint8_t  e2, uint8_t  e1, uint8_t  e0) {
+  simde__m256i_private r_;
+
+  r_.u8[ 0] =  e0;
+  r_.u8[ 1] =  e1;
+  r_.u8[ 2] =  e2;
+  r_.u8[ 3] =  e3;
+  r_.u8[ 4] =  e4;
+  r_.u8[ 5] =  e5;
+  r_.u8[ 6] =  e6;
+  r_.u8[ 7] =  e7;
+  r_.u8[ 8] =  e8;
+  r_.u8[ 9] =  e9;
+  r_.u8[10] = e10;
+  r_.u8[11] = e11;
+  r_.u8[12] = e12;
+  r_.u8[13] = e13;
+  r_.u8[14] = e14;
+  r_.u8[15] = e15;
+  r_.u8[16] = e16;
+  r_.u8[17] = e17;
+  r_.u8[18] = e18;
+  r_.u8[19] = e19;
+  r_.u8[20] = e20;
+  r_.u8[20] = e20;
+  r_.u8[21] = e21;
+  r_.u8[22] = e22;
+  r_.u8[23] = e23;
+  r_.u8[24] = e24;
+  r_.u8[25] = e25;
+  r_.u8[26] = e26;
+  r_.u8[27] = e27;
+  r_.u8[28] = e28;
+  r_.u8[29] = e29;
+  r_.u8[30] = e30;
+  r_.u8[31] = e31;
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_set_epu16 (uint16_t e15, uint16_t e14, uint16_t e13, uint16_t e12,
+                       uint16_t e11, uint16_t e10, uint16_t  e9, uint16_t  e8,
+                       uint16_t  e7, uint16_t  e6, uint16_t  e5, uint16_t  e4,
+                       uint16_t  e3, uint16_t  e2, uint16_t  e1, uint16_t  e0) {
+  simde__m256i_private r_;
+
+  r_.u16[ 0] =  e0;
+  r_.u16[ 1] =  e1;
+  r_.u16[ 2] =  e2;
+  r_.u16[ 3] =  e3;
+  r_.u16[ 4] =  e4;
+  r_.u16[ 5] =  e5;
+  r_.u16[ 6] =  e6;
+  r_.u16[ 7] =  e7;
+  r_.u16[ 8] =  e8;
+  r_.u16[ 9] =  e9;
+  r_.u16[10] = e10;
+  r_.u16[11] = e11;
+  r_.u16[12] = e12;
+  r_.u16[13] = e13;
+  r_.u16[14] = e14;
+  r_.u16[15] = e15;
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_set_epu32 (uint32_t e7, uint32_t e6, uint32_t e5, uint32_t e4,
+                         uint32_t e3, uint32_t e2, uint32_t e1, uint32_t e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_epi32(HEDLEY_STATIC_CAST(int32_t, e7), HEDLEY_STATIC_CAST(int32_t, e6), HEDLEY_STATIC_CAST(int32_t, e5), HEDLEY_STATIC_CAST(int32_t, e4),
+                            HEDLEY_STATIC_CAST(int32_t, e3), HEDLEY_STATIC_CAST(int32_t, e2), HEDLEY_STATIC_CAST(int32_t, e1), HEDLEY_STATIC_CAST(int32_t, e0));
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set_epi32(HEDLEY_STATIC_CAST(int32_t, e3), HEDLEY_STATIC_CAST(int32_t, e2), HEDLEY_STATIC_CAST(int32_t, e1), HEDLEY_STATIC_CAST(int32_t, e0));
+      r_.m128i[1] = simde_mm_set_epi32(HEDLEY_STATIC_CAST(int32_t, e7), HEDLEY_STATIC_CAST(int32_t, e6), HEDLEY_STATIC_CAST(int32_t, e5), HEDLEY_STATIC_CAST(int32_t, e4));
+    #else
+      r_.u32[ 0] =  e0;
+      r_.u32[ 1] =  e1;
+      r_.u32[ 2] =  e2;
+      r_.u32[ 3] =  e3;
+      r_.u32[ 4] =  e4;
+      r_.u32[ 5] =  e5;
+      r_.u32[ 6] =  e6;
+      r_.u32[ 7] =  e7;
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_set_epu64x (uint64_t  e3, uint64_t  e2, uint64_t  e1, uint64_t  e0) {
+  simde__m256i_private r_;
+
+  r_.u64[0] = e0;
+  r_.u64[1] = e1;
+  r_.u64[2] = e2;
+  r_.u64[3] = e3;
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_set_ps (simde_float32 e7, simde_float32 e6, simde_float32 e5, simde_float32 e4,
+                    simde_float32 e3, simde_float32 e2, simde_float32 e1, simde_float32 e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_ps(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    simde__m256_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_set_ps(e3, e2, e1, e0);
+      r_.m128[1] = simde_mm_set_ps(e7, e6, e5, e4);
+    #else
+      r_.f32[0] = e0;
+      r_.f32[1] = e1;
+      r_.f32[2] = e2;
+      r_.f32[3] = e3;
+      r_.f32[4] = e4;
+      r_.f32[5] = e5;
+      r_.f32[6] = e6;
+      r_.f32[7] = e7;
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_ps
+  #define _mm256_set_ps(e7, e6, e5, e4, e3, e2, e1, e0) \
+  simde_mm256_set_ps(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_set_pd (simde_float64 e3, simde_float64 e2, simde_float64 e1, simde_float64 e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set_pd(e3, e2, e1, e0);
+  #else
+    simde__m256d_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_set_pd(e1, e0);
+      r_.m128d[1] = simde_mm_set_pd(e3, e2);
+    #else
+      r_.f64[0] = e0;
+      r_.f64[1] = e1;
+      r_.f64[2] = e2;
+      r_.f64[3] = e3;
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_pd
+  #define _mm256_set_pd(e3, e2, e1, e0) \
+  simde_mm256_set_pd(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_set_m128 (simde__m128 e1, simde__m128 e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_ps(_mm256_castps128_ps256(e0), e1, 1);
+  #else
+    simde__m256_private r_;
+    simde__m128_private
+      e1_ = simde__m128_to_private(e1),
+      e0_ = simde__m128_to_private(e0);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128_private[0] = e0_;
+      r_.m128_private[1] = e1_;
+    #elif defined(SIMDE_HAVE_INT128_)
+      r_.i128[0] = e0_.i128[0];
+      r_.i128[1] = e1_.i128[0];
+    #else
+      r_.i64[0] = e0_.i64[0];
+      r_.i64[1] = e0_.i64[1];
+      r_.i64[2] = e1_.i64[0];
+      r_.i64[3] = e1_.i64[1];
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_m128
+  #define _mm256_set_m128(e1, e0) simde_mm256_set_m128(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_set_m128d (simde__m128d e1, simde__m128d e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_pd(_mm256_castpd128_pd256(e0), e1, 1);
+  #else
+    simde__m256d_private r_;
+    simde__m128d_private
+      e1_ = simde__m128d_to_private(e1),
+      e0_ = simde__m128d_to_private(e0);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d_private[0] = e0_;
+      r_.m128d_private[1] = e1_;
+    #else
+      r_.i64[0] = e0_.i64[0];
+      r_.i64[1] = e0_.i64[1];
+      r_.i64[2] = e1_.i64[0];
+      r_.i64[3] = e1_.i64[1];
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_m128d
+  #define _mm256_set_m128d(e1, e0) simde_mm256_set_m128d(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set_m128i (simde__m128i e1, simde__m128i e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_si256(_mm256_castsi128_si256(e0), e1, 1);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private
+      e1_ = simde__m128i_to_private(e1),
+      e0_ = simde__m128i_to_private(e0);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i_private[0] = e0_;
+      r_.m128i_private[1] = e1_;
+    #else
+      r_.i64[0] = e0_.i64[0];
+      r_.i64[1] = e0_.i64[1];
+      r_.i64[2] = e1_.i64[0];
+      r_.i64[3] = e1_.i64[1];
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set_m128i
+  #define _mm256_set_m128i(e1, e0) simde_mm256_set_m128i(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set1_epi8 (int8_t a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_epi8(a);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set1_epi8(a);
+      r_.m128i[1] = simde_mm_set1_epi8(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_epi8
+  #define _mm256_set1_epi8(a) simde_mm256_set1_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set1_epi16 (int16_t a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_epi16(a);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set1_epi16(a);
+      r_.m128i[1] = simde_mm_set1_epi16(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_epi16
+  #define _mm256_set1_epi16(a) simde_mm256_set1_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set1_epi32 (int32_t a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_epi32(a);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set1_epi32(a);
+      r_.m128i[1] = simde_mm_set1_epi32(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_epi32
+  #define _mm256_set1_epi32(a) simde_mm256_set1_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_set1_epi64x (int64_t a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_epi64x(a);
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_set1_epi64x(a);
+      r_.m128i[1] = simde_mm_set1_epi64x(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_epi64x
+  #define _mm256_set1_epi64x(a) simde_mm256_set1_epi64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_set1_ps (simde_float32 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_ps(a);
+  #else
+    simde__m256_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_set1_ps(a);
+      r_.m128[1] = simde_mm_set1_ps(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a;
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_ps
+  #define _mm256_set1_ps(a) simde_mm256_set1_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_set1_pd (simde_float64 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_set1_pd(a);
+  #else
+    simde__m256d_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_set1_pd(a);
+      r_.m128d[1] = simde_mm_set1_pd(a);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a;
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_set1_pd
+  #define _mm256_set1_pd(a) simde_mm256_set1_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_deinterleaveeven_epi16 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for(size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_deinterleaveeven_epi16(a_.m128i[i], b_.m128i[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 32, a_.i16, b_.i16, 0, 2, 4, 6, 16, 18, 20, 22, 8, 10, 12, 14, 24, 26, 28, 30);
+  #else
+    const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.i16[i] = a_.i16[2 * i];
+      r_.i16[i + quarter_point] = b_.i16[2 * i];
+      r_.i16[halfway_point + i] = a_.i16[halfway_point + 2 * i];
+      r_.i16[halfway_point + i + quarter_point] = b_.i16[halfway_point + 2 * i];
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_deinterleaveodd_epi16 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for(size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_deinterleaveodd_epi16(a_.m128i[i], b_.m128i[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 32, a_.i16, b_.i16, 1, 3, 5, 7, 17, 19, 21, 23, 9, 11, 13, 15, 25, 27, 29, 31);
+  #else
+    const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.i16[i] = a_.i16[2 * i + 1];
+      r_.i16[i + quarter_point] = b_.i16[2 * i + 1];
+      r_.i16[halfway_point + i] = a_.i16[halfway_point + 2 * i + 1];
+      r_.i16[halfway_point + i + quarter_point] = b_.i16[halfway_point + 2 * i + 1];
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_deinterleaveeven_epi32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for(size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_deinterleaveeven_epi32(a_.m128i[i], b_.m128i[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.i32, b_.i32, 0, 2, 8, 10, 4, 6, 12, 14);
+  #else
+    const size_t halfway_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.i32[i] = a_.i32[2 * i];
+      r_.i32[i + quarter_point] = b_.i32[2 * i];
+      r_.i32[halfway_point + i] = a_.i32[halfway_point + 2 * i];
+      r_.i32[halfway_point + i + quarter_point] = b_.i32[halfway_point + 2 * i];
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_deinterleaveodd_epi32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for(size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_deinterleaveodd_epi32(a_.m128i[i], b_.m128i[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.i32, b_.i32, 1, 3, 9, 11, 5, 7, 13, 15);
+  #else
+    const size_t halfway_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.i32[i] = a_.i32[2 * i + 1];
+      r_.i32[i + quarter_point] = b_.i32[2 * i + 1];
+      r_.i32[halfway_point + i] = a_.i32[halfway_point + 2 * i + 1];
+      r_.i32[halfway_point + i + quarter_point] = b_.i32[halfway_point + 2 * i + 1];
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_deinterleaveeven_ps (simde__m256 a, simde__m256 b) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+      r_.m128[i] = simde_x_mm_deinterleaveeven_ps(a_.m128[i], b_.m128[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, b_.f32, 0, 2, 8, 10, 4, 6, 12, 14);
+  #else
+    const size_t halfway_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.f32[i] = a_.f32[2 * i];
+      r_.f32[i + quarter_point] = b_.f32[2 * i];
+      r_.f32[halfway_point + i] = a_.f32[halfway_point + 2 * i];
+      r_.f32[halfway_point + i + quarter_point] = b_.f32[halfway_point + 2 * i];
+    }
+  #endif
+
+  return simde__m256_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_deinterleaveodd_ps (simde__m256 a, simde__m256 b) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+      r_.m128[i] = simde_x_mm_deinterleaveodd_ps(a_.m128[i], b_.m128[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, b_.f32, 1, 3, 9, 11, 5, 7, 13, 15);
+  #else
+    const size_t halfway_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.f32[i] = a_.f32[2 * i + 1];
+      r_.f32[i + quarter_point] = b_.f32[2 * i + 1];
+      r_.f32[halfway_point + i] = a_.f32[halfway_point + 2 * i + 1];
+      r_.f32[halfway_point + i + quarter_point] = b_.f32[halfway_point + 2 * i + 1];
+    }
+  #endif
+
+  return simde__m256_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_deinterleaveeven_pd (simde__m256d a, simde__m256d b) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+      r_.m128d[i] = simde_x_mm_deinterleaveeven_pd(a_.m128d[i], b_.m128d[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.f64, b_.f64, 0, 4, 2, 6);
+  #else
+    const size_t halfway_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.f64[i] = a_.f64[2 * i];
+      r_.f64[i + quarter_point] = b_.f64[2 * i];
+      r_.f64[halfway_point + i] = a_.f64[halfway_point + 2 * i];
+      r_.f64[halfway_point + i + quarter_point] = b_.f64[halfway_point + 2 * i];
+    }
+  #endif
+
+  return simde__m256d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_deinterleaveodd_pd (simde__m256d a, simde__m256d b) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+      r_.m128d[i] = simde_x_mm_deinterleaveodd_pd(a_.m128d[i], b_.m128d[i]);
+    }
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.f64, b_.f64, 1, 5, 3, 7);
+  #else
+    const size_t halfway_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 2;
+    const size_t quarter_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 4;
+    for (size_t i = 0 ; i < quarter_point ; i++) {
+      r_.f64[i] = a_.f64[2 * i + 1];
+      r_.f64[i + quarter_point] = b_.f64[2 * i + 1];
+      r_.f64[halfway_point + i] = a_.f64[halfway_point + 2 * i + 1];
+      r_.f64[halfway_point + i + quarter_point] = b_.f64[halfway_point + 2 * i + 1];
+    }
+  #endif
+
+  return simde__m256d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_abs_ps(simde__m256 a) {
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_fabsf(a_.f32[i]);
+      }
+    return simde__m256_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_abs_pd(simde__m256d a) {
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_fabs(a_.f64[i]);
+      }
+    return simde__m256d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_add_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_add_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_add_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_add_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 + b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] + b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_ps
+  #define _mm256_add_ps(a, b) simde_mm256_add_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_hadd_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hadd_ps(a, b);
+  #else
+    return simde_mm256_add_ps(simde_x_mm256_deinterleaveeven_ps(a, b), simde_x_mm256_deinterleaveodd_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hadd_ps
+  #define _mm256_hadd_ps(a, b) simde_mm256_hadd_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_add_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_add_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_add_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_add_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 + b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] + b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_pd
+  #define _mm256_add_pd(a, b) simde_mm256_add_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_hadd_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hadd_pd(a, b);
+  #else
+      return simde_mm256_add_pd(simde_x_mm256_deinterleaveeven_pd(a, b), simde_x_mm256_deinterleaveodd_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hadd_pd
+  #define _mm256_hadd_pd(a, b) simde_mm256_hadd_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_addsub_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_addsub_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_addsub_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_addsub_ps(a_.m128[1], b_.m128[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+        r_.f32[  i  ] = a_.f32[  i  ] - b_.f32[  i  ];
+        r_.f32[i + 1] = a_.f32[i + 1] + b_.f32[i + 1];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_addsub_ps
+  #define _mm256_addsub_ps(a, b) simde_mm256_addsub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_addsub_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_addsub_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_addsub_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_addsub_pd(a_.m128d[1], b_.m128d[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+        r_.f64[  i  ] = a_.f64[  i  ] - b_.f64[  i  ];
+        r_.f64[i + 1] = a_.f64[i + 1] + b_.f64[i + 1];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_addsub_pd
+  #define _mm256_addsub_pd(a, b) simde_mm256_addsub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_and_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_and_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_and_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_and_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_and_ps
+  #define _mm256_and_ps(a, b) simde_mm256_and_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_and_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_and_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_and_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_and_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_and_pd
+  #define _mm256_and_pd(a, b) simde_mm256_and_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_andnot_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_andnot_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_andnot_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_andnot_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_andnot_ps
+  #define _mm256_andnot_ps(a, b) simde_mm256_andnot_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_andnot_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_andnot_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_andnot_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_andnot_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_andnot_pd
+  #define _mm256_andnot_pd(a, b) simde_mm256_andnot_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_blend_ps (simde__m256 a, simde__m256 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    r_.f32[i] = ((imm8 >> i) & 1) ? b_.f32[i] : a_.f32[i];
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_blend_ps(a, b, imm8) _mm256_blend_ps(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_blend_ps(a, b, imm8) \
+      simde_mm256_set_m128( \
+          simde_mm_blend_ps(simde_mm256_extractf128_ps(a, 1), simde_mm256_extractf128_ps(b, 1), (imm8) >> 4), \
+          simde_mm_blend_ps(simde_mm256_extractf128_ps(a, 0), simde_mm256_extractf128_ps(b, 0), (imm8) & 0x0F))
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blend_ps
+  #define _mm256_blend_ps(a, b, imm8) simde_mm256_blend_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_blend_pd (simde__m256d a, simde__m256d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 15) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    r_.f64[i] = ((imm8 >> i) & 1) ? b_.f64[i] : a_.f64[i];
+  }
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_blend_pd(a, b, imm8) _mm256_blend_pd(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_blend_pd(a, b, imm8) \
+      simde_mm256_set_m128d( \
+          simde_mm_blend_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8) >> 2), \
+          simde_mm_blend_pd(simde_mm256_extractf128_pd(a, 0), simde_mm256_extractf128_pd(b, 0), (imm8) & 3))
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blend_pd
+  #define _mm256_blend_pd(a, b, imm8) simde_mm256_blend_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_blendv_ps (simde__m256 a, simde__m256 b, simde__m256 mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_blendv_ps(a, b, mask);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      mask_ = simde__m256_to_private(mask);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_blendv_ps(a_.m128[0], b_.m128[0], mask_.m128[0]);
+      r_.m128[1] = simde_mm_blendv_ps(a_.m128[1], b_.m128[1], mask_.m128[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.f32[i] = (mask_.u32[i] & (UINT32_C(1) << 31)) ? b_.f32[i] : a_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blendv_ps
+  #define _mm256_blendv_ps(a, b, imm8) simde_mm256_blendv_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_blendv_pd (simde__m256d a, simde__m256d b, simde__m256d mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_blendv_pd(a, b, mask);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b),
+      mask_ = simde__m256d_to_private(mask);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_blendv_pd(a_.m128d[0], b_.m128d[0], mask_.m128d[0]);
+      r_.m128d[1] = simde_mm_blendv_pd(a_.m128d[1], b_.m128d[1], mask_.m128d[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.f64[i] = (mask_.u64[i] & (UINT64_C(1) << 63)) ? b_.f64[i] : a_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blendv_pd
+  #define _mm256_blendv_pd(a, b, imm8) simde_mm256_blendv_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_broadcast_pd (simde__m128d const * mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_broadcast_pd(mem_addr);
+  #else
+    simde__m256d_private r_;
+
+    simde__m128d tmp = simde_mm_loadu_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, mem_addr));
+    r_.m128d[0] = tmp;
+    r_.m128d[1] = tmp;
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_pd
+  #define _mm256_broadcast_pd(mem_addr) simde_mm256_broadcast_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_broadcast_ps (simde__m128 const * mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_broadcast_ps(mem_addr);
+  #else
+    simde__m256_private r_;
+
+    simde__m128 tmp = simde_mm_loadu_ps(HEDLEY_REINTERPRET_CAST(simde_float32 const*, mem_addr));
+    r_.m128[0] = tmp;
+    r_.m128[1] = tmp;
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_ps
+  #define _mm256_broadcast_ps(mem_addr) simde_mm256_broadcast_ps(HEDLEY_REINTERPRET_CAST(simde__m128 const*, mem_addr))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_broadcast_sd (simde_float64 const * a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_broadcast_sd(a);
+  #else
+    simde__m256d_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = *a;
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_sd
+  #define _mm256_broadcast_sd(mem_addr) simde_mm256_broadcast_sd(HEDLEY_REINTERPRET_CAST(double const*, mem_addr))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_broadcast_ss (simde_float32 const * a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_broadcast_ss(a);
+  #else
+    simde__m128_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = *a;
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcast_ss
+  #define _mm_broadcast_ss(mem_addr) simde_mm_broadcast_ss(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_broadcast_ss (simde_float32 const * a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_broadcast_ss(a);
+  #else
+    simde__m256_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = *a;
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_ss
+  #define _mm256_broadcast_ss(mem_addr) simde_mm256_broadcast_ss(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_castpd128_pd256 (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castpd128_pd256(a);
+  #else
+    simde__m256d_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    r_.m128d_private[0] = a_;
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castpd128_pd256
+  #define _mm256_castpd128_pd256(a) simde_mm256_castpd128_pd256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm256_castpd256_pd128 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castpd256_pd128(a);
+  #else
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+    return a_.m128d[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castpd256_pd128
+  #define _mm256_castpd256_pd128(a) simde_mm256_castpd256_pd128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_castps128_ps256 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castps128_ps256(a);
+  #else
+    simde__m256_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    r_.m128_private[0] = a_;
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castps128_ps256
+  #define _mm256_castps128_ps256(a) simde_mm256_castps128_ps256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm256_castps256_ps128 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castps256_ps128(a);
+  #else
+    simde__m256_private a_ = simde__m256_to_private(a);
+    return a_.m128[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castps256_ps128
+  #define _mm256_castps256_ps128(a) simde_mm256_castps256_ps128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_castsi128_si256 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castsi128_si256(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    r_.m128i_private[0] = a_;
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castsi128_si256
+  #define _mm256_castsi128_si256(a) simde_mm256_castsi128_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_castsi256_si128 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_castsi256_si128(a);
+  #else
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+    return a_.m128i[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_castsi256_si128
+  #define _mm256_castsi256_si128(a) simde_mm256_castsi256_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_round_ps (simde__m256 a, const int rounding) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a);
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(simde_math_nearbyintf)
+      case SIMDE_MM_FROUND_CUR_DIRECTION:
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_nearbyintf(a_.f32[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_roundf)
+      case SIMDE_MM_FROUND_TO_NEAREST_INT:
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_roundf(a_.f32[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_floorf)
+      case SIMDE_MM_FROUND_TO_NEG_INF:
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_floorf(a_.f32[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_ceilf)
+      case SIMDE_MM_FROUND_TO_POS_INF:
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_ceilf(a_.f32[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_truncf)
+      case SIMDE_MM_FROUND_TO_ZERO:
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_truncf(a_.f32[i]);
+        }
+        break;
+    #endif
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm256_undefined_ps());
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_round_ps(a, rounding) _mm256_round_ps(a, rounding)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_round_ps
+  #define _mm256_round_ps(a, rounding) simde_mm256_round_ps(a, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_round_pd (simde__m256d a, const int rounding) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a);
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(simde_math_nearbyint)
+      case SIMDE_MM_FROUND_CUR_DIRECTION:
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_nearbyint(a_.f64[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_round)
+      case SIMDE_MM_FROUND_TO_NEAREST_INT:
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_round(a_.f64[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_floor)
+      case SIMDE_MM_FROUND_TO_NEG_INF:
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_floor(a_.f64[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_ceil)
+      case SIMDE_MM_FROUND_TO_POS_INF:
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_ceil(a_.f64[i]);
+        }
+        break;
+    #endif
+
+    #if defined(simde_math_trunc)
+      case SIMDE_MM_FROUND_TO_ZERO:
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_trunc(a_.f64[i]);
+        }
+        break;
+    #endif
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm256_undefined_pd());
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_round_pd(a, rounding) _mm256_round_pd(a, rounding)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_round_pd
+  #define _mm256_round_pd(a, rounding) simde_mm256_round_pd(a, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_ceil_pd (simde__m256d a) {
+  return simde_mm256_round_pd(a, SIMDE_MM_FROUND_TO_POS_INF);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_ceil_pd
+  #define _mm256_ceil_pd(a) simde_mm256_ceil_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_ceil_ps (simde__m256 a) {
+  return simde_mm256_round_ps(a, SIMDE_MM_FROUND_TO_POS_INF);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_ceil_ps
+  #define _mm256_ceil_ps(a) simde_mm256_ceil_ps(a)
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_FLOAT_EQUAL
+
+/* This implementation does not support signaling NaNs (yet?) */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmp_pd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+    case SIMDE_CMP_EQ_UQ:
+    case SIMDE_CMP_EQ_OS:
+    case SIMDE_CMP_EQ_US:
+      return simde_mm_cmpeq_pd(a, b);
+      break;
+    case SIMDE_CMP_LT_OS:
+    case SIMDE_CMP_NGE_US:
+    case SIMDE_CMP_LT_OQ:
+    case SIMDE_CMP_NGE_UQ:
+      return simde_mm_cmplt_pd(a, b);
+      break;
+    case SIMDE_CMP_LE_OS:
+    case SIMDE_CMP_NGT_US:
+    case SIMDE_CMP_LE_OQ:
+    case SIMDE_CMP_NGT_UQ:
+      return simde_mm_cmple_pd(a, b);
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+    case SIMDE_CMP_NEQ_OQ:
+    case SIMDE_CMP_NEQ_US:
+    case SIMDE_CMP_NEQ_OS:
+      return simde_mm_cmpneq_pd(a, b);
+      break;
+    case SIMDE_CMP_NLT_US:
+    case SIMDE_CMP_GE_OS:
+    case SIMDE_CMP_NLT_UQ:
+    case SIMDE_CMP_GE_OQ:
+      return simde_mm_cmpge_pd(a, b);
+      break;
+    case SIMDE_CMP_NLE_US:
+    case SIMDE_CMP_GT_OS:
+    case SIMDE_CMP_NLE_UQ:
+    case SIMDE_CMP_GT_OQ:
+      return simde_mm_cmpgt_pd(a, b);
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+    case SIMDE_CMP_FALSE_OS:
+      return simde_mm_setzero_pd();
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+    case SIMDE_CMP_TRUE_US:
+      return simde_x_mm_setone_pd();
+      break;
+    case SIMDE_CMP_UNORD_Q:
+    case SIMDE_CMP_UNORD_S:
+      return simde_mm_cmpunord_pd(a, b);
+      break;
+    case SIMDE_CMP_ORD_Q:
+    case SIMDE_CMP_ORD_S:
+      return simde_mm_cmpord_pd(a, b);
+      break;
+  }
+
+  HEDLEY_UNREACHABLE_RETURN(simde_mm_setzero_pd());
+}
+#if defined(SIMDE_X86_AVX_NATIVE) && (!defined(__clang__) || !defined(__AVX512F__))
+#  define simde_mm_cmp_pd(a, b, imm8) _mm_cmp_pd(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmp_pd
+  #define _mm_cmp_pd(a, b, imm8) simde_mm_cmp_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmp_ps (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+    case SIMDE_CMP_EQ_UQ:
+    case SIMDE_CMP_EQ_OS:
+    case SIMDE_CMP_EQ_US:
+      return simde_mm_cmpeq_ps(a, b);
+      break;
+    case SIMDE_CMP_LT_OS:
+    case SIMDE_CMP_NGE_US:
+    case SIMDE_CMP_LT_OQ:
+    case SIMDE_CMP_NGE_UQ:
+      return simde_mm_cmplt_ps(a, b);
+      break;
+    case SIMDE_CMP_LE_OS:
+    case SIMDE_CMP_NGT_US:
+    case SIMDE_CMP_LE_OQ:
+    case SIMDE_CMP_NGT_UQ:
+      return simde_mm_cmple_ps(a, b);
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+    case SIMDE_CMP_NEQ_OQ:
+    case SIMDE_CMP_NEQ_US:
+    case SIMDE_CMP_NEQ_OS:
+      return simde_mm_cmpneq_ps(a, b);
+      break;
+    case SIMDE_CMP_NLT_US:
+    case SIMDE_CMP_GE_OS:
+    case SIMDE_CMP_NLT_UQ:
+    case SIMDE_CMP_GE_OQ:
+      return simde_mm_cmpge_ps(a, b);
+      break;
+    case SIMDE_CMP_NLE_US:
+    case SIMDE_CMP_GT_OS:
+    case SIMDE_CMP_NLE_UQ:
+    case SIMDE_CMP_GT_OQ:
+      return simde_mm_cmpgt_ps(a, b);
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+    case SIMDE_CMP_FALSE_OS:
+      return simde_mm_setzero_ps();
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+    case SIMDE_CMP_TRUE_US:
+      return simde_x_mm_setone_ps();
+      break;
+    case SIMDE_CMP_UNORD_Q:
+    case SIMDE_CMP_UNORD_S:
+      return simde_mm_cmpunord_ps(a, b);
+      break;
+    case SIMDE_CMP_ORD_Q:
+    case SIMDE_CMP_ORD_S:
+      return simde_mm_cmpord_ps(a, b);
+      break;
+  }
+
+  HEDLEY_UNREACHABLE_RETURN(simde_mm_setzero_ps());
+}
+/* Prior to 9.0 clang has problems with _mm{,256}_cmp_{ps,pd} for all four of the true/false
+   comparisons, but only when AVX-512 is enabled.  __FILE_NAME__ was added in 9.0, so that's
+   what we use to check for clang 9 since the version macros are unreliable. */
+#if defined(SIMDE_X86_AVX_NATIVE) && (!defined(__clang__) || !defined(__AVX512F__))
+#  define simde_mm_cmp_ps(a, b, imm8) _mm_cmp_ps(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmp_ps
+  #define _mm_cmp_ps(a, b, imm8) simde_mm_cmp_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmp_sd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+      r_.u64[0] = (a_.f64[0] == b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_LT_OS:
+      r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_LE_OS:
+      r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_UNORD_Q:
+#if defined(simde_math_isnan)
+      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+#else
+  HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+      r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NLT_US:
+      r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NLE_US:
+      r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnan)
+      r_.u64[0] = (!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+#else
+  HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_UQ:
+      r_.u64[0] = (a_.f64[0] == b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NGE_US:
+      r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NGT_US:
+      r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+      r_.u64[0] = UINT64_C(0);
+      break;
+    case SIMDE_CMP_NEQ_OQ:
+      r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_GE_OS:
+      r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_GT_OS:
+      r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+      r_.u64[0] = ~UINT64_C(0);
+      break;
+    case SIMDE_CMP_EQ_OS:
+      r_.u64[0] = (a_.f64[0] == b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_LT_OQ:
+      r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_LE_OQ:
+      r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnan)
+      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+#else
+  HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_US:
+      r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NLT_UQ:
+      r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NLE_UQ:
+      r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnan)
+      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? UINT64_C(0) : ~UINT64_C(0);
+#else
+  HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_US:
+      r_.u64[0] = (a_.f64[0] == b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NGE_UQ:
+      r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_NGT_UQ:
+      r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_FALSE_OS:
+      r_.u64[0] = UINT64_C(0);
+      break;
+    case SIMDE_CMP_NEQ_OS:
+      r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_GE_OQ:
+      r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_GT_OQ:
+      r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+      break;
+    case SIMDE_CMP_TRUE_US:
+      r_.u64[0] = ~UINT64_C(0);
+      break;
+  }
+  r_.u64[1] = a_.u64[1];
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm_cmp_sd(a, b, imm8) _mm_cmp_sd(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmp_sd
+  #define _mm_cmp_sd(a, b, imm8) simde_mm_cmp_sd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmp_ss (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+      r_.u32[0] = (a_.f32[0] == b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_LT_OS:
+      r_.u32[0] = (a_.f32[0] < b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_LE_OS:
+      r_.u32[0] = (a_.f32[0] <= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_UNORD_Q:
+#if defined(simde_math_isnanf)
+      r_.u32[0] = (simde_math_isnanf(a_.f32[0]) || simde_math_isnanf(b_.f32[0])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+      r_.u32[0] = (a_.f32[0] != b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NLT_US:
+      r_.u32[0] = (a_.f32[0] >= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NLE_US:
+      r_.u32[0] = (a_.f32[0] > b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnanf)
+      r_.u32[0] = (!simde_math_isnanf(a_.f32[0]) && !simde_math_isnanf(b_.f32[0])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_UQ:
+      r_.u32[0] = (a_.f32[0] == b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NGE_US:
+      r_.u32[0] = (a_.f32[0] < b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NGT_US:
+      r_.u32[0] = (a_.f32[0] <= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+      r_.u32[0] = UINT32_C(0);
+      break;
+    case SIMDE_CMP_NEQ_OQ:
+      r_.u32[0] = (a_.f32[0] != b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_GE_OS:
+      r_.u32[0] = (a_.f32[0] >= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_GT_OS:
+      r_.u32[0] = (a_.f32[0] > b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+      r_.u32[0] = ~UINT32_C(0);
+      break;
+    case SIMDE_CMP_EQ_OS:
+      r_.u32[0] = (a_.f32[0] == b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_LT_OQ:
+      r_.u32[0] = (a_.f32[0] < b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_LE_OQ:
+      r_.u32[0] = (a_.f32[0] <= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnanf)
+      r_.u32[0] = (simde_math_isnanf(a_.f32[0]) || simde_math_isnanf(b_.f32[0])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_US:
+      r_.u32[0] = (a_.f32[0] != b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NLT_UQ:
+      r_.u32[0] = (a_.f32[0] >= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NLE_UQ:
+      r_.u32[0] = (a_.f32[0] > b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnanf)
+      r_.u32[0] = (simde_math_isnanf(a_.f32[0]) || simde_math_isnanf(b_.f32[0])) ? UINT32_C(0) : ~UINT32_C(0);
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_US:
+      r_.u32[0] = (a_.f32[0] == b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NGE_UQ:
+      r_.u32[0] = (a_.f32[0] < b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_NGT_UQ:
+      r_.u32[0] = (a_.f32[0] <= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_FALSE_OS:
+      r_.u32[0] = UINT32_C(0);
+      break;
+    case SIMDE_CMP_NEQ_OS:
+      r_.u32[0] = (a_.f32[0] != b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_GE_OQ:
+      r_.u32[0] = (a_.f32[0] >= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_GT_OQ:
+      r_.u32[0] = (a_.f32[0] > b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+      break;
+    case SIMDE_CMP_TRUE_US:
+      r_.u32[0] = ~UINT32_C(0);
+      break;
+  }
+  r_.u32[1] = a_.u32[1];
+  r_.u32[2] = a_.u32[2];
+  r_.u32[3] = a_.u32[3];
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm_cmp_ss(a, b, imm8) _mm_cmp_ss(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmp_ss
+  #define _mm_cmp_ss(a, b, imm8) simde_mm_cmp_ss(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cmp_pd (simde__m256d a, simde__m256d b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+      break;
+    case SIMDE_CMP_LT_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+      break;
+    case SIMDE_CMP_LE_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+      break;
+    case SIMDE_CMP_UNORD_Q:
+#if defined(simde_math_isnan)
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+      break;
+    case SIMDE_CMP_NLT_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+      break;
+    case SIMDE_CMP_NLE_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+      break;
+    case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnan)
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (!simde_math_isnan(a_.f64[i]) && !simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+      break;
+    case SIMDE_CMP_NGE_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+      break;
+    case SIMDE_CMP_NGT_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+      r_ = simde__m256d_to_private(simde_mm256_setzero_pd());
+      break;
+    case SIMDE_CMP_NEQ_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+      break;
+    case SIMDE_CMP_GE_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+      break;
+    case SIMDE_CMP_GT_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+      r_ = simde__m256d_to_private(simde_x_mm256_setone_pd());
+      break;
+    case SIMDE_CMP_EQ_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+      break;
+    case SIMDE_CMP_LT_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+      break;
+    case SIMDE_CMP_LE_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+      break;
+    case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnan)
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+     case SIMDE_CMP_NEQ_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+      break;
+    case SIMDE_CMP_NLT_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+      break;
+    case SIMDE_CMP_NLE_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+      break;
+    case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnan)
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? UINT64_C(0) : ~UINT64_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_US:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+      break;
+    case SIMDE_CMP_NGE_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+      break;
+    case SIMDE_CMP_NGT_UQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+      break;
+    case SIMDE_CMP_FALSE_OS:
+      r_ = simde__m256d_to_private(simde_mm256_setzero_pd());
+      break;
+    case SIMDE_CMP_NEQ_OS:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+      break;
+    case SIMDE_CMP_GE_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+      break;
+    case SIMDE_CMP_GT_OQ:
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+      break;
+    case SIMDE_CMP_TRUE_US:
+      r_ = simde__m256d_to_private(simde_x_mm256_setone_pd());
+      break;
+    default:
+      HEDLEY_UNREACHABLE();
+      break;
+  }
+#else
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    switch (imm8) {
+      case SIMDE_CMP_EQ_OQ:
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_LT_OS:
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_LE_OS:
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_UNORD_Q:
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NEQ_UQ:
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NLT_US:
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NLE_US:
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnan)
+        r_.u64[i] = (!simde_math_isnan(a_.f64[i]) && !simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_EQ_UQ:
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NGE_US:
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NGT_US:
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_FALSE_OQ:
+        r_.u64[i] = UINT64_C(0);
+        break;
+      case SIMDE_CMP_NEQ_OQ:
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_GE_OS:
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_GT_OS:
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_TRUE_UQ:
+        r_.u64[i] = ~UINT64_C(0);
+        break;
+      case SIMDE_CMP_EQ_OS:
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_LT_OQ:
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_LE_OQ:
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnan)
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_NEQ_US:
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NLT_UQ:
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NLE_UQ:
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnan)
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? UINT64_C(0) : ~UINT64_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_EQ_US:
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NGE_UQ:
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_NGT_UQ:
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_FALSE_OS:
+        r_.u64[i] = UINT64_C(0);
+        break;
+      case SIMDE_CMP_NEQ_OS:
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_GE_OQ:
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_GT_OQ:
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+        break;
+      case SIMDE_CMP_TRUE_US:
+        r_.u64[i] = ~UINT64_C(0);
+        break;
+      default:
+        HEDLEY_UNREACHABLE();
+        break;
+    }
+  }
+#endif
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE) && (!defined(__clang__) || !defined(__AVX512F__))
+#  define simde_mm256_cmp_pd(a, b, imm8) _mm256_cmp_pd(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmp_pd
+  #define _mm256_cmp_pd(a, b, imm8) simde_mm256_cmp_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cmp_ps (simde__m256 a, simde__m256 b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+  switch (imm8) {
+    case SIMDE_CMP_EQ_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+      break;
+    case SIMDE_CMP_LT_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+      break;
+    case SIMDE_CMP_LE_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+      break;
+    case SIMDE_CMP_UNORD_Q:
+#if defined(simde_math_isnanf)
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+      break;
+    case SIMDE_CMP_NLT_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+      break;
+    case SIMDE_CMP_NLE_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+      break;
+    case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnanf)
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (!simde_math_isnanf(a_.f32[i]) && !simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+      break;
+    case SIMDE_CMP_NGE_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+      break;
+    case SIMDE_CMP_NGT_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+      break;
+    case SIMDE_CMP_FALSE_OQ:
+      r_ = simde__m256_to_private(simde_mm256_setzero_ps());
+      break;
+    case SIMDE_CMP_NEQ_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+      break;
+    case SIMDE_CMP_GE_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+      break;
+    case SIMDE_CMP_GT_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+      break;
+    case SIMDE_CMP_TRUE_UQ:
+      r_ = simde__m256_to_private(simde_x_mm256_setone_ps());
+      break;
+    case SIMDE_CMP_EQ_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+      break;
+    case SIMDE_CMP_LT_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+      break;
+    case SIMDE_CMP_LE_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+      break;
+    case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnanf)
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_NEQ_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+      break;
+    case SIMDE_CMP_NLT_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+      break;
+    case SIMDE_CMP_NLE_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+      break;
+    case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnanf)
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? UINT32_C(0) : ~UINT32_C(0);
+      }
+#else
+      HEDLEY_UNREACHABLE();
+#endif
+      break;
+    case SIMDE_CMP_EQ_US:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+      break;
+    case SIMDE_CMP_NGE_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+      break;
+    case SIMDE_CMP_NGT_UQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+      break;
+    case SIMDE_CMP_FALSE_OS:
+      r_ = simde__m256_to_private(simde_mm256_setzero_ps());
+      break;
+    case SIMDE_CMP_NEQ_OS:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+      break;
+    case SIMDE_CMP_GE_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+      break;
+    case SIMDE_CMP_GT_OQ:
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+      break;
+    case SIMDE_CMP_TRUE_US:
+      r_ = simde__m256_to_private(simde_x_mm256_setone_ps());
+      break;
+    default:
+      HEDLEY_UNREACHABLE();
+      break;
+  }
+#else
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    switch (imm8) {
+      case SIMDE_CMP_EQ_OQ:
+        r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_LT_OS:
+        r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_LE_OS:
+        r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_UNORD_Q:
+#if defined(simde_math_isnanf)
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_NEQ_UQ:
+        r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NLT_US:
+        r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NLE_US:
+        r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_ORD_Q:
+#if defined(simde_math_isnanf)
+        r_.u32[i] = (!simde_math_isnanf(a_.f32[i]) && !simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_EQ_UQ:
+        r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NGE_US:
+        r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NGT_US:
+        r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_FALSE_OQ:
+        r_.u32[i] = UINT32_C(0);
+        break;
+      case SIMDE_CMP_NEQ_OQ:
+        r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_GE_OS:
+        r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_GT_OS:
+        r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_TRUE_UQ:
+        r_.u32[i] = ~UINT32_C(0);
+        break;
+      case SIMDE_CMP_EQ_OS:
+        r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_LT_OQ:
+        r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_LE_OQ:
+        r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_UNORD_S:
+#if defined(simde_math_isnanf)
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_NEQ_US:
+        r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NLT_UQ:
+        r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NLE_UQ:
+        r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_ORD_S:
+#if defined(simde_math_isnanf)
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? UINT32_C(0) : ~UINT32_C(0);
+#else
+        HEDLEY_UNREACHABLE();
+#endif
+        break;
+      case SIMDE_CMP_EQ_US:
+        r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NGE_UQ:
+        r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_NGT_UQ:
+        r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_FALSE_OS:
+        r_.u32[i] = UINT32_C(0);
+        break;
+      case SIMDE_CMP_NEQ_OS:
+        r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_GE_OQ:
+        r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_GT_OQ:
+        r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+        break;
+      case SIMDE_CMP_TRUE_US:
+        r_.u32[i] = ~UINT32_C(0);
+        break;
+      default:
+        HEDLEY_UNREACHABLE();
+        break;
+    }
+  }
+#endif
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE) && (!defined(__clang__) || !defined(__AVX512F__))
+#  define simde_mm256_cmp_ps(a, b, imm8) _mm256_cmp_ps(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmp_ps
+  #define _mm256_cmp_ps(a, b, imm8) simde_mm256_cmp_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_copysign_ps(simde__m256 dest, simde__m256 src) {
+  simde__m256_private
+    r_,
+    dest_ = simde__m256_to_private(dest),
+    src_ = simde__m256_to_private(src);
+
+  #if defined(simde_math_copysignf)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_copysignf(dest_.f32[i], src_.f32[i]);
+    }
+  #else
+    simde__m256 sgnbit = simde_mm256_xor_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), simde_mm256_set1_ps(-SIMDE_FLOAT32_C(0.0)));
+    return simde_mm256_xor_ps(simde_mm256_and_ps(sgnbit, src), simde_mm256_andnot_ps(sgnbit, dest));
+  #endif
+
+  return simde__m256_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_copysign_pd(simde__m256d dest, simde__m256d src) {
+  simde__m256d_private
+    r_,
+    dest_ = simde__m256d_to_private(dest),
+    src_ = simde__m256d_to_private(src);
+
+  #if defined(simde_math_copysign)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
+    }
+  #else
+    simde__m256d sgnbit = simde_mm256_xor_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), simde_mm256_set1_pd(-SIMDE_FLOAT64_C(0.0)));
+    return simde_mm256_xor_pd(simde_mm256_and_pd(sgnbit, src), simde_mm256_andnot_pd(sgnbit, dest));
+  #endif
+
+  return simde__m256d_from_private(r_);
+}
+
+HEDLEY_DIAGNOSTIC_POP /* -Wfloat-equal */
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cvtepi32_pd (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtepi32_pd(a);
+  #else
+    simde__m256d_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = HEDLEY_STATIC_CAST(simde_float64, a_.i32[i]);
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi32_pd
+  #define _mm256_cvtepi32_pd(a) simde_mm256_cvtepi32_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+  simde_mm256_cvtepi32_ps (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtepi32_ps(a);
+  #else
+    simde__m256_private r_;
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = HEDLEY_STATIC_CAST(simde_float32, a_.i32[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi32_ps
+  #define _mm256_cvtepi32_ps(a) simde_mm256_cvtepi32_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvtpd_epi32 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+
+    #if defined(simde_math_nearbyint)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_nearbyint(a_.f64[i]));
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtpd_epi32
+  #define _mm256_cvtpd_epi32(a) simde_mm256_cvtpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm256_cvtpd_ps (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtpd_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = HEDLEY_STATIC_CAST(simde_float32, a_.f64[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtpd_ps
+  #define _mm256_cvtpd_ps(a) simde_mm256_cvtpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtps_epi32 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtps_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m256_private a_ = simde__m256_to_private(a);
+
+    #if defined(simde_math_nearbyintf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_nearbyintf(a_.f32[i]));
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtps_epi32
+  #define _mm256_cvtps_epi32(a) simde_mm256_cvtps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cvtps_pd (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvtps_pd(a);
+  #else
+    simde__m256d_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+      r_.f64[i] = HEDLEY_STATIC_CAST(double, a_.f32[i]);
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtps_pd
+  #define _mm256_cvtps_pd(a) simde_mm256_cvtps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64
+simde_mm256_cvtsd_f64 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,9,0) || \
+      HEDLEY_GCC_VERSION_CHECK(7,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_MSVC_VERSION_CHECK(19,14,0))
+    return _mm256_cvtsd_f64(a);
+  #else
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+    return a_.f64[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsd_f64
+  #define _mm256_cvtsd_f64(a) simde_mm256_cvtsd_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm256_cvtsi256_si32 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,9,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_MSVC_VERSION_CHECK(19,14,0))
+    return _mm256_cvtsi256_si32(a);
+  #else
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+    return a_.i32[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsi256_si32
+  #define _mm256_cvtsi256_si32(a) simde_mm256_cvtsi256_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32
+simde_mm256_cvtss_f32 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && ( \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,9,0) || \
+      HEDLEY_GCC_VERSION_CHECK(7,0,0) || \
+      HEDLEY_INTEL_VERSION_CHECK(13,0,0) || \
+      HEDLEY_MSVC_VERSION_CHECK(19,14,0))
+    return _mm256_cvtss_f32(a);
+  #else
+    simde__m256_private a_ = simde__m256_to_private(a);
+    return a_.f32[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtss_f32
+  #define _mm256_cvtss_f32(a) simde_mm256_cvtss_f32(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvttpd_epi32 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvttpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+
+    #if defined(simde_math_trunc)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_trunc(a_.f64[i]));
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvttpd_epi32
+  #define _mm256_cvttpd_epi32(a) simde_mm256_cvttpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvttps_epi32 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cvttps_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m256_private a_ = simde__m256_to_private(a);
+
+    #if defined(simde_math_truncf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_truncf(a_.f32[i]));
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvttps_epi32
+  #define _mm256_cvttps_epi32(a) simde_mm256_cvttps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_div_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_div_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_div_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 / b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] / b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_ps
+  #define _mm256_div_ps(a, b) simde_mm256_div_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_div_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_div_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_div_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 / b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] / b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_pd
+  #define _mm256_div_pd(a, b) simde_mm256_div_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm256_extractf128_pd (simde__m256d a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1) {
+  simde__m256d_private a_ = simde__m256d_to_private(a);
+  return a_.m128d[imm8];
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_extractf128_pd(a, imm8) _mm256_extractf128_pd(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extractf128_pd
+  #define _mm256_extractf128_pd(a, imm8) simde_mm256_extractf128_pd(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm256_extractf128_ps (simde__m256 a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1) {
+  simde__m256_private a_ = simde__m256_to_private(a);
+  return a_.m128[imm8];
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_extractf128_ps(a, imm8) _mm256_extractf128_ps(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extractf128_ps
+  #define _mm256_extractf128_ps(a, imm8) simde_mm256_extractf128_ps(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_extractf128_si256 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.m128i[imm8];
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_extractf128_si256(a, imm8) _mm256_extractf128_si256(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extractf128_si256
+  #define _mm256_extractf128_si256(a, imm8) simde_mm256_extractf128_si256(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_floor_pd (simde__m256d a) {
+  return simde_mm256_round_pd(a, SIMDE_MM_FROUND_TO_NEG_INF);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_floor_pd
+  #define _mm256_floor_pd(a) simde_mm256_floor_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_floor_ps (simde__m256 a) {
+  return simde_mm256_round_ps(a, SIMDE_MM_FROUND_TO_NEG_INF);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_floor_ps
+  #define _mm256_floor_ps(a) simde_mm256_floor_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_insert_epi8 (simde__m256i a, int8_t i, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 31) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+
+  a_.i8[index] = i;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_insert_epi8(a, i, index) _mm256_insert_epi8(a, i, index)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insert_epi8
+  #define _mm256_insert_epi8(a, i, index) simde_mm256_insert_epi8(a, i, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_insert_epi16 (simde__m256i a, int16_t i, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 15)  {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+
+  a_.i16[index] = i;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_insert_epi16(a, i, index) _mm256_insert_epi16(a, i, index)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insert_epi16
+  #define _mm256_insert_epi16(a, i, imm8) simde_mm256_insert_epi16(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_insert_epi32 (simde__m256i a, int32_t i, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 7)  {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+
+  a_.i32[index] = i;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_insert_epi32(a, i, index) _mm256_insert_epi32(a, i, index)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insert_epi32
+  #define _mm256_insert_epi32(a, i, index) simde_mm256_insert_epi32(a, i, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_insert_epi64 (simde__m256i a, int64_t i, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 3)  {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+
+  a_.i64[index] = i;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE) && defined(SIMDE_ARCH_AMD64) && \
+    (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,20,0)) && \
+    SIMDE_DETECT_CLANG_VERSION_CHECK(3,7,0)
+  #define simde_mm256_insert_epi64(a, i, index) _mm256_insert_epi64(a, i, index)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insert_epi64
+  #define _mm256_insert_epi64(a, i, index) simde_mm256_insert_epi64(a, i, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d simde_mm256_insertf128_pd(simde__m256d a, simde__m128d b, int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3) {
+  simde__m256d_private a_ = simde__m256d_to_private(a);
+  simde__m128d_private b_ = simde__m128d_to_private(b);
+
+  a_.m128d_private[imm8] = b_;
+
+  return simde__m256d_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insertf128_pd
+  #define _mm256_insertf128_pd(a, b, imm8) simde_mm256_insertf128_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256 simde_mm256_insertf128_ps(simde__m256 a, simde__m128 b, int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7) {
+  simde__m256_private a_ = simde__m256_to_private(a);
+  simde__m128_private b_ = simde__m128_to_private(b);
+
+  a_.m128_private[imm8] = b_;
+
+  return simde__m256_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insertf128_ps
+  #define _mm256_insertf128_ps(a, b, imm8) simde_mm256_insertf128_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i simde_mm256_insertf128_si256(simde__m256i a, simde__m128i b, int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  simde__m128i_private b_ = simde__m128i_to_private(b);
+
+  a_.m128i_private[imm8] = b_;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_insertf128_si256
+  #define _mm256_insertf128_si256(a, b, imm8) simde_mm256_insertf128_si256(a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_dp_ps(a, b, imm8) _mm256_dp_ps(a, b, imm8)
+#else
+#  define simde_mm256_dp_ps(a, b, imm8) \
+    simde_mm256_set_m128( \
+      simde_mm_dp_ps(simde_mm256_extractf128_ps(a, 1), simde_mm256_extractf128_ps(b, 1), imm8), \
+      simde_mm_dp_ps(simde_mm256_extractf128_ps(a, 0), simde_mm256_extractf128_ps(b, 0), imm8))
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_dp_ps
+  #define _mm256_dp_ps(a, b, imm8) simde_mm256_dp_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm256_extract_epi32 (simde__m256i a, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 7) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.i32[index];
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_extract_epi32(a, index) _mm256_extract_epi32(a, index)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extract_epi32
+  #define _mm256_extract_epi32(a, index) simde_mm256_extract_epi32(a, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm256_extract_epi64 (simde__m256i a, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 3) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.i64[index];
+}
+#if defined(SIMDE_X86_AVX_NATIVE) && defined(SIMDE_ARCH_AMD64)
+  #if !defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,20,0)
+    #define simde_mm256_extract_epi64(a, index) _mm256_extract_epi64(a, index)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extract_epi64
+  #define _mm256_extract_epi64(a, index) simde_mm256_extract_epi64(a, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_loadu_epi8(void const* mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(SIMDE_ALIGN_CAST(simde__m256i const*, mem_addr));
+  #else
+    simde__m256i_private r_;
+
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_loadu_epi16(void const* mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(SIMDE_ALIGN_CAST(simde__m256i const*, mem_addr));
+  #else
+    simde__m256i_private r_;
+
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_loadu_epi32(void const* mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(SIMDE_ALIGN_CAST(simde__m256i const*, mem_addr));
+  #else
+    simde__m256i_private r_;
+
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_loadu_epi64(void const* mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(SIMDE_ALIGN_CAST(simde__m256i const*, mem_addr));
+  #else
+    simde__m256i_private r_;
+
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_lddqu_si256 (simde__m256i const * a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(a);
+  #else
+    simde__m256i_private r_;
+
+    simde_memcpy(&r_, a, sizeof(r_));
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_lddqu_si256
+  #define _mm256_lddqu_si256(a) simde_mm256_lddqu_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_load_pd (const double a[HEDLEY_ARRAY_PARAM(4)]) {
+  simde_assert_aligned(32, a);
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_load_pd(a);
+  #else
+    simde__m256d r;
+    r = *SIMDE_ALIGN_CAST(simde__m256d const*, SIMDE_ASSUME_ALIGNED(32, a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_load_pd
+  #define _mm256_load_pd(a) simde_mm256_load_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_load_ps (const float a[HEDLEY_ARRAY_PARAM(8)]) {
+  simde_assert_aligned(32, a);
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_load_ps(a);
+  #else
+    simde__m256 r;
+    r = *SIMDE_ALIGN_CAST( simde__m256 const*, SIMDE_ASSUME_ALIGNED(32, a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_load_ps
+  #define _mm256_load_ps(a) simde_mm256_load_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_load_si256 (simde__m256i const * mem_addr) {
+  simde_assert_aligned(32, mem_addr);
+
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_load_si256(HEDLEY_REINTERPRET_CAST(__m256i const*, mem_addr));
+  #else
+    simde__m256i r;
+    r = *mem_addr;
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_load_si256
+  #define _mm256_load_si256(a) simde_mm256_load_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_loadu_pd (const double a[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_pd(a);
+  #else
+    simde__m256d r;
+    simde_memcpy(&r, a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu_pd
+  #define _mm256_loadu_pd(a) simde_mm256_loadu_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_loadu_ps (const float a[HEDLEY_ARRAY_PARAM(8)]) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_ps(a);
+  #else
+    simde__m256 r;
+    simde_memcpy(&r, a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu_ps
+  #define _mm256_loadu_ps(a) simde_mm256_loadu_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_loadu_si256 (void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_loadu_si256(SIMDE_ALIGN_CAST(const __m256i*, mem_addr));
+  #else
+    simde__m256i r;
+
+    #if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias,3,3,0)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+      struct simde_mm256_loadu_si256_s {
+        __typeof__(r) v;
+      } __attribute__((__packed__, __may_alias__));
+      r = HEDLEY_REINTERPRET_CAST(const struct simde_mm256_loadu_si256_s *, mem_addr)->v;
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      simde_memcpy(&r, mem_addr, sizeof(r));
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu_si256
+  #define _mm256_loadu_si256(mem_addr) simde_mm256_loadu_si256(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_loadu2_m128 (const float hiaddr[HEDLEY_ARRAY_PARAM(4)], const float loaddr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    return _mm256_loadu2_m128(hiaddr, loaddr);
+  #else
+    return
+      simde_mm256_insertf128_ps(simde_mm256_castps128_ps256(simde_mm_loadu_ps(loaddr)),
+              simde_mm_loadu_ps(hiaddr), 1);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu2_m128
+  #define _mm256_loadu2_m128(hiaddr, loaddr) simde_mm256_loadu2_m128(hiaddr, loaddr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_loadu2_m128d (const double hiaddr[HEDLEY_ARRAY_PARAM(2)], const double loaddr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    return _mm256_loadu2_m128d(hiaddr, loaddr);
+  #else
+    return
+      simde_mm256_insertf128_pd(simde_mm256_castpd128_pd256(simde_mm_loadu_pd(loaddr)),
+              simde_mm_loadu_pd(hiaddr), 1);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu2_m128d
+  #define _mm256_loadu2_m128d(hiaddr, loaddr) simde_mm256_loadu2_m128d(hiaddr, loaddr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_loadu2_m128i (const simde__m128i* hiaddr, const simde__m128i* loaddr) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    return _mm256_loadu2_m128i(hiaddr, loaddr);
+  #else
+    return
+      simde_mm256_insertf128_si256(simde_mm256_castsi128_si256(simde_mm_loadu_si128(loaddr)),
+          simde_mm_loadu_si128(hiaddr), 1);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_loadu2_m128i
+  #define _mm256_loadu2_m128i(hiaddr, loaddr) simde_mm256_loadu2_m128i(hiaddr, loaddr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_maskload_pd (const simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_maskload_pd(mem_addr, mask);
+  #else
+    simde__m128d_private
+      mem_ = simde__m128d_to_private(simde_mm_loadu_pd(mem_addr)),
+      r_;
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vandq_s64(mem_.neon_i64, vshrq_n_s64(mask_.neon_i64, 63));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.i64[i] = mem_.i64[i] & (mask_.i64[i] >> 63);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskload_pd
+  #define _mm_maskload_pd(mem_addr, mask) simde_mm_maskload_pd(HEDLEY_REINTERPRET_CAST(double const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_maskload_pd (const simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_maskload_pd(mem_addr, mask);
+  #else
+    simde__m256d_private r_;
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+
+    r_ = simde__m256d_to_private(simde_mm256_loadu_pd(mem_addr));
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.i64[i] &= mask_.i64[i] >> 63;
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskload_pd
+  #define _mm256_maskload_pd(mem_addr, mask) simde_mm256_maskload_pd(HEDLEY_REINTERPRET_CAST(double const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_maskload_ps (const simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_maskload_ps(mem_addr, mask);
+  #else
+    simde__m128_private
+      mem_ = simde__m128_to_private(simde_mm_loadu_ps(mem_addr)),
+      r_;
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(mem_.neon_i32, vshrq_n_s32(mask_.neon_i32, 31));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = mem_.i32[i] & (mask_.i32[i] >> 31);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskload_ps
+  #define _mm_maskload_ps(mem_addr, mask) simde_mm_maskload_ps(HEDLEY_REINTERPRET_CAST(float const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskload_ps (const simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_maskload_ps(mem_addr, mask);
+  #else
+    simde__m256_private r_;
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+
+    r_ = simde__m256_to_private(simde_mm256_loadu_ps(mem_addr));
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.i32[i] &= mask_.i32[i] >> 31;
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskload_ps
+  #define _mm256_maskload_ps(mem_addr, mask) simde_mm256_maskload_ps(HEDLEY_REINTERPRET_CAST(float const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskstore_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128i mask, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm_maskstore_pd(mem_addr, mask, a);
+  #else
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+      if (mask_.u64[i] >> 63)
+        mem_addr[i] = a_.f64[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskstore_pd
+  #define _mm_maskstore_pd(mem_addr, mask, a) simde_mm_maskstore_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_maskstore_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm256_maskstore_pd(mem_addr, mask, a);
+  #else
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+      if (mask_.u64[i] & (UINT64_C(1) << 63))
+        mem_addr[i] = a_.f64[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskstore_pd
+  #define _mm256_maskstore_pd(mem_addr, mask, a) simde_mm256_maskstore_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskstore_ps (simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm_maskstore_ps(mem_addr, mask, a);
+  #else
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+      if (mask_.u32[i] & (UINT32_C(1) << 31))
+        mem_addr[i] = a_.f32[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskstore_ps
+  #define _mm_maskstore_ps(mem_addr, mask, a) simde_mm_maskstore_ps(HEDLEY_REINTERPRET_CAST(float*, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_maskstore_ps (simde_float32 mem_addr[HEDLEY_ARRAY_PARAM(8)], simde__m256i mask, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm256_maskstore_ps(mem_addr, mask, a);
+  #else
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+    simde__m256_private a_ = simde__m256_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+      if (mask_.u32[i] & (UINT32_C(1) << 31))
+        mem_addr[i] = a_.f32[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskstore_ps
+  #define _mm256_maskstore_ps(mem_addr, mask, a) simde_mm256_maskstore_ps(HEDLEY_REINTERPRET_CAST(float*, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_min_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_min_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_min_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_min_ps(a_.m128[1], b_.m128[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (a_.f32[i] < b_.f32[i]) ? a_.f32[i] : b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_ps
+  #define _mm256_min_ps(a, b) simde_mm256_min_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_min_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_min_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_min_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_min_pd(a_.m128d[1], b_.m128d[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_pd
+  #define _mm256_min_pd(a, b) simde_mm256_min_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_max_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_max_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_max_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_max_ps(a_.m128[1], b_.m128[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (a_.f32[i] > b_.f32[i]) ? a_.f32[i] : b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_ps
+  #define _mm256_max_ps(a, b) simde_mm256_max_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_max_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_max_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_max_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_max_pd(a_.m128d[1], b_.m128d[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_pd
+  #define _mm256_max_pd(a, b) simde_mm256_max_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_movedup_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_movedup_pd(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.f64, a_.f64, 0, 0, 2, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+        r_.f64[i] = r_.f64[i + 1] = a_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movedup_pd
+  #define _mm256_movedup_pd(a) simde_mm256_movedup_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_movehdup_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_movehdup_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, a_.f32, 1, 1, 3, 3, 5, 5, 7, 7);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+        r_.f32[i - 1] = r_.f32[i] = a_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movehdup_ps
+  #define _mm256_movehdup_ps(a) simde_mm256_movehdup_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_moveldup_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && 0
+    return _mm256_moveldup_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, a_.f32, 0, 0, 2, 2, 4, 4, 6, 6);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+        r_.f32[i] = r_.f32[i + 1] = a_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_moveldup_ps
+  #define _mm256_moveldup_ps(a) simde_mm256_moveldup_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_movemask_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_movemask_ps(a);
+  #else
+    simde__m256_private a_ = simde__m256_to_private(a);
+    int r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+      r |= (a_.u32[i] >> 31) << i;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movemask_ps
+  #define _mm256_movemask_ps(a) simde_mm256_movemask_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_movemask_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_movemask_pd(a);
+  #else
+    simde__m256d_private a_ = simde__m256d_to_private(a);
+    int r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+      r |= (a_.u64[i] >> 63) << i;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movemask_pd
+  #define _mm256_movemask_pd(a) simde_mm256_movemask_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mul_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_mul_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_mul_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_mul_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 * b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] * b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mul_ps
+  #define _mm256_mul_ps(a, b) simde_mm256_mul_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mul_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_mul_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_mul_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_mul_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 * b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] * b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mul_pd
+  #define _mm256_mul_pd(a, b) simde_mm256_mul_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_or_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_or_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_or_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_or_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] | b_.u32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_or_ps
+  #define _mm256_or_ps(a, b) simde_mm256_or_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_or_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_or_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_or_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_or_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] | b_.u64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_or_pd
+  #define _mm256_or_pd(a, b) simde_mm256_or_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_permute_ps (simde__m256 a, const int imm8) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    r_.f32[i] = a_.m128_private[i >> 2].f32[(imm8 >> ((i << 1) & 7)) & 3];
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_permute_ps(a, imm8) _mm256_permute_ps(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute_ps
+  #define _mm256_permute_ps(a, imm8) simde_mm256_permute_ps(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_permute_pd (simde__m256d a, const int imm8) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    r_.f64[i] = a_.f64[((imm8 >> i) & 1) + (i & 2)];
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_permute_pd(a, imm8) _mm256_permute_pd(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute_pd
+  #define _mm256_permute_pd(a, imm8) simde_mm256_permute_pd(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_permute_ps (simde__m128 a, const int imm8) {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    r_.f32[i] = a_.f32[(imm8 >> ((i << 1) & 7)) & 3];
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm_permute_ps(a, imm8) _mm_permute_ps(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permute_ps
+  #define _mm_permute_ps(a, imm8) simde_mm_permute_ps(a, imm8)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_permute_pd (simde__m128d a, const int imm8) {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    r_.f64[i] = a_.f64[((imm8 >> i) & 1) + (i & 2)];
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm_permute_pd(a, imm8) _mm_permute_pd(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permute_pd
+  #define _mm_permute_pd(a, imm8) simde_mm_permute_pd(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_permutevar_ps (simde__m128 a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_permutevar_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+    simde__m128i_private b_ = simde__m128i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[b_.i32[i] & 3];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permutevar_ps
+  #define _mm_permutevar_ps(a, b) simde_mm_permutevar_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_permutevar_pd (simde__m128d a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_permutevar_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+    simde__m128i_private b_ = simde__m128i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[(b_.i64[i] & 2) >> 1];
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_permutevar_pd
+  #define _mm_permutevar_pd(a, b) simde_mm_permutevar_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_permutevar_ps (simde__m256 a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_permutevar_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+    simde__m256i_private b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[(b_.i32[i] & 3) + (i & 4)];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutevar_ps
+  #define _mm256_permutevar_ps(a, b) simde_mm256_permutevar_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_permutevar_pd (simde__m256d a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_permutevar_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+    simde__m256i_private b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[((b_.i64[i] & 2) >> 1) + (i & 2)];
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutevar_pd
+  #define _mm256_permutevar_pd(a, b) simde_mm256_permutevar_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_permute2f128_ps (simde__m256 a, simde__m256 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+  r_.m128_private[0] = (imm8 & 0x08) ? simde__m128_to_private(simde_mm_setzero_ps()) : ((imm8 & 0x02) ? b_.m128_private[(imm8     ) & 1] : a_.m128_private[(imm8     ) & 1]);
+  r_.m128_private[1] = (imm8 & 0x80) ? simde__m128_to_private(simde_mm_setzero_ps()) : ((imm8 & 0x20) ? b_.m128_private[(imm8 >> 4) & 1] : a_.m128_private[(imm8 >> 4) & 1]);
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_permute2f128_ps(a, b, imm8) _mm256_permute2f128_ps(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute2f128_ps
+  #define _mm256_permute2f128_ps(a, b, imm8) simde_mm256_permute2f128_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_permute2f128_pd (simde__m256d a, simde__m256d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+  r_.m128d_private[0] = (imm8 & 0x08) ? simde__m128d_to_private(simde_mm_setzero_pd()) : ((imm8 & 0x02) ? b_.m128d_private[(imm8     ) & 1] : a_.m128d_private[(imm8     ) & 1]);
+  r_.m128d_private[1] = (imm8 & 0x80) ? simde__m128d_to_private(simde_mm_setzero_pd()) : ((imm8 & 0x20) ? b_.m128d_private[(imm8 >> 4) & 1] : a_.m128d_private[(imm8 >> 4) & 1]);
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_permute2f128_pd(a, b, imm8) _mm256_permute2f128_pd(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute2f128_pd
+  #define _mm256_permute2f128_pd(a, b, imm8) simde_mm256_permute2f128_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permute2f128_si256 (simde__m256i a, simde__m256i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  r_.m128i_private[0] = (imm8 & 0x08) ? simde__m128i_to_private(simde_mm_setzero_si128()) : ((imm8 & 0x02) ? b_.m128i_private[(imm8     ) & 1] : a_.m128i_private[(imm8     ) & 1]);
+  r_.m128i_private[1] = (imm8 & 0x80) ? simde__m128i_to_private(simde_mm_setzero_si128()) : ((imm8 & 0x20) ? b_.m128i_private[(imm8 >> 4) & 1] : a_.m128i_private[(imm8 >> 4) & 1]);
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+#  define simde_mm256_permute2f128_si128(a, b, imm8) _mm256_permute2f128_si128(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute2f128_si256
+  #define _mm256_permute2f128_si256(a, b, imm8) simde_mm256_permute2f128_si256(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_rcp_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rcp_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128_private[0])) ; i++) {
+        r_.m128[i] = simde_mm_rcp_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = SIMDE_FLOAT32_C(1.0) / a_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rcp_ps
+  #define _mm256_rcp_ps(a) simde_mm256_rcp_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_rsqrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rsqrt_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if defined(simde_math_sqrtf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = 1.0f / simde_math_sqrtf(a_.f32[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rsqrt_ps
+  #define _mm256_rsqrt_ps(a) simde_mm256_rsqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setr_epi8 (
+    int8_t e31, int8_t e30, int8_t e29, int8_t e28, int8_t e27, int8_t e26, int8_t e25, int8_t e24,
+    int8_t e23, int8_t e22, int8_t e21, int8_t e20, int8_t e19, int8_t e18, int8_t e17, int8_t e16,
+    int8_t e15, int8_t e14, int8_t e13, int8_t e12, int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+    int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4, int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_epi8(
+        e31, e30, e29, e28, e27, e26, e25, e24,
+        e23, e22, e21, e20, e19, e18, e17, e16,
+        e15, e14, e13, e12, e11, e10,  e9,  e8,
+        e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm256_set_epi8(
+        e0,  e1,  e2,  e3,  e4,  e5,  e6,  e7,
+        e8,  e9, e10, e11, e12, e13, e14, e15,
+        e16, e17, e18, e19, e20, e21, e22, e23,
+        e24, e25, e26, e27, e28, e29, e30, e31);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_epi8
+  #define _mm256_setr_epi8(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) \
+    simde_mm256_setr_epi8(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setr_epi16 (
+    int16_t e15, int16_t e14, int16_t e13, int16_t e12, int16_t e11, int16_t e10, int16_t  e9, int16_t  e8,
+    int16_t  e7, int16_t  e6, int16_t  e5, int16_t  e4, int16_t  e3, int16_t  e2, int16_t  e1, int16_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_epi16(
+        e15, e14, e13, e12, e11, e10,  e9,  e8,
+        e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm256_set_epi16(
+        e0,  e1,  e2,  e3,  e4,  e5,  e6,  e7,
+        e8,  e9, e10, e11, e12, e13, e14, e15);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_epi16
+  #define _mm256_setr_epi16(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) \
+    simde_mm256_setr_epi16(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setr_epi32 (
+    int32_t  e7, int32_t  e6, int32_t  e5, int32_t  e4, int32_t  e3, int32_t  e2, int32_t  e1, int32_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_epi32(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    return simde_mm256_set_epi32(e0, e1, e2, e3, e4, e5, e6, e7);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_epi32
+  #define _mm256_setr_epi32(e7, e6, e5, e4, e3, e2, e1, e0) \
+    simde_mm256_setr_epi32(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setr_epi64x (int64_t  e3, int64_t  e2, int64_t  e1, int64_t  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_epi64x(e3, e2, e1, e0);
+  #else
+    return simde_mm256_set_epi64x(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_epi64x
+  #define _mm256_setr_epi64x(e3, e2, e1, e0) \
+    simde_mm256_setr_epi64x(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_setr_ps (
+    simde_float32  e7, simde_float32  e6, simde_float32  e5, simde_float32  e4,
+    simde_float32  e3, simde_float32  e2, simde_float32  e1, simde_float32  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_ps(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    return simde_mm256_set_ps(e0, e1, e2, e3, e4, e5, e6, e7);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_ps
+  #define _mm256_setr_ps(e7, e6, e5, e4, e3, e2, e1, e0) \
+    simde_mm256_setr_ps(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_setr_pd (simde_float64  e3, simde_float64  e2, simde_float64  e1, simde_float64  e0) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_setr_pd(e3, e2, e1, e0);
+  #else
+    return simde_mm256_set_pd(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_pd
+  #define _mm256_setr_pd(e3, e2, e1, e0) \
+    simde_mm256_setr_pd(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_setr_m128 (simde__m128 lo, simde__m128 hi) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && \
+      !defined(SIMDE_BUG_GCC_REV_247851) && \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,6,0)
+    return _mm256_setr_m128(lo, hi);
+  #else
+    return simde_mm256_set_m128(hi, lo);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_m128
+  #define _mm256_setr_m128(lo, hi) \
+    simde_mm256_setr_m128(lo, hi)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_setr_m128d (simde__m128d lo, simde__m128d hi) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && \
+      !defined(SIMDE_BUG_GCC_REV_247851) && \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,6,0)
+    return _mm256_setr_m128d(lo, hi);
+  #else
+    return simde_mm256_set_m128d(hi, lo);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_m128d
+  #define _mm256_setr_m128d(lo, hi) \
+    simde_mm256_setr_m128d(lo, hi)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_setr_m128i (simde__m128i lo, simde__m128i hi) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && \
+      !defined(SIMDE_BUG_GCC_REV_247851) && \
+      SIMDE_DETECT_CLANG_VERSION_CHECK(3,6,0)
+    return _mm256_setr_m128i(lo, hi);
+  #else
+    return simde_mm256_set_m128i(hi, lo);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_setr_m128i
+  #define _mm256_setr_m128i(lo, hi) \
+    simde_mm256_setr_m128i(lo, hi)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_shuffle_ps (simde__m256 a, simde__m256 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256_private
+    r_,
+    a_ = simde__m256_to_private(a),
+    b_ = simde__m256_to_private(b);
+
+  r_.f32[0] = a_.m128_private[0].f32[(imm8 >> 0) & 3];
+  r_.f32[1] = a_.m128_private[0].f32[(imm8 >> 2) & 3];
+  r_.f32[2] = b_.m128_private[0].f32[(imm8 >> 4) & 3];
+  r_.f32[3] = b_.m128_private[0].f32[(imm8 >> 6) & 3];
+  r_.f32[4] = a_.m128_private[1].f32[(imm8 >> 0) & 3];
+  r_.f32[5] = a_.m128_private[1].f32[(imm8 >> 2) & 3];
+  r_.f32[6] = b_.m128_private[1].f32[(imm8 >> 4) & 3];
+  r_.f32[7] = b_.m128_private[1].f32[(imm8 >> 6) & 3];
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_shuffle_ps(a, b, imm8) _mm256_shuffle_ps(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+  #define simde_mm256_shuffle_ps(a, b, imm8) \
+      simde_mm256_set_m128( \
+          simde_mm_shuffle_ps(simde_mm256_extractf128_ps(a, 1), simde_mm256_extractf128_ps(b, 1), (imm8)), \
+          simde_mm_shuffle_ps(simde_mm256_extractf128_ps(a, 0), simde_mm256_extractf128_ps(b, 0), (imm8)))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm256_shuffle_ps(a, b, imm8) \
+    SIMDE_SHUFFLE_VECTOR_(32, 32, a, b, \
+      (((imm8) >> 0) & 3) + 0, \
+      (((imm8) >> 2) & 3) + 0, \
+      (((imm8) >> 4) & 3) + 8, \
+      (((imm8) >> 6) & 3) + 8, \
+      (((imm8) >> 0) & 3) + 4, \
+      (((imm8) >> 2) & 3) + 4, \
+      (((imm8) >> 4) & 3) + 12, \
+      (((imm8) >> 6) & 3) + 12)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shuffle_ps
+  #define _mm256_shuffle_ps(a, b, imm8) simde_mm256_shuffle_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_shuffle_pd (simde__m256d a, simde__m256d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 15) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a),
+    b_ = simde__m256d_to_private(b);
+
+  r_.f64[0] = a_.f64[((imm8     ) & 1)    ];
+  r_.f64[1] = b_.f64[((imm8 >> 1) & 1)    ];
+  r_.f64[2] = a_.f64[((imm8 >> 2) & 1) | 2];
+  r_.f64[3] = b_.f64[((imm8 >> 3) & 1) | 2];
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_NATIVE)
+  #define simde_mm256_shuffle_pd(a, b, imm8) _mm256_shuffle_pd(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+  #define simde_mm256_shuffle_pd(a, b, imm8) \
+      simde_mm256_set_m128d( \
+          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 1), simde_mm256_extractf128_pd(b, 1), (imm8 >> 0) & 3), \
+          simde_mm_shuffle_pd(simde_mm256_extractf128_pd(a, 0), simde_mm256_extractf128_pd(b, 0), (imm8 >> 2) & 3))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm256_shuffle_pd(a, b, imm8) \
+    SIMDE_SHUFFLE_VECTOR_(64, 32, a, b, \
+      (((imm8) >> 0) & 1) + 0, \
+      (((imm8) >> 1) & 1) + 4, \
+      (((imm8) >> 2) & 1) + 2, \
+      (((imm8) >> 3) & 1) + 6)
+#endif
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shuffle_pd
+  #define _mm256_shuffle_pd(a, b, imm8) simde_mm256_shuffle_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sqrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sqrt_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_sqrt_ps(a_.m128[0]);
+      r_.m128[1] = simde_mm_sqrt_ps(a_.m128[1]);
+    #elif defined(simde_math_sqrtf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sqrtf(a_.f32[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sqrt_ps
+  #define _mm256_sqrt_ps(a) simde_mm256_sqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sqrt_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sqrt_pd(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_sqrt_pd(a_.m128d[0]);
+      r_.m128d[1] = simde_mm_sqrt_pd(a_.m128d[1]);
+    #elif defined(simde_math_sqrt)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sqrt(a_.f64[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sqrt_pd
+  #define _mm256_sqrt_pd(a) simde_mm256_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_store_ps (simde_float32 mem_addr[8], simde__m256 a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_store_ps(mem_addr, a);
+#else
+  *SIMDE_ALIGN_CAST(simde__m256*, SIMDE_ASSUME_ALIGNED(32, mem_addr)) = a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_store_ps
+  #define _mm256_store_ps(mem_addr, a) simde_mm256_store_ps(HEDLEY_REINTERPRET_CAST(float*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_store_pd (simde_float64 mem_addr[4], simde__m256d a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_store_pd(mem_addr, a);
+#else
+  *SIMDE_ALIGN_CAST(simde__m256d*, SIMDE_ASSUME_ALIGNED(32, mem_addr)) =  a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_store_pd
+  #define _mm256_store_pd(mem_addr, a) simde_mm256_store_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_store_si256 (simde__m256i* mem_addr, simde__m256i a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_store_si256(mem_addr, a);
+#else
+  *mem_addr = a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_store_si256
+  #define _mm256_store_si256(mem_addr, a) simde_mm256_store_si256(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu_ps (simde_float32 mem_addr[8], simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm256_storeu_ps(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu_ps
+  #define _mm256_storeu_ps(mem_addr, a) simde_mm256_storeu_ps(HEDLEY_REINTERPRET_CAST(float*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu_pd (simde_float64 mem_addr[4], simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm256_storeu_pd(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu_pd
+  #define _mm256_storeu_pd(mem_addr, a) simde_mm256_storeu_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu_si256 (simde__m256i* mem_addr, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    _mm256_storeu_si256(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu_si256
+  #define _mm256_storeu_si256(mem_addr, a) simde_mm256_storeu_si256(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu2_m128 (simde_float32 hi_addr[4], simde_float32 lo_addr[4], simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    _mm256_storeu2_m128(hi_addr, lo_addr, a);
+  #else
+    simde_mm_storeu_ps(lo_addr, simde_mm256_castps256_ps128(a));
+    simde_mm_storeu_ps(hi_addr, simde_mm256_extractf128_ps(a, 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu2_m128
+  #define _mm256_storeu2_m128(hi_addr, lo_addr, a) simde_mm256_storeu2_m128(hi_addr, lo_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu2_m128d (simde_float64 hi_addr[2], simde_float64 lo_addr[2], simde__m256d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    _mm256_storeu2_m128d(hi_addr, lo_addr, a);
+  #else
+    simde_mm_storeu_pd(lo_addr, simde_mm256_castpd256_pd128(a));
+    simde_mm_storeu_pd(hi_addr, simde_mm256_extractf128_pd(a, 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu2_m128d
+  #define _mm256_storeu2_m128d(hi_addr, lo_addr, a) simde_mm256_storeu2_m128d(hi_addr, lo_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_storeu2_m128i (simde__m128i* hi_addr, simde__m128i* lo_addr, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE) && !defined(SIMDE_BUG_GCC_91341)
+    _mm256_storeu2_m128i(hi_addr, lo_addr, a);
+  #else
+    simde_mm_storeu_si128(lo_addr, simde_mm256_castsi256_si128(a));
+    simde_mm_storeu_si128(hi_addr, simde_mm256_extractf128_si256(a, 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_storeu2_m128i
+  #define _mm256_storeu2_m128i(hi_addr, lo_addr, a) simde_mm256_storeu2_m128i(hi_addr, lo_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_stream_ps (simde_float32 mem_addr[8], simde__m256 a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_stream_ps(mem_addr, a);
+#else
+  *SIMDE_ALIGN_CAST(simde__m256*, SIMDE_ASSUME_ALIGNED(32, mem_addr)) = a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_stream_ps
+  #define _mm256_stream_ps(mem_addr, a) simde_mm256_stream_ps(HEDLEY_REINTERPRET_CAST(float*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_stream_pd (simde_float64 mem_addr[4], simde__m256d a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_stream_pd(mem_addr, a);
+#else
+  *SIMDE_ALIGN_CAST(simde__m256d*, SIMDE_ASSUME_ALIGNED(32, mem_addr)) =  a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_stream_pd
+  #define _mm256_stream_pd(mem_addr, a) simde_mm256_stream_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_stream_si256 (simde__m256i* mem_addr, simde__m256i a) {
+  simde_assert_aligned(32, mem_addr);
+
+#if defined(SIMDE_X86_AVX_NATIVE)
+  _mm256_stream_si256(mem_addr, a);
+#else
+  *mem_addr = a;
+#endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_stream_si256
+  #define _mm256_stream_si256(mem_addr, a) simde_mm256_stream_si256(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sub_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sub_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_sub_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_sub_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 - b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] - b_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_ps
+  #define _mm256_sub_ps(a, b) simde_mm256_sub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_hsub_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hsub_ps(a, b);
+  #else
+      return simde_mm256_sub_ps(simde_x_mm256_deinterleaveeven_ps(a, b), simde_x_mm256_deinterleaveodd_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hsub_ps
+  #define _mm256_hsub_ps(a, b) simde_mm256_hsub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sub_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sub_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_sub_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_sub_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 - b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] - b_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_pd
+  #define _mm256_sub_pd(a, b) simde_mm256_sub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_hsub_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hsub_pd(a, b);
+  #else
+      return simde_mm256_sub_pd(simde_x_mm256_deinterleaveeven_pd(a, b), simde_x_mm256_deinterleaveodd_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hsub_pd
+  #define _mm256_hsub_pd(a, b) simde_mm256_hsub_pd(a, b)
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_undefined_ps (void) {
+  simde__m256_private r_;
+
+#if \
+    defined(SIMDE_X86_AVX_NATIVE) && \
+    (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(5,0,0)) && \
+    (!defined(__has_builtin) || HEDLEY_HAS_BUILTIN(__builtin_ia32_undef256))
+  r_.n = _mm256_undefined_ps();
+#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  r_ = simde__m256_to_private(simde_mm256_setzero_ps());
+#endif
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_undefined_ps
+  #define _mm256_undefined_ps() simde_mm256_undefined_ps()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_undefined_pd (void) {
+  simde__m256d_private r_;
+
+#if \
+    defined(SIMDE_X86_AVX_NATIVE) && \
+    (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(5,0,0)) && \
+    (!defined(__has_builtin) || HEDLEY_HAS_BUILTIN(__builtin_ia32_undef256))
+  r_.n = _mm256_undefined_pd();
+#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  r_ = simde__m256d_to_private(simde_mm256_setzero_pd());
+#endif
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_undefined_pd
+  #define _mm256_undefined_pd() simde_mm256_undefined_pd()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_undefined_si256 (void) {
+  simde__m256i_private r_;
+#if \
+    defined(SIMDE_X86_AVX_NATIVE) && \
+    (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(5,0,0)) && \
+    (!defined(__has_builtin) || HEDLEY_HAS_BUILTIN(__builtin_ia32_undef256))
+  r_.n = _mm256_undefined_si256();
+#elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  r_ = simde__m256i_to_private(simde_mm256_setzero_si256());
+#endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_undefined_si256
+  #define _mm256_undefined_si256() simde_mm256_undefined_si256()
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_POP
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_xor_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_xor_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128[0] = simde_mm_xor_ps(a_.m128[0], b_.m128[0]);
+      r_.m128[1] = simde_mm_xor_ps(a_.m128[1], b_.m128[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] ^ b_.u32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_xor_ps
+  #define _mm256_xor_ps(a, b) simde_mm256_xor_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_xor_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_xor_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128d[0] = simde_mm_xor_pd(a_.m128d[0], b_.m128d[0]);
+      r_.m128d[1] = simde_mm_xor_pd(a_.m128d[1], b_.m128d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] ^ b_.u64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_xor_pd
+  #define _mm256_xor_pd(a, b) simde_mm256_xor_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_xorsign_ps(simde__m256 dest, simde__m256 src) {
+  return simde_mm256_xor_ps(simde_mm256_and_ps(simde_mm256_set1_ps(-0.0f), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_xorsign_pd(simde__m256d dest, simde__m256d src) {
+  return simde_mm256_xor_pd(simde_mm256_and_pd(simde_mm256_set1_pd(-0.0), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_negate_ps(simde__m256 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return simde_mm256_xor_ps(a,_mm256_set1_ps(SIMDE_FLOAT32_C(-0.0)));
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if defined(SIMDE_VECTOR_NEGATE)
+      r_.f32 = -a_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = -a_.f32[i];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_negate_pd(simde__m256d a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return simde_mm256_xor_pd(a, _mm256_set1_pd(SIMDE_FLOAT64_C(-0.0)));
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if defined(SIMDE_VECTOR_NEGATE)
+      r_.f64 = -a_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = -a_.f64[i];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_unpackhi_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_unpackhi_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, b_.f32, 2, 10, 3, 11, 6, 14, 7, 15);
+    #else
+      r_.f32[0] = a_.f32[2];
+      r_.f32[1] = b_.f32[2];
+      r_.f32[2] = a_.f32[3];
+      r_.f32[3] = b_.f32[3];
+      r_.f32[4] = a_.f32[6];
+      r_.f32[5] = b_.f32[6];
+      r_.f32[6] = a_.f32[7];
+      r_.f32[7] = b_.f32[7];
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_ps
+  #define _mm256_unpackhi_ps(a, b) simde_mm256_unpackhi_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_unpackhi_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_unpackhi_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.f64, b_.f64, 1, 5, 3, 7);
+    #else
+      r_.f64[0] = a_.f64[1];
+      r_.f64[1] = b_.f64[1];
+      r_.f64[2] = a_.f64[3];
+      r_.f64[3] = b_.f64[3];
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_pd
+  #define _mm256_unpackhi_pd(a, b) simde_mm256_unpackhi_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_unpacklo_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_unpacklo_ps(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.f32, b_.f32, 0, 8, 1, 9, 4, 12, 5, 13);
+    #else
+      r_.f32[0] = a_.f32[0];
+      r_.f32[1] = b_.f32[0];
+      r_.f32[2] = a_.f32[1];
+      r_.f32[3] = b_.f32[1];
+      r_.f32[4] = a_.f32[4];
+      r_.f32[5] = b_.f32[4];
+      r_.f32[6] = a_.f32[5];
+      r_.f32[7] = b_.f32[5];
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_ps
+  #define _mm256_unpacklo_ps(a, b) simde_mm256_unpacklo_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_unpacklo_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_unpacklo_pd(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.f64, b_.f64, 0, 4, 2, 6);
+    #else
+      r_.f64[0] = a_.f64[0];
+      r_.f64[1] = b_.f64[0];
+      r_.f64[2] = a_.f64[2];
+      r_.f64[3] = b_.f64[2];
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_pd
+  #define _mm256_unpacklo_pd(a, b) simde_mm256_unpacklo_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_zextps128_ps256 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_ps(_mm256_setzero_ps(), a, 0);
+  #else
+    simde__m256_private r_;
+
+    r_.m128_private[0] = simde__m128_to_private(a);
+    r_.m128_private[1] = simde__m128_to_private(simde_mm_setzero_ps());
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_zextps128_ps256
+  #define _mm256_zextps128_ps256(a) simde_mm256_zextps128_ps256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_zextpd128_pd256 (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_pd(_mm256_setzero_pd(), a, 0);
+  #else
+    simde__m256d_private r_;
+
+    r_.m128d_private[0] = simde__m128d_to_private(a);
+    r_.m128d_private[1] = simde__m128d_to_private(simde_mm_setzero_pd());
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_zextpd128_pd256
+  #define _mm256_zextpd128_pd256(a) simde_mm256_zextpd128_pd256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_zextsi128_si256 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_insertf128_si256(_mm256_setzero_si256(), a, 0);
+  #else
+    simde__m256i_private r_;
+
+    r_.m128i_private[0] = simde__m128i_to_private(a);
+    r_.m128i_private[1] = simde__m128i_to_private(simde_mm_setzero_si128());
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_zextsi128_si256
+  #define _mm256_zextsi128_si256(a) simde_mm256_zextsi128_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testc_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testc_ps(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u32x4_shr(wasm_v128_or(wasm_v128_not(b_.wasm_v128), a_.wasm_v128), 31);
+      m = wasm_v128_and(m, simde_mm_movehl_ps(m, m));
+      m = wasm_v128_and(m, simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
+      return wasm_i32x4_extract_lane(m, 0);
+    #else
+      uint_fast32_t r = 0;
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+        r |= ~a_.u32[i] & b_.u32[i];
+      }
+
+      return HEDLEY_STATIC_CAST(int, ((~r >> 31) & 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testc_ps
+  #define _mm_testc_ps(a, b) simde_mm_testc_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testc_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testc_pd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u64x2_shr(wasm_v128_or(wasm_v128_not(b_.wasm_v128), a_.wasm_v128), 63);
+      return HEDLEY_STATIC_CAST(int, wasm_i64x2_extract_lane(m, 0) & wasm_i64x2_extract_lane(m, 1));
+    #else
+      uint_fast64_t r = 0;
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        r |= ~a_.u64[i] & b_.u64[i];
+      }
+
+      return HEDLEY_STATIC_CAST(int, ((~r >> 63) & 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testc_pd
+  #define _mm_testc_pd(a, b) simde_mm_testc_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testc_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testc_ps(a, b);
+  #else
+    uint_fast32_t r = 0;
+    simde__m256_private
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+      r |= ~a_.u32[i] & b_.u32[i];
+    }
+
+    return HEDLEY_STATIC_CAST(int, ((~r >> 31) & 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testc_ps
+  #define _mm256_testc_ps(a, b) simde_mm256_testc_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testc_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testc_pd(a, b);
+  #else
+    uint_fast64_t r = 0;
+    simde__m256d_private
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+      r |= ~a_.u64[i] & b_.u64[i];
+    }
+
+    return HEDLEY_STATIC_CAST(int, ((~r >> 63) & 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testc_pd
+  #define _mm256_testc_pd(a, b) simde_mm256_testc_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testc_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testc_si256(a, b);
+  #else
+    int_fast32_t r = 0;
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+      r |= ~a_.i32f[i] & b_.i32f[i];
+    }
+
+    return HEDLEY_STATIC_CAST(int, !r);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testc_si256
+  #define _mm256_testc_si256(a, b) simde_mm256_testc_si256(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testz_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testz_ps(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u32x4_shr(wasm_v128_not(wasm_v128_and(a_.wasm_v128, b_.wasm_v128)), 31);
+      m = wasm_v128_and(m, simde_mm_movehl_ps(m, m));
+      m = wasm_v128_and(m, simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
+      return wasm_i32x4_extract_lane(m, 0);
+    #else
+      uint_fast32_t r = 0;
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+        r |= a_.u32[i] & b_.u32[i];
+      }
+
+      return HEDLEY_STATIC_CAST(int, ((~r >> 31) & 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testz_ps
+  #define _mm_testz_ps(a, b) simde_mm_testz_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testz_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testz_pd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u64x2_shr(wasm_v128_not(wasm_v128_and(a_.wasm_v128, b_.wasm_v128)), 63);
+      return HEDLEY_STATIC_CAST(int, wasm_i64x2_extract_lane(m, 0) & wasm_i64x2_extract_lane(m, 1));
+    #else
+      uint_fast64_t r = 0;
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        r |= a_.u64[i] & b_.u64[i];
+      }
+
+      return HEDLEY_STATIC_CAST(int, ((~r >> 63) & 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testz_pd
+  #define _mm_testz_pd(a, b) simde_mm_testz_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testz_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testz_ps(a, b);
+  #else
+    uint_fast32_t r = 0;
+    simde__m256_private
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+      r |= a_.u32[i] & b_.u32[i];
+    }
+
+    return HEDLEY_STATIC_CAST(int, ((~r >> 31) & 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testz_ps
+  #define _mm256_testz_ps(a, b) simde_mm256_testz_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testz_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testz_pd(a, b);
+  #else
+    uint_fast64_t r = 0;
+    simde__m256d_private
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+      r |= a_.u64[i] & b_.u64[i];
+    }
+
+    return HEDLEY_STATIC_CAST(int, ((~r >> 63) & 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testz_pd
+  #define _mm256_testz_pd(a, b) simde_mm256_testz_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testz_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testz_si256(a, b);
+  #else
+    int_fast32_t r = 0;
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r = simde_mm_testz_si128(a_.m128i[0], b_.m128i[0]) && simde_mm_testz_si128(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+        r |= a_.i32f[i] & b_.i32f[i];
+      }
+
+      r = !r;
+    #endif
+
+    return HEDLEY_STATIC_CAST(int, r);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testz_si256
+  #define _mm256_testz_si256(a, b) simde_mm256_testz_si256(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testnzc_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testnzc_ps(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u32x4_shr(wasm_v128_and(a_.wasm_v128, b_.wasm_v128), 31);
+      v128_t m2 = wasm_u32x4_shr(wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128), 31);
+      m  = wasm_v128_or(m,  simde_mm_movehl_ps(m, m));
+      m2 = wasm_v128_or(m2, simde_mm_movehl_ps(m2, m2));
+      m  = wasm_v128_or(m,  simde_mm_shuffle_epi32(m, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
+      m2 = wasm_v128_or(m2, simde_mm_shuffle_epi32(m2, SIMDE_MM_SHUFFLE(3, 2, 0, 1)));
+      return wasm_i32x4_extract_lane(m, 0) & wasm_i32x4_extract_lane(m2, 0);
+    #else
+      uint32_t rz = 0, rc = 0;
+      for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+        rc |= ~a_.u32[i] & b_.u32[i];
+        rz |=  a_.u32[i] & b_.u32[i];
+      }
+
+      return
+        (rc >> ((sizeof(rc) * CHAR_BIT) - 1)) &
+        (rz >> ((sizeof(rz) * CHAR_BIT) - 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testnzc_ps
+  #define _mm_testnzc_ps(a, b) simde_mm_testnzc_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testnzc_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm_testnzc_pd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_u64x2_shr(wasm_v128_and(a_.wasm_v128, b_.wasm_v128), 63);
+      v128_t m2 = wasm_u64x2_shr(wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128), 63);
+      return HEDLEY_STATIC_CAST(int, (wasm_i64x2_extract_lane(m, 0)  | wasm_i64x2_extract_lane(m, 1))
+        & (wasm_i64x2_extract_lane(m2, 0) | wasm_i64x2_extract_lane(m2, 1)));
+    #else
+      uint64_t rc = 0, rz = 0;
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        rc |= ~a_.u64[i] & b_.u64[i];
+        rz |=  a_.u64[i] & b_.u64[i];
+      }
+
+      return
+        (rc >> ((sizeof(rc) * CHAR_BIT) - 1)) &
+        (rz >> ((sizeof(rz) * CHAR_BIT) - 1));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testnzc_pd
+  #define _mm_testnzc_pd(a, b) simde_mm_testnzc_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testnzc_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testnzc_ps(a, b);
+  #else
+    uint32_t rc = 0, rz = 0;
+    simde__m256_private
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(a_.u32) / sizeof(a_.u32[0])) ; i++) {
+      rc |= ~a_.u32[i] & b_.u32[i];
+      rz |=  a_.u32[i] & b_.u32[i];
+    }
+
+    return
+      (rc >> ((sizeof(rc) * CHAR_BIT) - 1)) &
+      (rz >> ((sizeof(rz) * CHAR_BIT) - 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testnzc_ps
+  #define _mm256_testnzc_ps(a, b) simde_mm256_testnzc_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testnzc_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testnzc_pd(a, b);
+  #else
+    uint64_t rc = 0, rz = 0;
+    simde__m256d_private
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+      rc |= ~a_.u64[i] & b_.u64[i];
+      rz |=  a_.u64[i] & b_.u64[i];
+    }
+
+    return
+      (rc >> ((sizeof(rc) * CHAR_BIT) - 1)) &
+      (rz >> ((sizeof(rz) * CHAR_BIT) - 1));
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testnzc_pd
+  #define _mm256_testnzc_pd(a, b) simde_mm256_testnzc_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_testnzc_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_testnzc_si256(a, b);
+  #else
+    int32_t rc = 0, rz = 0;
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+      rc |= ~a_.i32f[i] & b_.i32f[i];
+      rz |=  a_.i32f[i] & b_.i32f[i];
+    }
+
+    return !!(rc & rz);
+  #endif
+}
+#if defined(SIMDE_X86_AVX_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_testnzc_si256
+  #define _mm256_testnzc_si256(a, b) simde_mm256_testnzc_si256(a, b)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX_H) */

--- a/2.0/simde/x86/avx2.h
+++ b/2.0/simde/x86/avx2.h
@@ -1,0 +1,5613 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2018-2020 Evan Nemerson <evan@nemerson.com>
+ *   2019      Michael R. Crusoe <michael.crusoe@gmail.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX2_H)
+#define SIMDE_X86_AVX2_H
+
+#include "avx.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_abs_epi8 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_abs_epi8(a);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = (a_.i8[i] < INT32_C(0)) ? -a_.i8[i] : a_.i8[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_abs_epi8
+  #define _mm256_abs_epi8(a) simde_mm256_abs_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_abs_epi16 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_abs_epi16(a);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = (a_.i16[i] < INT32_C(0)) ? -a_.i16[i] : a_.i16[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_abs_epi16
+  #define _mm256_abs_epi16(a) simde_mm256_abs_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_abs_epi32(simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_abs_epi32(a);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+      r_.i32[i] = (a_.i32[i] < INT32_C(0)) ? -a_.i32[i] : a_.i32[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_abs_epi32
+  #define _mm256_abs_epi32(a) simde_mm256_abs_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_add_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_add_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_add_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_add_epi8(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 + b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] + b_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_epi8
+  #define _mm256_add_epi8(a, b) simde_mm256_add_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_add_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_add_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_add_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_add_epi16(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 + b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] + b_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_epi16
+  #define _mm256_add_epi16(a, b) simde_mm256_add_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hadd_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hadd_epi16(a, b);
+  #else
+    return simde_mm256_add_epi16(simde_x_mm256_deinterleaveeven_epi16(a, b), simde_x_mm256_deinterleaveodd_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hadd_epi16
+  #define _mm256_hadd_epi16(a, b) simde_mm256_hadd_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_add_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_add_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_add_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_add_epi32(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 + b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] + b_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_epi32
+  #define _mm256_add_epi32(a, b) simde_mm256_add_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hadd_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hadd_epi32(a, b);
+  #else
+    return simde_mm256_add_epi32(simde_x_mm256_deinterleaveeven_epi32(a, b), simde_x_mm256_deinterleaveodd_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hadd_epi32
+  #define _mm256_hadd_epi32(a, b) simde_mm256_hadd_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_add_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_add_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_add_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_add_epi64(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 + b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] + b_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_add_epi64
+  #define _mm256_add_epi64(a, b) simde_mm256_add_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_alignr_epi8 (simde__m256i a, simde__m256i b, int count) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  if (HEDLEY_UNLIKELY(count > 31))
+    return simde_mm256_setzero_si256();
+
+  for (size_t h = 0 ; h < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; h++) {
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.m128i_private[h].i8) / sizeof(r_.m128i_private[h].i8[0])) ; i++) {
+      const int srcpos = count + HEDLEY_STATIC_CAST(int, i);
+      if (srcpos > 31) {
+        r_.m128i_private[h].i8[i] = 0;
+      } else if (srcpos > 15) {
+        r_.m128i_private[h].i8[i] = a_.m128i_private[h].i8[(srcpos) & 15];
+      } else {
+        r_.m128i_private[h].i8[i] = b_.m128i_private[h].i8[srcpos];
+      }
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_alignr_epi8(a, b, count) _mm256_alignr_epi8(a, b, count)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_alignr_epi8(a, b, count) \
+      simde_mm256_set_m128i( \
+          simde_mm_alignr_epi8(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (count)), \
+          simde_mm_alignr_epi8(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (count)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_alignr_epi8
+  #define _mm256_alignr_epi8(a, b, count) simde_mm256_alignr_epi8(a, b, (count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_and_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_and_si256(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_and_si128(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_and_si128(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] & b_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_and_si256
+  #define _mm256_and_si256(a, b) simde_mm256_and_si256(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_andnot_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_andnot_si256(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i_private[0] = simde__m128i_to_private(simde_mm_andnot_si128(simde__m128i_from_private(a_.m128i_private[0]), simde__m128i_from_private(b_.m128i_private[0])));
+      r_.m128i_private[1] = simde__m128i_to_private(simde_mm_andnot_si128(simde__m128i_from_private(a_.m128i_private[1]), simde__m128i_from_private(b_.m128i_private[1])));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_andnot_si256
+  #define _mm256_andnot_si256(a, b) simde_mm256_andnot_si256(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_adds_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_adds_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+        r_.m128i[i] = simde_mm_adds_epi8(a_.m128i[i], b_.m128i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        const int32_t tmp =
+          HEDLEY_STATIC_CAST(int16_t, a_.i8[i]) +
+          HEDLEY_STATIC_CAST(int16_t, b_.i8[i]);
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, ((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN) : INT8_MAX));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_adds_epi8
+  #define _mm256_adds_epi8(a, b) simde_mm256_adds_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_adds_epi16(simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_adds_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+        r_.m128i[i] = simde_mm_adds_epi16(a_.m128i[i], b_.m128i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int32_t tmp =
+          HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) +
+          HEDLEY_STATIC_CAST(int32_t, b_.i16[i]);
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((tmp < INT16_MAX) ? ((tmp > INT16_MIN) ? tmp : INT16_MIN) : INT16_MAX));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_adds_epi16
+  #define _mm256_adds_epi16(a, b) simde_mm256_adds_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hadds_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hadds_epi16(a, b);
+  #else
+    return simde_mm256_adds_epi16(simde_x_mm256_deinterleaveeven_epi16(a, b), simde_x_mm256_deinterleaveodd_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hadds_epi16
+  #define _mm256_hadds_epi16(a, b) simde_mm256_hadds_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_adds_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_adds_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_adds_epu8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_adds_epu8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = ((UINT8_MAX - a_.u8[i]) > b_.u8[i]) ? (a_.u8[i] + b_.u8[i]) : UINT8_MAX;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_adds_epu8
+  #define _mm256_adds_epu8(a, b) simde_mm256_adds_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_adds_epu16(simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_adds_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_adds_epu16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_adds_epu16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = ((UINT16_MAX - a_.u16[i]) > b_.u16[i]) ? (a_.u16[i] + b_.u16[i]) : UINT16_MAX;
+    }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_adds_epu16
+  #define _mm256_adds_epu16(a, b) simde_mm256_adds_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_avg_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_avg_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_avg_epu8
+  #define _mm256_avg_epu8(a, b) simde_mm256_avg_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_avg_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_avg_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_avg_epu16
+  #define _mm256_avg_epu16(a, b) simde_mm256_avg_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_blend_epi32(simde__m128i a, simde__m128i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = ((imm8 >> i) & 1) ? b_.i32[i] : a_.i32[i];
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm_blend_epi32(a, b, imm8) _mm_blend_epi32(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm_blend_epi32(a, b, imm8) \
+  simde_mm_castps_si128(simde_mm_blend_ps(simde_mm_castsi128_ps(a), simde_mm_castsi128_ps(b), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blend_epi32
+  #define _mm_blend_epi32(a, b, imm8) simde_mm_blend_epi32(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_blend_epi16(simde__m256i a, simde__m256i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = ((imm8 >> i%8) & 1) ? b_.i16[i] : a_.i16[i];
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_blend_epi16(a, b, imm8) _mm256_blend_epi16(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_blend_epi16(a, b, imm8) \
+      simde_mm256_set_m128i( \
+          simde_mm_blend_epi16(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8)), \
+          simde_mm_blend_epi16(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blend_epi16
+  #define _mm256_blend_epi16(a, b, imm8) simde_mm256_blend_epi16(a, b, imm8)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_blend_epi32(simde__m256i a, simde__m256i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = ((imm8 >> i) & 1) ? b_.i32[i] : a_.i32[i];
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_blend_epi32(a, b, imm8) _mm256_blend_epi32(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_blend_epi32(a, b, imm8) \
+      simde_mm256_set_m128i( \
+          simde_mm_blend_epi32(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8) >> 4), \
+          simde_mm_blend_epi32(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (imm8) & 0x0F))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blend_epi32
+  #define _mm256_blend_epi32(a, b, imm8) simde_mm256_blend_epi32(a, b, imm8)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_blendv_epi8(simde__m256i a, simde__m256i b, simde__m256i mask) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_blendv_epi8(a, b, mask);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b),
+      mask_ = simde__m256i_to_private(mask);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i_private[0] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[0]), simde__m128i_from_private(b_.m128i_private[0]), simde__m128i_from_private(mask_.m128i_private[0])));
+      r_.m128i_private[1] = simde__m128i_to_private(simde_mm_blendv_epi8(simde__m128i_from_private(a_.m128i_private[1]), simde__m128i_from_private(b_.m128i_private[1]), simde__m128i_from_private(mask_.m128i_private[1])));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        if (mask_.u8[i] & 0x80) {
+          r_.u8[i] = b_.u8[i];
+        } else {
+          r_.u8[i] = a_.u8[i];
+        }
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_blendv_epi8(a, b, imm8)  _mm256_blendv_epi8(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_blendv_epi8
+  #define _mm256_blendv_epi8(a, b, mask) simde_mm256_blendv_epi8(a, b, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_broadcastb_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_broadcastb_epi8(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = a_.i8[0];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastb_epi8
+  #define _mm_broadcastb_epi8(a) simde_mm_broadcastb_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_broadcastb_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastb_epi8(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = a_.i8[0];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastb_epi8
+  #define _mm256_broadcastb_epi8(a) simde_mm256_broadcastb_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_broadcastw_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_broadcastw_epi16(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[0];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastw_epi16
+  #define _mm_broadcastw_epi16(a) simde_mm_broadcastw_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_broadcastw_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastw_epi16(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[0];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastw_epi16
+  #define _mm256_broadcastw_epi16(a) simde_mm256_broadcastw_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_broadcastd_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_broadcastd_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[0];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastd_epi32
+  #define _mm_broadcastd_epi32(a) simde_mm_broadcastd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_broadcastd_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastd_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[0];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastd_epi32
+  #define _mm256_broadcastd_epi32(a) simde_mm256_broadcastd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_broadcastq_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_broadcastq_epi64(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[0];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastq_epi64
+  #define _mm_broadcastq_epi64(a) simde_mm_broadcastq_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_broadcastq_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastq_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[0];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastq_epi64
+  #define _mm256_broadcastq_epi64(a) simde_mm256_broadcastq_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_broadcastss_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_broadcastss_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m128_private a_= simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[0];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastss_ps
+  #define _mm_broadcastss_ps(a) simde_mm_broadcastss_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_broadcastss_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastss_ps(a);
+  #else
+    simde__m256_private r_;
+    simde__m128_private a_= simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[0];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastss_ps
+  #define _mm256_broadcastss_ps(a) simde_mm256_broadcastss_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_broadcastsd_pd (simde__m128d a) {
+  return simde_mm_movedup_pd(a);
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_broadcastsd_pd
+  #define _mm_broadcastsd_pd(a) simde_mm_broadcastsd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_broadcastsd_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_broadcastsd_pd(a);
+  #else
+    simde__m256d_private r_;
+    simde__m128d_private a_= simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[0];
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastsd_pd
+  #define _mm256_broadcastsd_pd(a) simde_mm256_broadcastsd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_broadcastsi128_si256 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE) && \
+      (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,8,0))
+    return _mm256_broadcastsi128_si256(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i_private[0] = a_;
+      r_.m128i_private[1] = a_;
+    #else
+      r_.i64[0] = a_.i64[0];
+      r_.i64[1] = a_.i64[1];
+      r_.i64[2] = a_.i64[0];
+      r_.i64[3] = a_.i64[1];
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#define simde_mm_broadcastsi128_si256(a) simde_mm256_broadcastsi128_si256(a)
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcastsi128_si256
+  #define _mm256_broadcastsi128_si256(a) simde_mm256_broadcastsi128_si256(a)
+  #undef _mm_broadcastsi128_si256
+  #define _mm_broadcastsi128_si256(a) simde_mm256_broadcastsi128_si256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_bslli_epi128 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+    const int ssize = HEDLEY_STATIC_CAST(int, (sizeof(r_.i8) / sizeof(r_.i8[0])));
+
+    SIMDE_VECTORIZE
+    for (int i = 0 ; i < ssize ; i++) {
+      const int e = i - imm8;
+      if(i >= (ssize/2)) {
+        if(e >= (ssize/2) && e < ssize)
+          r_.i8[i] = a_.i8[e];
+        else
+          r_.i8[i] = 0;
+      }
+      else{
+        if(e >= 0 && e < (ssize/2))
+          r_.i8[i] = a_.i8[e];
+        else
+          r_.i8[i] = 0;
+      }
+    }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE) && \
+    (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,8,0)) && \
+    SIMDE_DETECT_CLANG_VERSION_CHECK(3,7,0)
+  #define simde_mm256_bslli_epi128(a, imm8) _mm256_bslli_epi128(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_bslli_epi128
+  #define _mm256_bslli_epi128(a, imm8) simde_mm256_bslli_epi128(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_bsrli_epi128 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+    const int ssize = HEDLEY_STATIC_CAST(int, (sizeof(r_.i8) / sizeof(r_.i8[0])));
+
+    SIMDE_VECTORIZE
+    for (int i = 0 ; i < ssize ; i++) {
+      const int e = i + imm8;
+      if(i < (ssize/2)) {
+        if(e >= 0 && e < (ssize/2))
+          r_.i8[i] = a_.i8[e];
+        else
+          r_.i8[i] = 0;
+      }
+      else{
+        if(e >= (ssize/2) && e < ssize)
+          r_.i8[i] = a_.i8[e];
+        else
+          r_.i8[i] = 0;
+      }
+    }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE) && \
+    (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,8,0)) && \
+    SIMDE_DETECT_CLANG_VERSION_CHECK(3,7,0)
+  #define simde_mm256_bsrli_epi128(a, imm8) _mm256_bsrli_epi128(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_bsrli_epi128
+  #define _mm256_bsrli_epi128(a, imm8) simde_mm256_bsrli_epi128(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpeq_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpeq_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_cmpeq_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpeq_epi8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpeq_epi8
+  #define _mm256_cmpeq_epi8(a, b) simde_mm256_cmpeq_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpeq_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpeq_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpeq_epi16
+  #define _mm256_cmpeq_epi16(a, b) simde_mm256_cmpeq_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpeq_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpeq_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i[0] = simde_mm_cmpeq_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpeq_epi32(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpeq_epi32
+  #define _mm256_cmpeq_epi32(a, b) simde_mm256_cmpeq_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpeq_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpeq_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i[0] = simde_mm_cmpeq_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpeq_epi64(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = (a_.i64[i] == b_.i64[i]) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpeq_epi64
+  #define _mm256_cmpeq_epi64(a, b) simde_mm256_cmpeq_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpgt_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpgt_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_cmpgt_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpgt_epi8(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), a_.i8 > b_.i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpgt_epi8
+  #define _mm256_cmpgt_epi8(a, b) simde_mm256_cmpgt_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpgt_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpgt_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_cmpgt_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpgt_epi16(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 > b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpgt_epi16
+  #define _mm256_cmpgt_epi16(a, b) simde_mm256_cmpgt_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpgt_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpgt_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_cmpgt_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpgt_epi32(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 > b_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpgt_epi32
+  #define _mm256_cmpgt_epi32(a, b) simde_mm256_cmpgt_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cmpgt_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cmpgt_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_cmpgt_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_cmpgt_epi64(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), a_.i64 > b_.i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = (a_.i64[i] > b_.i64[i]) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cmpgt_epi64
+  #define _mm256_cmpgt_epi64(a, b) simde_mm256_cmpgt_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi8_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi8_epi16(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i16, a_.i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi8_epi16
+  #define _mm256_cvtepi8_epi16(a) simde_mm256_cvtepi8_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi8_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi8_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi8_epi32
+  #define _mm256_cvtepi8_epi32(a) simde_mm256_cvtepi8_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi8_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi8_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i8[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi8_epi64
+  #define _mm256_cvtepi8_epi64(a) simde_mm256_cvtepi8_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi16_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi16_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi16_epi32
+  #define _mm256_cvtepi16_epi32(a) simde_mm256_cvtepi16_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi16_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi16_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.m64_private[0].i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi16_epi64
+  #define _mm256_cvtepi16_epi64(a) simde_mm256_cvtepi16_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepi32_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepi32_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepi32_epi64
+  #define _mm256_cvtepi32_epi64(a) simde_mm256_cvtepi32_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu8_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu8_epi16(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i16, a_.u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu8_epi16
+  #define _mm256_cvtepu8_epi16(a) simde_mm256_cvtepu8_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu8_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu8_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu8_epi32
+  #define _mm256_cvtepu8_epi32(a) simde_mm256_cvtepu8_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu8_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu8_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.u8[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu8_epi64
+  #define _mm256_cvtepu8_epi64(a) simde_mm256_cvtepu8_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu16_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu16_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu16_epi32
+  #define _mm256_cvtepu16_epi32(a) simde_mm256_cvtepu16_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu16_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu16_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.m64_private[0].u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu16_epi64
+  #define _mm256_cvtepu16_epi64(a) simde_mm256_cvtepu16_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_cvtepu32_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_cvtepu32_epi64(a);
+  #else
+    simde__m256i_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.u32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.u32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtepu32_epi64
+  #define _mm256_cvtepu32_epi64(a) simde_mm256_cvtepu32_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_extract_epi8 (simde__m256i a, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 31){
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.i8[index];
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_extract_epi8(a, index) _mm256_extract_epi8(a, index)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extract_epi8
+  #define _mm256_extract_epi8(a, index) simde_mm256_extract_epi8(a, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm256_extract_epi16 (simde__m256i a, const int index)
+    SIMDE_REQUIRE_RANGE(index, 0, 15)  {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.i16[index];
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_extract_epi16(a, index) _mm256_extract_epi16(a, index)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extract_epi16
+  #define _mm256_extract_epi16(a, index) simde_mm256_extract_epi16(a, index)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_extracti128_si256 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  return a_.m128i[imm8];
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_extracti128_si256(a, imm8) _mm256_extracti128_si256(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_extracti128_si256
+  #define _mm256_extracti128_si256(a, imm8) simde_mm256_extracti128_si256(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i32gather_epi32(const int32_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i32gather_epi32(base_addr, vindex, scale) _mm_i32gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i32_gather_epi32
+  #define _mm_i32gather_epi32(base_addr, vindex, scale) simde_mm_i32gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i32gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i32gather_epi32
+  #define _mm_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) simde_mm_mask_i32gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_i32gather_epi32(const int32_t* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i32gather_epi32(base_addr, vindex, scale) _mm256_i32gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i32_gather_epi32
+  #define _mm256_i32gather_epi32(base_addr, vindex, scale) simde_mm256_i32gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_i32gather_epi32(simde__m256i src, const int32_t* base_addr, simde__m256i vindex, simde__m256i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    src_ = simde__m256i_to_private(src),
+    mask_ = simde__m256i_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i32gather_epi32
+  #define _mm256_mask_i32gather_epi32(src, base_addr, vindex, mask, scale) simde_mm256_mask_i32gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i64gather_epi32(const int32_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i64gather_epi32(base_addr, vindex, scale) _mm_i64gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i64_gather_epi32
+  #define _mm_i64gather_epi32(base_addr, vindex, scale) simde_mm_i64gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i64gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i64gather_epi32
+  #define _mm_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) simde_mm_mask_i64gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_i64gather_epi32(const int32_t* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128i_private
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int32_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i32[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i64gather_epi32(base_addr, vindex, scale) _mm256_i64gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i64_gather_epi32
+  #define _mm256_i64gather_epi32(base_addr, vindex, scale) simde_mm256_i64gather_epi32(SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_mask_i64gather_epi32(simde__m128i src, const int32_t* base_addr, simde__m256i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128i_private
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int32_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i32[i] = dst;
+    }
+    else {
+      r_.i32[i] = src_.i32[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int const*, int32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i64gather_epi32
+  #define _mm256_mask_i64gather_epi32(src, base_addr, vindex, mask, scale) simde_mm256_mask_i64gather_epi32(src, SIMDE_CHECKED_REINTERPRET_CAST(int32_t const*, int const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i32gather_epi64(const int64_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int64_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i64[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm_i32gather_epi64(base_addr, vindex, scale) _mm_i32gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+  #else
+    #define simde_mm_i32gather_epi64(base_addr, vindex, scale) _mm_i32gather_epi64(HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i32_gather_epi64
+  #define _mm_i32gather_epi64(base_addr, vindex, scale) simde_mm_i32gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i32gather_epi64(simde__m128i src, const int64_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int64_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i64[i] = dst;
+    }
+    else {
+      r_.i64[i] = src_.i64[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+  #else
+    #define simde_mm_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, mask, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i32gather_epi64
+  #define _mm_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) simde_mm_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_i32gather_epi64(const int64_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m256i_private
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int64_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i64[i] = dst;
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm256_i32gather_epi64(base_addr, vindex, scale) _mm256_i32gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+  #else
+    #define simde_mm256_i32gather_epi64(base_addr, vindex, scale) _mm256_i32gather_epi64(HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i32_gather_epi64
+  #define _mm256_i32gather_epi64(base_addr, vindex, scale) simde_mm256_i32gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_i32gather_epi64(simde__m256i src, const int64_t* base_addr, simde__m128i vindex, simde__m256i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    src_ = simde__m256i_to_private(src),
+    mask_ = simde__m256i_to_private(mask),
+    r_;
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int64_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i64[i] = dst;
+    }
+    else {
+      r_.i64[i] = src_.i64[i];
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm256_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+  #else
+    #define simde_mm256_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, mask, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i32gather_epi64
+  #define _mm256_mask_i32gather_epi64(src, base_addr, vindex, mask, scale) simde_mm256_mask_i32gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_i64gather_epi64(const int64_t* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int64_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i64[i] = dst;
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm_i64gather_epi64(base_addr, vindex, scale) _mm_i64gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+  #else
+    #define simde_mm_i64gather_epi64(base_addr, vindex, scale) _mm_i64gather_epi64(HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i64_gather_epi64
+  #define _mm_i64gather_epi64(base_addr, vindex, scale) simde_mm_i64gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_i64gather_epi64(simde__m128i src, const int64_t* base_addr, simde__m128i vindex, simde__m128i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex),
+    src_ = simde__m128i_to_private(src),
+    mask_ = simde__m128i_to_private(mask),
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int64_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i64[i] = dst;
+    }
+    else {
+      r_.i64[i] = src_.i64[i];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+  #else
+    #define simde_mm_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, mask, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i64gather_epi64
+  #define _mm_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) simde_mm_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_i64gather_epi64(const int64_t* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    r_ = simde__m256i_to_private(simde_mm256_setzero_si256());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    int64_t dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.i64[i] = dst;
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm256_i64gather_epi64(base_addr, vindex, scale) _mm256_i64gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+  #else
+    #define simde_mm256_i64gather_epi64(base_addr, vindex, scale) _mm256_i64gather_epi64(HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i64_gather_epi64
+  #define _mm256_i64gather_epi64(base_addr, vindex, scale) simde_mm256_i64gather_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_i64gather_epi64(simde__m256i src, const int64_t* base_addr, simde__m256i vindex, simde__m256i mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex),
+    src_ = simde__m256i_to_private(src),
+    mask_ = simde__m256i_to_private(mask),
+    r_ = simde__m256i_to_private(simde_mm256_setzero_si256());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      int64_t dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.i64[i] = dst;
+    }
+    else {
+      r_.i64[i] = src_.i64[i];
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #if SIMDE_DETECT_CLANG_VERSION_CHECK(3,8,0)
+    #define simde_mm256_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+  #else
+    #define simde_mm256_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(long long const*, base_addr), vindex, mask, scale)
+  #endif
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i64gather_epi64
+  #define _mm256_mask_i64gather_epi64(src, base_addr, vindex, mask, scale) simde_mm256_mask_i64gather_epi64(src, HEDLEY_REINTERPRET_CAST(int64_t const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_i32gather_ps(const simde_float32* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128_private
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float32 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f32[i] = dst;
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i32gather_ps(base_addr, vindex, scale) _mm_i32gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i32_gather_ps
+  #define _mm_i32gather_ps(base_addr, vindex, scale) simde_mm_i32gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_i32gather_ps(simde__m128 src, const simde_float32* base_addr, simde__m128i vindex, simde__m128 mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128_private
+    src_ = simde__m128_to_private(src),
+    mask_ = simde__m128_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float32 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f32[i] = dst;
+    }
+    else {
+      r_.f32[i] = src_.f32[i];
+    }
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i32gather_ps(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i32gather_ps
+  #define _mm_mask_i32gather_ps(src, base_addr, vindex, mask, scale) simde_mm_mask_i32gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_i32gather_ps(const simde_float32* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m256_private
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float32 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f32[i] = dst;
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i32gather_ps(base_addr, vindex, scale) _mm256_i32gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i32_gather_ps
+  #define _mm256_i32gather_ps(base_addr, vindex, scale) simde_mm256_i32gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_i32gather_ps(simde__m256 src, const simde_float32* base_addr, simde__m256i vindex, simde__m256 mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m256_private
+    src_ = simde__m256_to_private(src),
+    mask_ = simde__m256_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float32 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f32[i] = dst;
+    }
+    else {
+      r_.f32[i] = src_.f32[i];
+    }
+  }
+
+  return simde__m256_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i32gather_ps
+  #define _mm256_mask_i32gather_ps(src, base_addr, vindex, mask, scale) simde_mm256_mask_i32gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_i64gather_ps(const simde_float32* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128_private
+    r_ = simde__m128_to_private(simde_mm_setzero_ps());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float32 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f32[i] = dst;
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i64gather_ps(base_addr, vindex, scale) _mm_i64gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i64_gather_ps
+  #define _mm_i64gather_ps(base_addr, vindex, scale) simde_mm_i64gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_i64gather_ps(simde__m128 src, const simde_float32* base_addr, simde__m128i vindex, simde__m128 mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128_private
+    src_ = simde__m128_to_private(src),
+    mask_ = simde__m128_to_private(mask),
+    r_ = simde__m128_to_private(simde_mm_setzero_ps());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+     simde_float32 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f32[i] = dst;
+    }
+    else {
+      r_.f32[i] = src_.f32[i];
+    }
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i64gather_ps(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(float const*, float32_t const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i64gather_ps
+  #define _mm_mask_i64gather_ps(src, base_addr, vindex, mask, scale) simde_mm_mask_i64gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm256_i64gather_ps(const simde_float32* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128_private
+    r_ = simde__m128_to_private(simde_mm_setzero_ps());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float32 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f32[i] = dst;
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i64gather_ps(base_addr, vindex, scale) _mm256_i64gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i64_gather_ps
+  #define _mm256_i64gather_ps(base_addr, vindex, scale) simde_mm256_i64gather_ps(SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm256_mask_i64gather_ps(simde__m128 src, const simde_float32* base_addr, simde__m256i vindex, simde__m128 mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m128_private
+    src_ = simde__m128_to_private(src),
+    mask_ = simde__m128_to_private(mask),
+    r_ = simde__m128_to_private(simde_mm_setzero_ps());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i32[i] >> 31) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float32 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f32[i] = dst;
+    }
+    else {
+      r_.f32[i] = src_.f32[i];
+    }
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i64gather_ps(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(float const*, simde_float32 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i64gather_ps
+  #define _mm256_mask_i64gather_ps(src, base_addr, vindex, mask, scale) simde_mm256_mask_i64gather_ps(src, SIMDE_CHECKED_REINTERPRET_CAST(simde_float32 const*, float const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_i32gather_pd(const simde_float64* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128d_private
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float64 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f64[i] = dst;
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i32gather_pd(base_addr, vindex, scale) _mm_i32gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i32_gather_pd
+  #define _mm_i32gather_pd(base_addr, vindex, scale) simde_mm_i32gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mask_i32gather_pd(simde__m128d src, const simde_float64* base_addr, simde__m128i vindex, simde__m128d mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128d_private
+    src_ = simde__m128d_to_private(src),
+    mask_ = simde__m128d_to_private(mask),
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float64 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f64[i] = dst;
+    }
+    else {
+      r_.f64[i] = src_.f64[i];
+    }
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i32gather_pd(src, base_addr, vindex, mask, scale) _mm_mask_i32gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i32gather_pd
+  #define _mm_mask_i32gather_pd(src, base_addr, vindex, mask, scale) simde_mm_mask_i32gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_i32gather_pd(const simde_float64* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m256d_private
+    r_;
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float64 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f64[i] = dst;
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i32gather_pd(base_addr, vindex, scale) _mm256_i32gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i32_gather_pd
+  #define _mm256_i32gather_pd(base_addr, vindex, scale) simde_mm256_i32gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_i32gather_pd(simde__m256d src, const simde_float64* base_addr, simde__m128i vindex, simde__m256d mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256d_private
+    src_ = simde__m256d_to_private(src),
+    mask_ = simde__m256d_to_private(mask),
+    r_;
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i32) / sizeof(vindex_.i32[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i32[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float64 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f64[i] = dst;
+    }
+    else {
+      r_.f64[i] = src_.f64[i];
+    }
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i32gather_pd(src, base_addr, vindex, mask, scale) _mm256_mask_i32gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i32gather_pd
+  #define _mm256_mask_i32gather_pd(src, base_addr, vindex, mask, scale) simde_mm256_mask_i32gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_i64gather_pd(const simde_float64* base_addr, simde__m128i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128d_private
+    r_ = simde__m128d_to_private(simde_mm_setzero_pd());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float64 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f64[i] = dst;
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_i64gather_pd(base_addr, vindex, scale) _mm_i64gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_i64_gather_pd
+  #define _mm_i64gather_pd(base_addr, vindex, scale) simde_mm_i64gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mask_i64gather_pd(simde__m128d src, const simde_float64* base_addr, simde__m128i vindex, simde__m128d mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m128i_private
+    vindex_ = simde__m128i_to_private(vindex);
+  simde__m128d_private
+    src_ = simde__m128d_to_private(src),
+    mask_ = simde__m128d_to_private(mask),
+    r_ = simde__m128d_to_private(simde_mm_setzero_pd());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float64 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f64[i] = dst;
+    }
+    else {
+      r_.f64[i] = src_.f64[i];
+    }
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_mask_i64gather_pd(src, base_addr, vindex, mask, scale) _mm_mask_i64gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_i64gather_pd
+  #define _mm_mask_i64gather_pd(src, base_addr, vindex, mask, scale) simde_mm_mask_i64gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_i64gather_pd(const simde_float64* base_addr, simde__m256i vindex, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m256d_private
+    r_ = simde__m256d_to_private(simde_mm256_setzero_pd());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    const uint8_t* src = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+    simde_float64 dst;
+    simde_memcpy(&dst, src, sizeof(dst));
+    r_.f64[i] = dst;
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_i64gather_pd(base_addr, vindex, scale) _mm256_i64gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_i64_gather_pd
+  #define _mm256_i64gather_pd(base_addr, vindex, scale) simde_mm256_i64gather_pd(HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_i64gather_pd(simde__m256d src, const simde_float64* base_addr, simde__m256i vindex, simde__m256d mask, const int32_t scale)
+    SIMDE_REQUIRE_CONSTANT(scale)
+    HEDLEY_REQUIRE_MSG((scale && scale <= 8 && !(scale & (scale - 1))), "`scale' must be a power of two less than or equal to 8") {
+  simde__m256i_private
+    vindex_ = simde__m256i_to_private(vindex);
+  simde__m256d_private
+    src_ = simde__m256d_to_private(src),
+    mask_ = simde__m256d_to_private(mask),
+    r_ = simde__m256d_to_private(simde_mm256_setzero_pd());
+  const uint8_t* addr = HEDLEY_REINTERPRET_CAST(const uint8_t*, base_addr);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(vindex_.i64) / sizeof(vindex_.i64[0])) ; i++) {
+    if ((mask_.i64[i] >> 63) & 1) {
+      const uint8_t* src1 = addr + (HEDLEY_STATIC_CAST(size_t , vindex_.i64[i]) * HEDLEY_STATIC_CAST(size_t , scale));
+      simde_float64 dst;
+      simde_memcpy(&dst, src1, sizeof(dst));
+      r_.f64[i] = dst;
+    }
+    else {
+      r_.f64[i] = src_.f64[i];
+    }
+  }
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale) _mm256_mask_i64gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_i64gather_pd
+  #define _mm256_mask_i64gather_pd(src, base_addr, vindex, mask, scale) simde_mm256_mask_i64gather_pd(src, HEDLEY_REINTERPRET_CAST(simde_float64 const*, base_addr), vindex, mask, scale)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_inserti128_si256(simde__m256i a, simde__m128i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  simde__m128i_private b_ = simde__m128i_to_private(b);
+
+  a_.m128i_private[ imm8 & 1 ] = b_;
+
+  return simde__m256i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_inserti128_si256(a, b, imm8) _mm256_inserti128_si256(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #define _mm256_inserti128_si256(a, b, imm8) simde_mm256_inserti128_si256(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_madd_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_madd_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    r_.m128i[0] = simde_mm_madd_epi16(a_.m128i[0], b_.m128i[0]);
+    r_.m128i[1] = simde_mm_madd_epi16(a_.m128i[1], b_.m128i[1]);
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_madd_epi16
+  #define _mm256_madd_epi16(a, b) simde_mm256_madd_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maddubs_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_maddubs_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_maddubs_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_maddubs_epi16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int idx = HEDLEY_STATIC_CAST(int, i) << 1;
+        int32_t ts =
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[  idx  ]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[  idx  ])) +
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[idx + 1]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[idx + 1]));
+        r_.i16[i] = (ts > INT16_MIN) ? ((ts < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, ts) : INT16_MAX) : INT16_MIN;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maddubs_epi16
+  #define _mm256_maddubs_epi16(a, b) simde_mm256_maddubs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskload_epi32 (const int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_maskload_epi32(mem_addr, mask);
+  #else
+    simde__m128i_private
+      mem_ = simde__m128i_to_private(simde_x_mm_loadu_epi32(mem_addr)),
+      r_,
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(mem_.neon_i32, vshrq_n_s32(mask_.neon_i32, 31));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = mem_.i32[i] & (mask_.i32[i] >> 31);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskload_epi32
+  #define _mm_maskload_epi32(mem_addr, mask) simde_mm_maskload_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskload_epi32 (const int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_maskload_epi32(mem_addr, mask);
+  #else
+    simde__m256i_private
+      mask_ = simde__m256i_to_private(mask),
+      r_ = simde__m256i_to_private(simde_x_mm256_loadu_epi32(mem_addr));
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] &= mask_.i32[i] >> 31;
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskload_epi32
+  #define _mm256_maskload_epi32(mem_addr, mask) simde_mm256_maskload_epi32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_maskload_epi64(HEDLEY_REINTERPRET_CAST(const long long *, mem_addr), mask);
+  #else
+    simde__m128i_private
+      mem_ = simde__m128i_to_private(simde_x_mm_loadu_epi64((mem_addr))),
+      r_,
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vandq_s64(mem_.neon_i64, vshrq_n_s64(mask_.neon_i64, 63));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = mem_.i64[i] & (mask_.i64[i] >> 63);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskload_epi64
+  #define _mm_maskload_epi64(mem_addr, mask) simde_mm_maskload_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskload_epi64 (const int64_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_maskload_epi64(HEDLEY_REINTERPRET_CAST(const long long *, mem_addr), mask);
+  #else
+    simde__m256i_private
+      mask_ = simde__m256i_to_private(mask),
+      r_ = simde__m256i_to_private(simde_x_mm256_loadu_epi64((mem_addr)));
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] &= mask_.i64[i] >> 63;
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskload_epi64
+  #define _mm256_maskload_epi64(mem_addr, mask) simde_mm256_maskload_epi64(HEDLEY_REINTERPRET_CAST(int64_t const*, mem_addr), mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskstore_epi32 (int32_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m128i mask, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    _mm_maskstore_epi32(mem_addr, mask, a);
+  #else
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      if (mask_.u32[i] & (UINT32_C(1) << 31))
+        mem_addr[i] = a_.i32[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskstore_epi32
+  #define _mm_maskstore_epi32(mem_addr, mask, a) simde_mm_maskstore_epi32(HEDLEY_REINTERPRET_CAST(int32_t *, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_maskstore_epi32 (int32_t mem_addr[HEDLEY_ARRAY_PARAM(8)], simde__m256i mask, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    _mm256_maskstore_epi32(mem_addr, mask, a);
+  #else
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      if (mask_.u32[i] & (UINT32_C(1) << 31))
+        mem_addr[i] = a_.i32[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskstore_epi32
+  #define _mm256_maskstore_epi32(mem_addr, mask, a) simde_mm256_maskstore_epi32(HEDLEY_REINTERPRET_CAST(int32_t *, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskstore_epi64 (int64_t mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128i mask, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    _mm_maskstore_epi64(HEDLEY_REINTERPRET_CAST(long long *, mem_addr), mask, a);
+  #else
+    simde__m128i_private mask_ = simde__m128i_to_private(mask);
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      if (mask_.u64[i] >> 63)
+        mem_addr[i] = a_.i64[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskstore_epi64
+  #define _mm_maskstore_epi64(mem_addr, mask, a) simde_mm_maskstore_epi64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm256_maskstore_epi64 (int64_t mem_addr[HEDLEY_ARRAY_PARAM(4)], simde__m256i mask, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    _mm256_maskstore_epi64(HEDLEY_REINTERPRET_CAST(long long *, mem_addr), mask, a);
+  #else
+    simde__m256i_private mask_ = simde__m256i_to_private(mask);
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      if (mask_.u64[i] & (UINT64_C(1) << 63))
+        mem_addr[i] = a_.i64[i];
+    }
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskstore_epi64
+  #define _mm256_maskstore_epi64(mem_addr, mask, a) simde_mm256_maskstore_epi64(HEDLEY_REINTERPRET_CAST(int64_t *, mem_addr), mask, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE) && !defined(__PGI)
+    return _mm256_max_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_max_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epi8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] > b_.i8[i] ? a_.i8[i] : b_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epi8
+  #define _mm256_max_epi8(a, b) simde_mm256_max_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_max_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i[0] = simde_mm_max_epu8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epu8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epu8
+  #define _mm256_max_epu8(a, b) simde_mm256_max_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_max_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i[0] = simde_mm_max_epu16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epu16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] > b_.u16[i]) ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epu16
+  #define _mm256_max_epu16(a, b) simde_mm256_max_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epu32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_max_epu32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i[0] = simde_mm_max_epu32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epu32(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = (a_.u32[i] > b_.u32[i]) ? a_.u32[i] : b_.u32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epu32
+  #define _mm256_max_epu32(a, b) simde_mm256_max_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_max_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_max_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epi16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epi16
+  #define _mm256_max_epi16(a, b) simde_mm256_max_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_max_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_max_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_max_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_max_epi32(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] > b_.i32[i] ? a_.i32[i] : b_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_max_epi32
+  #define _mm256_max_epi32(a, b) simde_mm256_max_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE) && !defined(__PGI)
+    return _mm256_min_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epi8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] < b_.i8[i] ? a_.i8[i] : b_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epi8
+  #define _mm256_min_epi8(a, b) simde_mm256_min_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_min_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epi16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epi16
+  #define _mm256_min_epi16(a, b) simde_mm256_min_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_min_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epi32(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] < b_.i32[i] ? a_.i32[i] : b_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epi32
+  #define _mm256_min_epi32(a, b) simde_mm256_min_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_min_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epu8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epu8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epu8
+  #define _mm256_min_epu8(a, b) simde_mm256_min_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_min_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epu16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epu16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] < b_.u16[i]) ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epu16
+  #define _mm256_min_epu16(a, b) simde_mm256_min_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_min_epu32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_min_epu32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_min_epu32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_min_epu32(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = (a_.u32[i] < b_.u32[i]) ? a_.u32[i] : b_.u32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_min_epu32
+  #define _mm256_min_epu32(a, b) simde_mm256_min_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm256_movemask_epi8 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_movemask_epi8(a);
+  #else
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+    uint32_t r = 0;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(a_.m128i) / sizeof(a_.m128i[0])) ; i++) {
+        r |= HEDLEY_STATIC_CAST(uint32_t,simde_mm_movemask_epi8(a_.m128i[i])) << (16 * i);
+      }
+    #else
+      r = 0;
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[31 - i] >> 7) << (31 - i);
+      }
+    #endif
+
+    return HEDLEY_STATIC_CAST(int32_t, r);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movemask_epi8
+  #define _mm256_movemask_epi8(a) simde_mm256_movemask_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mpsadbw_epu8 (simde__m256i a, simde__m256i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7)  {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  const int a_offset1 = imm8 & 4;
+  const int b_offset1 = (imm8 & 3) << 2;
+  const int a_offset2 = (imm8 >> 3) & 4;
+  const int b_offset2 = ((imm8 >> 3) & 3) << 2;
+
+  #if defined(simde_math_abs)
+    const int halfway_point = HEDLEY_STATIC_CAST(int, (sizeof(r_.u16) / sizeof(r_.u16[0])) ) / 2;
+    for (int i = 0 ; i < halfway_point ; i++) {
+      r_.u16[i] =
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset1 + i + 0] - b_.u8[b_offset1 + 0]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset1 + i + 1] - b_.u8[b_offset1 + 1]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset1 + i + 2] - b_.u8[b_offset1 + 2]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset1 + i + 3] - b_.u8[b_offset1 + 3])));
+      r_.u16[halfway_point + i] =
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[2 * halfway_point + a_offset2 + i + 0] - b_.u8[2 * halfway_point + b_offset2 + 0]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[2 * halfway_point + a_offset2 + i + 1] - b_.u8[2 * halfway_point + b_offset2 + 1]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[2 * halfway_point + a_offset2 + i + 2] - b_.u8[2 * halfway_point + b_offset2 + 2]))) +
+        HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[2 * halfway_point + a_offset2 + i + 3] - b_.u8[2 * halfway_point + b_offset2 + 3])));
+    }
+  #else
+    HEDLEY_UNREACHABLE();
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE) && SIMDE_DETECT_CLANG_VERSION_CHECK(3,9,0)
+  #define simde_mm256_mpsadbw_epu8(a, b, imm8) _mm256_mpsadbw_epu8(a, b, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+  #define simde_mm256_mpsadbw_epu8(a, b, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_mpsadbw_epu8(simde_mm256_extracti128_si256(a, 1), simde_mm256_extracti128_si256(b, 1), (imm8 >> 3)), \
+       simde_mm_mpsadbw_epu8(simde_mm256_extracti128_si256(a, 0), simde_mm256_extracti128_si256(b, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mpsadbw_epu8
+  #define _mm256_mpsadbw_epu8(a, b, imm8) simde_mm256_mpsadbw_epu8(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mul_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mul_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] =
+        HEDLEY_STATIC_CAST(int64_t, a_.i32[i * 2]) *
+        HEDLEY_STATIC_CAST(int64_t, b_.i32[i * 2]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_mul_epi32(a, b) simde_mm256_mul_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mul_epu32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mul_epu32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
+      }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_mul_epu32(a, b) simde_mm256_mul_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mulhi_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mulhi_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (HEDLEY_STATIC_CAST(uint32_t, HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) >> 16));
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_mulhi_epi16(a, b) simde_mm256_mulhi_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mulhi_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mulhi_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]) >> 16);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_mulhi_epu16(a, b) simde_mm256_mulhi_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mulhrs_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mulhrs_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, (((HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) + 0x4000) >> 15));
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_mulhrs_epi16(a, b) simde_mm256_mulhrs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mullo_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mullo_epi16(a, b);
+  #else
+    simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] * b_.i16[i]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mullo_epi16
+  #define _mm256_mullo_epi16(a, b) simde_mm256_mullo_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mullo_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_mullo_epi32(a, b);
+  #else
+    simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, a_.i32[i] * b_.i32[i]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mullo_epi32
+  #define _mm256_mullo_epi32(a, b) simde_mm256_mullo_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_mullo_epu32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 * b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] * b_.u32[i];
+      }
+    #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_or_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_or_si256(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_or_si128(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_or_si128(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_or_si256
+  #define _mm256_or_si256(a, b) simde_mm256_or_si256(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_packs_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_packs_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_packs_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_packs_epi16(a_.m128i[1], b_.m128i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i8) / sizeof(r_.i8[0]))/2;
+      const size_t quarter_point = (sizeof(r_.i8) / sizeof(r_.i8[0]))/4;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < quarter_point ; i++) {
+        r_.i8[i]     = (a_.i16[i] > INT8_MAX) ? INT8_MAX : ((a_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+        r_.i8[i + quarter_point] = (b_.i16[i] > INT8_MAX) ? INT8_MAX : ((b_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[i]));
+        r_.i8[halfway_point + i]     = (a_.i16[quarter_point + i] > INT8_MAX) ? INT8_MAX : ((a_.i16[quarter_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[quarter_point + i]));
+        r_.i8[halfway_point + i + quarter_point] = (b_.i16[quarter_point + i] > INT8_MAX) ? INT8_MAX : ((b_.i16[quarter_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[quarter_point + i]));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_packs_epi16
+  #define _mm256_packs_epi16(a, b) simde_mm256_packs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_packs_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_packs_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      v_[] = {
+        simde__m256i_to_private(a),
+        simde__m256i_to_private(b)
+      };
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) || defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.m128i_private[0] = simde__m128i_to_private(simde_mm_packs_epi32(simde__m128i_from_private(v_[0].m128i_private[0]), simde__m128i_from_private(v_[1].m128i_private[0])));
+      r_.m128i_private[1] = simde__m128i_to_private(simde_mm_packs_epi32(simde__m128i_from_private(v_[0].m128i_private[1]), simde__m128i_from_private(v_[1].m128i_private[1])));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int32_t v = v_[(i >> 2) & 1].i32[(i & 11) - ((i & 8) >> 1)];
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, (v > INT16_MAX) ? INT16_MAX : ((v < INT16_MIN) ? INT16_MIN : v));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_packs_epi32
+  #define _mm256_packs_epi32(a, b) simde_mm256_packs_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_packus_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_packus_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_packus_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_packus_epi16(a_.m128i[1], b_.m128i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 4;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < quarter_point ; i++) {
+        r_.u8[i] = (a_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]));
+        r_.u8[i + quarter_point] = (b_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]));
+        r_.u8[halfway_point + i] = (a_.i16[quarter_point + i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[quarter_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[quarter_point + i]));
+        r_.u8[halfway_point + i + quarter_point] = (b_.i16[quarter_point + i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[quarter_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[quarter_point + i]));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_packus_epi16
+  #define _mm256_packus_epi16(a, b) simde_mm256_packus_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_packus_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_packus_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_packus_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_packus_epi32(a_.m128i[1], b_.m128i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 4;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < quarter_point ; i++) {
+        r_.u16[i] = (a_.i32[i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[i]));
+        r_.u16[i + quarter_point] = (b_.i32[i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[i]));
+        r_.u16[halfway_point + i]     = (a_.i32[quarter_point + i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[quarter_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[quarter_point + i]));
+        r_.u16[halfway_point + i + quarter_point] = (b_.i32[quarter_point + i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[quarter_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[quarter_point + i]));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_packus_epi32
+  #define _mm256_packus_epi32(a, b) simde_mm256_packus_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permute2x128_si256 (simde__m256i a, simde__m256i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  r_.m128i_private[0] = (imm8 & 0x08) ? simde__m128i_to_private(simde_mm_setzero_si128()) : ((imm8 & 0x02) ? b_.m128i_private[(imm8     ) & 1] : a_.m128i_private[(imm8     ) & 1]);
+  r_.m128i_private[1] = (imm8 & 0x80) ? simde__m128i_to_private(simde_mm_setzero_si128()) : ((imm8 & 0x20) ? b_.m128i_private[(imm8 >> 4) & 1] : a_.m128i_private[(imm8 >> 4) & 1]);
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_permute2x128_si256(a, b, imm8) _mm256_permute2x128_si256(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute2x128_si256
+  #define _mm256_permute2x128_si256(a, b, imm8) simde_mm256_permute2x128_si256(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permute4x64_epi64 (simde__m256i a, const int imm8)
+SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  r_.i64[0] = (imm8 & 0x02) ? a_.i64[((imm8       ) & 1)+2] : a_.i64[(imm8       ) & 1];
+  r_.i64[1] = (imm8 & 0x08) ? a_.i64[((imm8 >> 2  ) & 1)+2] : a_.i64[(imm8 >> 2  ) & 1];
+  r_.i64[2] = (imm8 & 0x20) ? a_.i64[((imm8 >> 4  ) & 1)+2] : a_.i64[(imm8 >> 4  ) & 1];
+  r_.i64[3] = (imm8 & 0x80) ? a_.i64[((imm8 >> 6  ) & 1)+2] : a_.i64[(imm8 >> 6  ) & 1];
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_permute4x64_epi64(a, imm8) _mm256_permute4x64_epi64(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute4x64_epi64
+  #define _mm256_permute4x64_epi64(a, imm8) simde_mm256_permute4x64_epi64(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_permute4x64_pd (simde__m256d a, const int imm8)
+SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  simde__m256d_private
+    r_,
+    a_ = simde__m256d_to_private(a);
+
+  r_.f64[0] = (imm8 & 0x02) ? a_.f64[((imm8       ) & 1)+2] : a_.f64[(imm8       ) & 1];
+  r_.f64[1] = (imm8 & 0x08) ? a_.f64[((imm8 >> 2  ) & 1)+2] : a_.f64[(imm8 >> 2  ) & 1];
+  r_.f64[2] = (imm8 & 0x20) ? a_.f64[((imm8 >> 4  ) & 1)+2] : a_.f64[(imm8 >> 4  ) & 1];
+  r_.f64[3] = (imm8 & 0x80) ? a_.f64[((imm8 >> 6  ) & 1)+2] : a_.f64[(imm8 >> 6  ) & 1];
+
+  return simde__m256d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_permute4x64_pd(a, imm8) _mm256_permute4x64_pd(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permute4x64_pd
+  #define _mm256_permute4x64_pd(a, imm8) simde_mm256_permute4x64_pd(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_permutevar8x32_epi32 (simde__m256i a, simde__m256i idx) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_permutevar8x32_epi32(a, idx);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      idx_ = simde__m256i_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[idx_.i32[i] & 7];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutevar8x32_epi32
+  #define _mm256_permutevar8x32_epi32(a, idx) simde_mm256_permutevar8x32_epi32(a, idx)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_permutevar8x32_ps (simde__m256 a, simde__m256i idx) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_permutevar8x32_ps(a, idx);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+    simde__m256i_private
+      idx_ = simde__m256i_to_private(idx);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[idx_.i32[i] & 7];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_permutevar8x32_ps
+  #define _mm256_permutevar8x32_ps(a, idx) simde_mm256_permutevar8x32_ps(a, idx)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sad_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sad_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sad_epu8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_sad_epu8(a_.m128i[1], b_.m128i[1]);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        uint16_t tmp = 0;
+        SIMDE_VECTORIZE_REDUCTION(+:tmp)
+        for (size_t j = 0 ; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 4) ; j++) {
+          const size_t e = j + (i * 8);
+          tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e]) : (b_.u8[e] - a_.u8[e]);
+        }
+        r_.i64[i] = tmp;
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sad_epu8
+  #define _mm256_sad_epu8(a, b) simde_mm256_sad_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_shuffle_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_shuffle_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_shuffle_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_shuffle_epi8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2) ; i++) {
+        r_.u8[  i   ] = (b_.u8[  i   ] & 0x80) ? 0 : a_.u8[(b_.u8[  i   ] & 0x0f)     ];
+        r_.u8[i + 16] = (b_.u8[i + 16] & 0x80) ? 0 : a_.u8[(b_.u8[i + 16] & 0x0f) + 16];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shuffle_epi8
+  #define _mm256_shuffle_epi8(a, b) simde_mm256_shuffle_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_shuffle_epi32 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  for (size_t i = 0 ; i < ((sizeof(r_.i32) / sizeof(r_.i32[0])) / 2) ; i++) {
+    r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
+  }
+  for (size_t i = 0 ; i < ((sizeof(r_.i32) / sizeof(r_.i32[0])) / 2) ; i++) {
+    r_.i32[i + 4] = a_.i32[((imm8 >> (i * 2)) & 3) + 4];
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_shuffle_epi32(a, imm8) _mm256_shuffle_epi32(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(__PGI)
+#  define simde_mm256_shuffle_epi32(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_shuffle_epi32(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+       simde_mm_shuffle_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#  define simde_mm256_shuffle_epi32(a, imm8) (__extension__ ({ \
+      const simde__m256i_private simde__tmp_a_ = simde__m256i_to_private(a); \
+      simde__m256i_from_private((simde__m256i_private) { .i32 = \
+          SIMDE_SHUFFLE_VECTOR_(32, 32, \
+                                (simde__tmp_a_).i32, \
+                                (simde__tmp_a_).i32, \
+                                ((imm8)     ) & 3, \
+                                ((imm8) >> 2) & 3, \
+                                ((imm8) >> 4) & 3, \
+                                ((imm8) >> 6) & 3, \
+                                (((imm8)     ) & 3) + 4, \
+                                (((imm8) >> 2) & 3) + 4, \
+                                (((imm8) >> 4) & 3) + 4, \
+                                (((imm8) >> 6) & 3) + 4) }); }))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shuffle_epi32
+  #define _mm256_shuffle_epi32(a, imm8) simde_mm256_shuffle_epi32(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_shufflehi_epi16(a, imm8) _mm256_shufflehi_epi16(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_shufflehi_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_shufflehi_epi16(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+       simde_mm_shufflehi_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#  define simde_mm256_shufflehi_epi16(a, imm8) (__extension__ ({ \
+      const simde__m256i_private simde__tmp_a_ = simde__m256i_to_private(a); \
+      simde__m256i_from_private((simde__m256i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 32, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          0, 1, 2, 3, \
+          (((imm8)     ) & 3) + 4, \
+          (((imm8) >> 2) & 3) + 4, \
+          (((imm8) >> 4) & 3) + 4, \
+          (((imm8) >> 6) & 3) + 4, \
+          8, 9, 10, 11, \
+          ((((imm8)     ) & 3) + 8 + 4), \
+          ((((imm8) >> 2) & 3) + 8 + 4), \
+          ((((imm8) >> 4) & 3) + 8 + 4), \
+          ((((imm8) >> 6) & 3) + 8 + 4) \
+          ) }); }))
+#else
+#  define simde_mm256_shufflehi_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_shufflehi_epi16(simde_mm256_extracti128_si256(a, 1), imm8), \
+       simde_mm_shufflehi_epi16(simde_mm256_extracti128_si256(a, 0), imm8))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shufflehi_epi16
+  #define _mm256_shufflehi_epi16(a, imm8) simde_mm256_shufflehi_epi16(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_shufflelo_epi16(a, imm8) _mm256_shufflelo_epi16(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_shufflelo_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_shufflelo_epi16(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+       simde_mm_shufflelo_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#  define simde_mm256_shufflelo_epi16(a, imm8) (__extension__ ({ \
+      const simde__m256i_private simde__tmp_a_ = simde__m256i_to_private(a); \
+      simde__m256i_from_private((simde__m256i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 32, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          (((imm8)     ) & 3), \
+          (((imm8) >> 2) & 3), \
+          (((imm8) >> 4) & 3), \
+          (((imm8) >> 6) & 3), \
+          4, 5, 6, 7, \
+          ((((imm8)     ) & 3) + 8), \
+          ((((imm8) >> 2) & 3) + 8), \
+          ((((imm8) >> 4) & 3) + 8), \
+          ((((imm8) >> 6) & 3) + 8), \
+          12, 13, 14, 15) }); }))
+#else
+#  define simde_mm256_shufflelo_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_shufflelo_epi16(simde_mm256_extracti128_si256(a, 1), imm8), \
+       simde_mm_shufflelo_epi16(simde_mm256_extracti128_si256(a, 0), imm8))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_shufflelo_epi16
+  #define _mm256_shufflelo_epi16(a, imm8) simde_mm256_shufflelo_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sign_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sign_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = (b_.i8[i] < INT32_C(0)) ? -a_.i8[i] : a_.i8[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sign_epi8
+  #define _mm256_sign_epi8(a, b) simde_mm256_sign_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sign_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sign_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = (b_.i16[i] < INT32_C(0)) ? -a_.i16[i] : a_.i16[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sign_epi16
+  #define _mm256_sign_epi16(a, b) simde_mm256_sign_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sign_epi32(simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sign_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+      r_.i32[i] = (b_.i32[i] < INT32_C(0)) ? -a_.i32[i] : a_.i32[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sign_epi32
+  #define _mm256_sign_epi32(a, b) simde_mm256_sign_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sll_epi16 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sll_epi16(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sll_epi16(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_sll_epi16(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 15)
+        return simde_mm256_setzero_si256();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i16 = a_.i16 << HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sll_epi16
+  #define _mm256_sll_epi16(a, count) simde_mm256_sll_epi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sll_epi32 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sll_epi32(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sll_epi32(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_sll_epi32(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 31)
+        return simde_mm256_setzero_si256();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i32 = a_.i32 << HEDLEY_STATIC_CAST(int32_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, a_.i32[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sll_epi32
+  #define _mm256_sll_epi32(a, count) simde_mm256_sll_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sll_epi64 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sll_epi64(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sll_epi64(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_sll_epi64(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 63)
+        return simde_mm256_setzero_si256();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i64 = a_.i64 << HEDLEY_STATIC_CAST(int64_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.i64[i] = HEDLEY_STATIC_CAST(int64_t, a_.i64[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sll_epi64
+  #define _mm256_sll_epi64(a, count) simde_mm256_sll_epi64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_slli_epi16 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  /* Note: There is no consistency in how compilers handle values outside of
+     the expected range, hence the discrepancy between what we allow and what
+     Intel specifies.  Some compilers will return 0, others seem to just mask
+     off everything outside of the range. */
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned short, imm8));
+    for (size_t i = 0 ; i < (sizeof(a_.altivec_i16) / sizeof(a_.altivec_i16[0])) ; i++) {
+      r_.altivec_i16[i] = vec_sl(a_.altivec_i16[i], sv);
+    }
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 << HEDLEY_STATIC_CAST(int16_t, imm8);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << (imm8 & 0xff));
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_slli_epi16(a, imm8) _mm256_slli_epi16(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_slli_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_slli_epi16(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_slli_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_slli_epi16
+  #define _mm256_slli_epi16(a, imm8) simde_mm256_slli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_slli_epi32 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 31) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8));
+    for (size_t i = 0 ; i < (sizeof(a_.altivec_i32) / sizeof(a_.altivec_i32[0])) ; i++) {
+      r_.altivec_i32[i] = vec_sl(a_.altivec_i32[i], sv);
+    }
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i32 = a_.i32 << HEDLEY_STATIC_CAST(int32_t, imm8);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_slli_epi32(a, imm8) _mm256_slli_epi32(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_slli_epi32(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_slli_epi32(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_slli_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_slli_epi32
+  #define _mm256_slli_epi32(a, imm8) simde_mm256_slli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_slli_epi64 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 63) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  r_.i64 = a_.i64 << HEDLEY_STATIC_CAST(int64_t, imm8);
+#else
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+    r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
+  }
+#endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_slli_epi64(a, imm8) _mm256_slli_epi64(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_slli_epi64(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_slli_epi64(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_slli_epi64(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_slli_epi64
+  #define _mm256_slli_epi64(a, imm8) simde_mm256_slli_epi64(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_slli_si256 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  for (size_t h = 0 ; h < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; h++) {
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.m128i_private[h].i8) / sizeof(r_.m128i_private[h].i8[0])) ; i++) {
+      const int e = HEDLEY_STATIC_CAST(int, i) - imm8;
+      r_.m128i_private[h].i8[i] = (e >= 0) ? a_.m128i_private[h].i8[e] : 0;
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_slli_si256(a, imm8) _mm256_slli_si256(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(__PGI)
+#  define simde_mm256_slli_si256(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_slli_si128(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_slli_si128(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm256_slli_si256(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_bslli_si128(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+       simde_mm_bslli_si128(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_slli_si256
+  #define _mm256_slli_si256(a, imm8) simde_mm256_slli_si256(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sllv_epi32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = HEDLEY_STATIC_CAST(__typeof__(r_.u32), (b_.u32 < 32) & (a_.u32 << b_.u32));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (b_.u32[i] < 32) ? (a_.u32[i] << b_.u32[i]) : 0;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_sllv_epi32(a, b) _mm_sllv_epi32(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sllv_epi32
+  #define _mm_sllv_epi32(a, b) simde_mm_sllv_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sllv_epi32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = HEDLEY_STATIC_CAST(__typeof__(r_.u32), (b_.u32 < 32) & (a_.u32 << b_.u32));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (b_.u32[i] < 32) ? (a_.u32[i] << b_.u32[i]) : 0;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_sllv_epi32(a, b) _mm256_sllv_epi32(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sllv_epi32
+  #define _mm256_sllv_epi32(a, b) simde_mm256_sllv_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sllv_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u64 = HEDLEY_STATIC_CAST(__typeof__(r_.u64), (b_.u64 < 64) & (a_.u64 << b_.u64));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (b_.u64[i] < 64) ? (a_.u64[i] << b_.u64[i]) : 0;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_sllv_epi64(a, b) _mm_sllv_epi64(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sllv_epi64
+  #define _mm_sllv_epi64(a, b) simde_mm_sllv_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sllv_epi64 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u64 = HEDLEY_STATIC_CAST(__typeof__(r_.u64), (b_.u64 < 64) & (a_.u64 << b_.u64));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (b_.u64[i] < 64) ? (a_.u64[i] << b_.u64[i]) : 0;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_sllv_epi64(a, b) _mm256_sllv_epi64(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sllv_epi64
+  #define _mm256_sllv_epi64(a, b) simde_mm256_sllv_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sra_epi16 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sra_epi16(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sra_epi16(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_sra_epi16(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+
+      if (shift > 15) shift = 15;
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = a_.i16[i] >> shift;
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sra_epi16
+  #define _mm256_sra_epi16(a, count) simde_mm256_sra_epi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sra_epi32 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sra_epi32(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sra_epi32(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_sra_epi32(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+
+      if (shift > 31) shift = 31;
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i32 = a_.i32 >> HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = a_.i32[i] >> shift;
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sra_epi32
+  #define _mm256_sra_epi32(a, count) simde_mm256_sra_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srai_epi16 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+  unsigned int shift = HEDLEY_STATIC_CAST(unsigned int, imm8);
+
+  if (shift > 15) shift = 15;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[i] >> shift;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srai_epi16(a, imm8) _mm256_srai_epi16(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_srai_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srai_epi16(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srai_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srai_epi16
+  #define _mm256_srai_epi16(a, imm8) simde_mm256_srai_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srai_epi32 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+  unsigned int shift = HEDLEY_STATIC_CAST(unsigned int, imm8);
+
+  if (shift > 31) shift = 31;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i32 = a_.i32 >> HEDLEY_STATIC_CAST(int16_t, shift);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] >> shift;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srai_epi32(a, imm8) _mm256_srai_epi32(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_srai_epi32(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srai_epi32(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srai_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srai_epi32
+  #define _mm256_srai_epi32(a, imm8) simde_mm256_srai_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srav_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm_srav_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      uint32_t shift = HEDLEY_STATIC_CAST(uint32_t, count_.i32[i]);
+      if (shift > 31) shift = 31;
+      r_.i32[i] = a_.i32[i] >> shift;
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_srav_epi32
+  #define _mm_srav_epi32(a, count) simde_mm_srav_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srav_epi32 (simde__m256i a, simde__m256i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_srav_epi32(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      count_ = simde__m256i_to_private(count);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        uint32_t shift = HEDLEY_STATIC_CAST(uint32_t, count_.i32[i]);
+        if (shift > 31) shift = 31;
+        r_.i32[i] = a_.i32[i] >> shift;
+      }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srav_epi32
+  #define _mm256_srav_epi32(a, count) simde_mm256_srav_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srl_epi16 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_srl_epi16(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_srl_epi16(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_srl_epi16(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t , (count_.i64[0] > 16 ? 16 : count_.i64[0]));
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u16 = a_.u16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.u16[i] = a_.u16[i] >> (shift);
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srl_epi16
+  #define _mm256_srl_epi16(a, count) simde_mm256_srl_epi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srl_epi32 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_srl_epi32(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_srl_epi32(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_srl_epi32(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t , (count_.i64[0] > 32 ? 32 : count_.i64[0]));
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u32 = a_.u32 >> HEDLEY_STATIC_CAST(int32_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.u32[i] = a_.u32[i] >> (shift);
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srl_epi32
+  #define _mm256_srl_epi32(a, count) simde_mm256_srl_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srl_epi64 (simde__m256i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_srl_epi64(a, count);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_srl_epi64(a_.m128i[0], count);
+      r_.m128i[1] = simde_mm_srl_epi64(a_.m128i[1], count);
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t , (count_.i64[0] > 64 ? 64 : count_.i64[0]));
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u64 = a_.u64 >> HEDLEY_STATIC_CAST(int64_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.u64[i] = a_.u64[i] >> (shift);
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srl_epi64
+  #define _mm256_srl_epi64(a, count) simde_mm256_srl_epi64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srli_epi16 (simde__m256i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  if (imm8 > 15)
+    return simde_mm256_setzero_si256();
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned short, imm8));
+    for (size_t i = 0 ; i < (sizeof(a_.altivec_u16) / sizeof(a_.altivec_u16[0])) ; i++) {
+      r_.altivec_u16[i] = vec_sr(a_.altivec_u16[i], sv);
+    }
+  #else
+    if (HEDLEY_STATIC_CAST(unsigned int, imm8) > 15) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u16 = a_.u16 >> HEDLEY_STATIC_CAST(int16_t, imm8);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+          r_.u16[i] = a_.u16[i] >> imm8;
+        }
+      #endif
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srli_epi16(a, imm8) _mm256_srli_epi16(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_srli_epi16(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srli_epi16(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srli_epi16(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srli_epi16
+  #define _mm256_srli_epi16(a, imm8) simde_mm256_srli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srli_epi32 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) sv = vec_splats(HEDLEY_STATIC_CAST(unsigned int, imm8));
+    for (size_t i = 0 ; i < (sizeof(a_.altivec_u32) / sizeof(a_.altivec_u32[0])) ; i++) {
+      r_.altivec_u32[i] = vec_sr(a_.altivec_u32[i], sv);
+    }
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = a_.u32 >> HEDLEY_STATIC_CAST(int16_t, imm8);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] >> imm8;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srli_epi32(a, imm8) _mm256_srli_epi32(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_srli_epi32(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srli_epi32(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srli_epi32(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srli_epi32
+  #define _mm256_srli_epi32(a, imm8) simde_mm256_srli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srli_epi64 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+#if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+  r_.u64 = a_.u64 >> HEDLEY_STATIC_CAST(int32_t, imm8);
+#else
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+    r_.u64[i] = a_.u64[i] >> imm8;
+  }
+#endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srli_epi64(a, imm8) _mm256_srli_epi64(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+#  define simde_mm256_srli_epi64(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srli_epi64(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srli_epi64(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srli_epi64
+  #define _mm256_srli_epi64(a, imm8) simde_mm256_srli_epi64(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srli_si256 (simde__m256i a, const int imm8) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a);
+
+  for (size_t h = 0 ; h < (sizeof(r_.m128i_private) / sizeof(r_.m128i_private[0])) ; h++) {
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.m128i_private[h].i8) / sizeof(r_.m128i_private[h].i8[0])) ; i++) {
+      const int e = imm8 + HEDLEY_STATIC_CAST(int, i);
+      r_.m128i_private[h].i8[i] = (e < 16) ? a_.m128i_private[h].i8[e] : 0;
+    }
+  }
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+#  define simde_mm256_srli_si256(a, imm8) _mm256_srli_si256(a, imm8)
+#elif SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(__PGI)
+#  define simde_mm256_srli_si256(a, imm8) \
+     simde_mm256_set_m128i( \
+         simde_mm_srli_si128(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+         simde_mm_srli_si128(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm256_srli_si256(a, imm8) \
+     simde_mm256_set_m128i( \
+       simde_mm_bsrli_si128(simde_mm256_extracti128_si256(a, 1), (imm8)), \
+       simde_mm_bsrli_si128(simde_mm256_extracti128_si256(a, 0), (imm8)))
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srli_si256
+  #define _mm256_srli_si256(a, imm8) simde_mm256_srli_si256(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srlv_epi32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = HEDLEY_STATIC_CAST(__typeof__(r_.u32), (b_.u32 < 32) & (a_.u32 >> b_.u32));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (b_.u32[i] < 32) ? (a_.u32[i] >> b_.u32[i]) : 0;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_srlv_epi32(a, b) _mm_srlv_epi32(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_srlv_epi32
+  #define _mm_srlv_epi32(a, b) simde_mm_srlv_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srlv_epi32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = HEDLEY_STATIC_CAST(__typeof__(r_.u32), (b_.u32 < 32) & (a_.u32 >> b_.u32));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (b_.u32[i] < 32) ? (a_.u32[i] >> b_.u32[i]) : 0;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_srlv_epi32(a, b) _mm256_srlv_epi32(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srlv_epi32
+  #define _mm256_srlv_epi32(a, b) simde_mm256_srlv_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srlv_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u64 = HEDLEY_STATIC_CAST(__typeof__(r_.u64), (b_.u64 < 64) & (a_.u64 >> b_.u64));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (b_.u64[i] < 64) ? (a_.u64[i] >> b_.u64[i]) : 0;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm_srlv_epi64(a, b) _mm_srlv_epi64(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_srlv_epi64
+  #define _mm_srlv_epi64(a, b) simde_mm_srlv_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_srlv_epi64 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u64 = HEDLEY_STATIC_CAST(__typeof__(r_.u64), (b_.u64 < 64) & (a_.u64 >> b_.u64));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (b_.u64[i] < 64) ? (a_.u64[i] >> b_.u64[i]) : 0;
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX2_NATIVE)
+  #define simde_mm256_srlv_epi64(a, b) _mm256_srlv_epi64(a, b)
+#endif
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_srlv_epi64
+  #define _mm256_srlv_epi64(a, b) simde_mm256_srlv_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_stream_load_si256 (const simde__m256i* mem_addr) {
+  simde_assert_aligned(32, mem_addr);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_stream_load_si256(HEDLEY_CONST_CAST(simde__m256i*, mem_addr));
+  #else
+    /* Use memcpy to avoid aliasing; data must still be 32-byte aligned */
+    simde__m256i r;
+    simde_memcpy(&r, mem_addr, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+#  define _mm256_stream_load_si256(mem_addr) simde_mm256_stream_load_si256(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sub_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sub_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sub_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_sub_epi8(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 - b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] - b_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_epi8
+  #define _mm256_sub_epi8(a, b) simde_mm256_sub_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sub_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sub_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sub_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_sub_epi16(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 - b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] - b_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_epi16
+  #define _mm256_sub_epi16(a, b) simde_mm256_sub_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hsub_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hsub_epi16(a, b);
+  #else
+    return simde_mm256_sub_epi16(simde_x_mm256_deinterleaveeven_epi16(a, b), simde_x_mm256_deinterleaveodd_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hsub_epi16
+  #define _mm256_hsub_epi16(a, b) simde_mm256_hsub_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sub_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sub_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sub_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_sub_epi32(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 - b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] - b_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_epi32
+  #define _mm256_sub_epi32(a, b) simde_mm256_sub_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hsub_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hsub_epi32(a, b);
+  #else
+    return simde_mm256_sub_epi32(simde_x_mm256_deinterleaveeven_epi32(a, b), simde_x_mm256_deinterleaveodd_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hsub_epi32
+  #define _mm256_hsub_epi32(a, b) simde_mm256_hsub_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_sub_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_sub_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_sub_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_sub_epi64(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] - b_.i64[i];
+      }
+    #endif
+
+  return simde__m256i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sub_epi64
+  #define _mm256_sub_epi64(a, b) simde_mm256_sub_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_sub_epu32 (simde__m256i a, simde__m256i b) {
+  simde__m256i_private
+    r_,
+    a_ = simde__m256i_to_private(a),
+    b_ = simde__m256i_to_private(b);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.u32 = a_.u32 - b_.u32;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] - b_.u32[i];
+    }
+  #endif
+
+  return simde__m256i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_subs_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_subs_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_subs_epi8(a_.m128i[i], b_.m128i[i]);
+        }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        const int32_t tmp =
+          HEDLEY_STATIC_CAST(int16_t, a_.i8[i]) -
+          HEDLEY_STATIC_CAST(int16_t, b_.i8[i]);
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, ((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN) : INT8_MAX));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_subs_epi8
+  #define _mm256_subs_epi8(a, b) simde_mm256_subs_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_subs_epi16(simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_subs_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128) && !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_subs_epi16(a_.m128i[i], b_.m128i[i]);
+        }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int32_t tmp =
+          HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) -
+          HEDLEY_STATIC_CAST(int32_t, b_.i16[i]);
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((tmp < INT16_MAX) ? ((tmp > INT16_MIN) ? tmp : INT16_MIN) : INT16_MAX));
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_subs_epi16
+  #define _mm256_subs_epi16(a, b) simde_mm256_subs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_hsubs_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_hsubs_epi16(a, b);
+  #else
+    return simde_mm256_subs_epi16(simde_x_mm256_deinterleaveeven_epi16(a, b), simde_x_mm256_deinterleaveodd_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hsubs_epi16
+  #define _mm256_hsubs_epi16(a, b) simde_mm256_hsubs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_subs_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_subs_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_subs_epu8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_subs_epu8(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? (a_.u8[i] - b_.u8[i]) : UINT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_subs_epu8
+  #define _mm256_subs_epu8(a, b) simde_mm256_subs_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_subs_epu16(simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_subs_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_subs_epu16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_subs_epu16(a_.m128i[1], b_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] > b_.u16[i]) ? (a_.u16[i] - b_.u16[i]) : UINT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_subs_epu16
+  #define _mm256_subs_epu16(a, b) simde_mm256_subs_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_x_mm256_test_all_ones (simde__m256i a) {
+  simde__m256i_private a_ = simde__m256i_to_private(a);
+  int r;
+  int_fast32_t r_ = ~HEDLEY_STATIC_CAST(int_fast32_t, 0);
+
+  SIMDE_VECTORIZE_REDUCTION(&:r_)
+  for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+    r_ &= a_.i32f[i];
+  }
+
+  r = (r_ == ~HEDLEY_STATIC_CAST(int_fast32_t, 0));
+
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpacklo_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpacklo_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 32, a_.i8, b_.i8,
+           0, 32,  1, 33,  2, 34,  3, 35,
+           4, 36,  5, 37,  6, 38,  7, 39,
+          16, 48, 17, 49, 18, 50, 19, 51,
+          20, 52, 21, 53, 22, 54, 23, 55);
+    #else
+      r_.m128i[0] = simde_mm_unpacklo_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpacklo_epi8(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_epi8
+  #define _mm256_unpacklo_epi8(a, b) simde_mm256_unpacklo_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpacklo_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpacklo_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 =SIMDE_SHUFFLE_VECTOR_(16, 32, a_.i16, b_.i16,
+        0, 16, 1, 17, 2, 18, 3, 19, 8, 24, 9, 25, 10, 26, 11, 27);
+    #else
+      r_.m128i[0] = simde_mm_unpacklo_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpacklo_epi16(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_epi16
+  #define _mm256_unpacklo_epi16(a, b) simde_mm256_unpacklo_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpacklo_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpacklo_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.i32, b_.i32,
+                                    0, 8, 1, 9, 4, 12, 5, 13);
+    #else
+      r_.m128i[0] = simde_mm_unpacklo_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpacklo_epi32(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_epi32
+  #define _mm256_unpacklo_epi32(a, b) simde_mm256_unpacklo_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpacklo_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpacklo_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.i64, b_.i64, 0, 4, 2, 6);
+    #else
+      r_.m128i[0] = simde_mm_unpacklo_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpacklo_epi64(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpacklo_epi64
+  #define _mm256_unpacklo_epi64(a, b) simde_mm256_unpacklo_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpackhi_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpackhi_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 32, a_.i8, b_.i8,
+           8, 40,  9, 41, 10, 42, 11, 43,
+          12, 44, 13, 45, 14, 46, 15, 47,
+          24, 56, 25, 57, 26, 58, 27, 59,
+          28, 60, 29, 61, 30, 62, 31, 63);
+    #else
+      r_.m128i[0] = simde_mm_unpackhi_epi8(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpackhi_epi8(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_epi8
+  #define _mm256_unpackhi_epi8(a, b) simde_mm256_unpackhi_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpackhi_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpackhi_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 32, a_.i16, b_.i16,
+         4, 20,  5, 21,  6, 22,  7, 23,
+        12, 28, 13, 29, 14, 30, 15, 31);
+    #else
+      r_.m128i[0] = simde_mm_unpackhi_epi16(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpackhi_epi16(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_epi16
+  #define _mm256_unpackhi_epi16(a, b) simde_mm256_unpackhi_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpackhi_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpackhi_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 32, a_.i32, b_.i32,
+                                    2, 10, 3, 11, 6, 14, 7, 15);
+    #else
+      r_.m128i[0] = simde_mm_unpackhi_epi32(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpackhi_epi32(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_epi32
+  #define _mm256_unpackhi_epi32(a, b) simde_mm256_unpackhi_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_unpackhi_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_unpackhi_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 32, a_.i64, b_.i64, 1, 5, 3, 7);
+    #else
+      r_.m128i[0] = simde_mm_unpackhi_epi64(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_unpackhi_epi64(a_.m128i[1], b_.m128i[1]);
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_unpackhi_epi64
+  #define _mm256_unpackhi_epi64(a, b) simde_mm256_unpackhi_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_xor_si256 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    return _mm256_xor_si256(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_xor_si128(a_.m128i[0], b_.m128i[0]);
+      r_.m128i[1] = simde_mm_xor_si128(a_.m128i[1], b_.m128i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] ^ b_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX2_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_xor_si256
+  #define _mm256_xor_si256(a, b) simde_mm256_xor_si256(a, b)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX2_H) */

--- a/2.0/simde/x86/avx512.h
+++ b/2.0/simde/x86/avx512.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_H)
+#define SIMDE_X86_AVX512_H
+
+#include "avx512/types.h"
+
+#include "avx512/abs.h"
+#include "avx512/add.h"
+#include "avx512/adds.h"
+#include "avx512/and.h"
+#include "avx512/andnot.h"
+#include "avx512/avg.h"
+#include "avx512/blend.h"
+#include "avx512/broadcast.h"
+#include "avx512/cast.h"
+#include "avx512/cmp.h"
+#include "avx512/cmpeq.h"
+#include "avx512/cmpge.h"
+#include "avx512/cmpgt.h"
+#include "avx512/cmple.h"
+#include "avx512/cmplt.h"
+#include "avx512/copysign.h"
+#include "avx512/cvt.h"
+#include "avx512/cvts.h"
+#include "avx512/div.h"
+#include "avx512/extract.h"
+#include "avx512/fmadd.h"
+#include "avx512/fmsub.h"
+#include "avx512/fnmadd.h"
+#include "avx512/fnmsub.h"
+#include "avx512/insert.h"
+#include "avx512/load.h"
+#include "avx512/loadu.h"
+#include "avx512/lzcnt.h"
+#include "avx512/max.h"
+#include "avx512/min.h"
+#include "avx512/mov.h"
+#include "avx512/mov_mask.h"
+#include "avx512/movm.h"
+#include "avx512/mul.h"
+#include "avx512/mulhi.h"
+#include "avx512/mulhrs.h"
+#include "avx512/mullo.h"
+#include "avx512/negate.h"
+#include "avx512/or.h"
+#include "avx512/packs.h"
+#include "avx512/packus.h"
+#include "avx512/permutexvar.h"
+#include "avx512/permutex2var.h"
+#include "avx512/sad.h"
+#include "avx512/set.h"
+#include "avx512/set1.h"
+#include "avx512/set4.h"
+#include "avx512/setr.h"
+#include "avx512/setr4.h"
+#include "avx512/setzero.h"
+#include "avx512/setone.h"
+#include "avx512/shuffle.h"
+#include "avx512/sll.h"
+#include "avx512/slli.h"
+#include "avx512/sllv.h"
+#include "avx512/sqrt.h"
+#include "avx512/sra.h"
+#include "avx512/srai.h"
+#include "avx512/srav.h"
+#include "avx512/srl.h"
+#include "avx512/srli.h"
+#include "avx512/srlv.h"
+#include "avx512/store.h"
+#include "avx512/storeu.h"
+#include "avx512/sub.h"
+#include "avx512/subs.h"
+#include "avx512/test.h"
+#include "avx512/unpacklo.h"
+#include "avx512/unpackhi.h"
+#include "avx512/xor.h"
+#include "avx512/xorsign.h"
+
+#endif

--- a/2.0/simde/x86/avx512/abs.h
+++ b/2.0/simde/x86/avx512/abs.h
@@ -1,0 +1,499 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_ABS_H)
+#define SIMDE_X86_AVX512_ABS_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_abs_epi8(simde__m128i src, simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_abs_epi8(src, k, a);
+  #else
+    return simde_mm_mask_mov_epi8(src, k, simde_mm_abs_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_abs_epi8
+  #define _mm_mask_abs_epi8(src, k, a) simde_mm_mask_abs_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_abs_epi8(simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_abs_epi8(k, a);
+  #else
+    return simde_mm_maskz_mov_epi8(k, simde_mm_abs_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_abs_epi8
+  #define _mm_maskz_abs_epi8(k, a) simde_mm_maskz_abs_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_abs_epi16(simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_abs_epi16(src, k, a);
+  #else
+    return simde_mm_mask_mov_epi16(src, k, simde_mm_abs_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_abs_epi16
+  #define _mm_mask_abs_epi16(src, k, a) simde_mm_mask_abs_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_abs_epi16(simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_abs_epi16(k, a);
+  #else
+    return simde_mm_maskz_mov_epi16(k, simde_mm_abs_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_abs_epi16
+  #define _mm_maskz_abs_epi16(k, a) simde_mm_maskz_abs_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_abs_epi32(simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_abs_epi32(src, k, a);
+  #else
+    return simde_mm_mask_mov_epi32(src, k, simde_mm_abs_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_abs_epi32
+  #define _mm_mask_abs_epi32(src, k, a) simde_mm_mask_abs_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_abs_epi32(simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_abs_epi32(k, a);
+  #else
+    return simde_mm_maskz_mov_epi32(k, simde_mm_abs_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_abs_epi32
+  #define _mm_maskz_abs_epi32(k, a) simde_mm_maskz_abs_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_abs_epi64(simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_abs_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+      r_.i64[i] = (a_.i64[i] < INT64_C(0)) ? -a_.i64[i] : a_.i64[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_abs_epi64
+  #define _mm_abs_epi64(a) simde_mm_abs_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_abs_epi64(simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_abs_epi64(src, k, a);
+  #else
+    return simde_mm_mask_mov_epi64(src, k, simde_mm_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_abs_epi64
+  #define _mm_mask_abs_epi64(src, k, a) simde_mm_mask_abs_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_abs_epi64(simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_abs_epi64(k, a);
+  #else
+    return simde_mm_maskz_mov_epi64(k, simde_mm_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_abs_epi64
+  #define _mm_maskz_abs_epi64(k, a) simde_mm_maskz_abs_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_abs_epi64(simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_abs_epi64(a);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+      r_.i64[i] = (a_.i64[i] < INT64_C(0)) ? -a_.i64[i] : a_.i64[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_abs_epi64
+  #define _mm256_abs_epi64(a) simde_mm256_abs_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_abs_epi64(simde__m256i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_abs_epi64(src, k, a);
+  #else
+    return simde_mm256_mask_mov_epi64(src, k, simde_mm256_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_abs_epi64
+  #define _mm256_mask_abs_epi64(src, k, a) simde_mm256_mask_abs_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_abs_epi64(simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_abs_epi64(k, a);
+  #else
+    return simde_mm256_maskz_mov_epi64(k, simde_mm256_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_abs_epi64
+  #define _mm256_maskz_abs_epi64(k, a) simde_mm256_maskz_abs_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_abs_epi8 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_abs_epi8(a);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = (a_.i8[i] < INT32_C(0)) ? -a_.i8[i] : a_.i8[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_epi8
+  #define _mm512_abs_epi8(a) simde_mm512_abs_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_abs_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_abs_epi8(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_abs_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_abs_epi8
+  #define _mm512_mask_abs_epi8(src, k, a) simde_mm512_mask_abs_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_abs_epi8 (simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_abs_epi8(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_abs_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_abs_epi8
+  #define _mm512_maskz_abs_epi8(k, a) simde_mm512_maskz_abs_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_abs_epi16 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_abs_epi16(a);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = (a_.i16[i] < INT32_C(0)) ? -a_.i16[i] : a_.i16[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_epi16
+  #define _mm512_abs_epi16(a) simde_mm512_abs_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_abs_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_abs_epi16(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_abs_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_abs_epi16
+  #define _mm512_mask_abs_epi16(src, k, a) simde_mm512_mask_abs_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_abs_epi16 (simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_abs_epi16(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_abs_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_abs_epi16
+  #define _mm512_maskz_abs_epi16(k, a) simde_mm512_maskz_abs_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_abs_epi32(simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_abs_epi32(a);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+      r_.i32[i] = (a_.i32[i] < INT64_C(0)) ? -a_.i32[i] : a_.i32[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_epi32
+  #define _mm512_abs_epi32(a) simde_mm512_abs_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_abs_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_abs_epi32(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_abs_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_abs_epi32(src, k, a) simde_mm512_mask_abs_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_abs_epi32(simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_abs_epi32(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_abs_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_abs_epi32(k, a) simde_mm512_maskz_abs_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_abs_epi64(simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_abs_epi64(a);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i64) / sizeof(r_.i64[0])); i++) {
+      r_.i64[i] = (a_.i64[i] < INT64_C(0)) ? -a_.i64[i] : a_.i64[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_epi64
+  #define _mm512_abs_epi64(a) simde_mm512_abs_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_abs_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_abs_epi64(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_abs_epi64(src, k, a) simde_mm512_mask_abs_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_abs_epi64(simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_abs_epi64(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_abs_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_abs_epi64(k, a) simde_mm512_maskz_abs_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_abs_ps(simde__m512 v2) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_abs_ps(v2);
+  #else
+    simde__m512_private
+      r_,
+      v2_ = simde__m512_to_private(v2);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.f32) / sizeof(r_.f32[0])); i++) {
+      r_.f32[i] = (v2_.f32[i] < INT64_C(0)) ? -v2_.f32[i] : v2_.f32[i];
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_ps
+  #define _mm512_abs_ps(v2) simde_mm512_abs_ps(v2)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_abs_ps(simde__m512 src, simde__mmask16 k, simde__m512 v2) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_mask_abs_ps(src, k, v2);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_abs_ps(v2));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_abs_ps(src, k, v2) simde_mm512_mask_abs_ps(src, k, v2)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_abs_pd(simde__m512d v2) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_abs_pd(v2);
+  #else
+    simde__m512d_private
+      r_,
+      v2_ = simde__m512d_to_private(v2);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.f64) / sizeof(r_.f64[0])); i++) {
+      r_.f64[i] = (v2_.f64[i] < INT64_C(0)) ? -v2_.f64[i] : v2_.f64[i];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_abs_pd
+  #define _mm512_abs_pd(v2) simde_mm512_abs_pd(v2)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_abs_pd(simde__m512d src, simde__mmask8 k, simde__m512d v2) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+    return _mm512_mask_abs_pd(src, k, v2);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_abs_pd(v2));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_abs_pd(src, k, v2) simde_mm512_mask_abs_pd(src, k, v2)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_ABS_H) */

--- a/2.0/simde/x86/avx512/add.h
+++ b/2.0/simde/x86/avx512/add.h
@@ -1,0 +1,641 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_ADD_H)
+#define SIMDE_X86_AVX512_ADD_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_add_epi8(simde__m128i src, simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_add_epi8(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi8(src, k, simde_mm_add_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_add_epi8
+  #define _mm_mask_add_epi8(src, k, a, b) simde_mm_mask_add_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_add_epi8(simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_add_epi8(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi8(k, simde_mm_add_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_add_epi8
+  #define _mm_maskz_add_epi8(k, a, b) simde_mm_maskz_add_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_add_epi16(simde__m128i src, simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_add_epi16(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi16(src, k, simde_mm_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_add_epi16
+  #define _mm_mask_add_epi16(src, k, a, b) simde_mm_mask_add_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_add_epi16(simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_add_epi16(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi16(k, simde_mm_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_add_epi16
+  #define _mm_maskz_add_epi16(k, a, b) simde_mm_maskz_add_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_add_epi32(simde__m128i src, simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_add_epi32(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi32(src, k, simde_mm_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_add_epi32
+  #define _mm_mask_add_epi32(src, k, a, b) simde_mm_mask_add_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_add_epi32(simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_add_epi32(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi32(k, simde_mm_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_add_epi32
+  #define _mm_maskz_add_epi32(k, a, b) simde_mm_maskz_add_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_add_epi64(simde__m128i src, simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_add_epi64(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi64(src, k, simde_mm_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_add_epi64
+  #define _mm_mask_add_epi64(src, k, a, b) simde_mm_mask_add_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_add_epi64(simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_add_epi64(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi64(k, simde_mm_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_add_epi64
+  #define _mm_maskz_add_epi64(k, a, b) simde_mm_maskz_add_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_add_ss(simde__m128 src, simde__mmask8 k, simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return _mm_mask_add_ss(src, k, a, b);
+  #elif 1
+    simde__m128_private
+      src_ = simde__m128_to_private(src),
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      r_ = simde__m128_to_private(a);
+
+    r_.f32[0] = (k & 1) ? (a_.f32[0] + b_.f32[0]) : src_.f32[0];
+
+    return simde__m128_from_private(r_);
+  #else
+    return simde_mm_move_ss(a, simde_mm_mask_mov_ps(src, k, simde_mm_add_ps(a, b)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_add_ss
+  #define _mm_mask_add_ss(src, k, a, b) simde_mm_mask_add_ss(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_maskz_add_ss(simde__mmask8 k, simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+    return _mm_maskz_add_ss(k, a, b);
+  #elif 1
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      r_ = simde__m128_to_private(a);
+
+    r_.f32[0] = (k & 1) ? (a_.f32[0] + b_.f32[0]) : 0.0f;
+
+    return simde__m128_from_private(r_);
+  #else
+    return simde_mm_move_ss(a, simde_mm_maskz_mov_ps(k, simde_mm_add_ps(a, b)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_add_ss
+  #define _mm_maskz_add_ss(k, a, b) simde_mm_maskz_add_ss(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_add_epi16(simde__m256i src, simde__mmask16 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_mask_add_epi16(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi16(src, k, simde_mm256_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_add_epi16
+  #define _mm256_mask_add_epi16(src, k, a, b) simde_mm256_mask_add_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_add_epi16(simde__mmask16 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_maskz_add_epi16(k, a, b);
+  #else
+    return simde_mm256_maskz_mov_epi16(k, simde_mm256_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_add_epi16
+  #define _mm256_maskz_add_epi16(k, a, b) simde_mm256_maskz_add_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_add_epi32(simde__m256i src, simde__mmask8 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_add_epi32(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi32(src, k, simde_mm256_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_add_epi32
+  #define _mm256_mask_add_epi32(src, k, a, b) simde_mm256_mask_add_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_add_epi32(simde__mmask8 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_add_epi32(k, a, b);
+  #else
+    return simde_mm256_maskz_mov_epi32(k, simde_mm256_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_add_epi32
+  #define _mm256_maskz_add_epi32(k, a, b) simde_mm256_maskz_add_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_add_epi64(simde__m256i src, simde__mmask8 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_add_epi64(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi64(src, k, simde_mm256_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_add_epi64
+  #define _mm256_mask_add_epi64(src, k, a, b) simde_mm256_mask_add_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_add_epi64(simde__mmask8 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_add_epi64(k, a, b);
+  #else
+    return simde_mm256_maskz_mov_epi64(k, simde_mm256_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_add_epi64
+  #define _mm256_maskz_add_epi64(k, a, b) simde_mm256_maskz_add_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_add_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_add_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 + b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi8(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_epi8
+  #define _mm512_add_epi8(a, b) simde_mm512_add_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_add_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_add_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_add_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_epi8
+  #define _mm512_mask_add_epi8(src, k, a, b) simde_mm512_mask_add_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_add_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_add_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_add_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_epi8
+  #define _mm512_maskz_add_epi8(k, a, b) simde_mm512_maskz_add_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_add_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_add_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 + b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi16(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_epi16
+  #define _mm512_add_epi16(a, b) simde_mm512_add_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_add_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_add_epi16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_epi16
+  #define _mm512_mask_add_epi16(src, k, a, b) simde_mm512_mask_add_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_add_epi16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_add_epi16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_add_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_epi16
+  #define _mm512_maskz_add_epi16(k, a, b) simde_mm512_maskz_add_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_add_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_add_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_ARM_SVE_NATIVE)
+      const size_t n = sizeof(a_.i32) / sizeof(a_.i32[0]);
+      size_t i = 0;
+      svbool_t pg = svwhilelt_b32(i, n);
+      do {
+        svint32_t
+          va = svld1_s32(pg, &(a_.i32[i])),
+          vb = svld1_s32(pg, &(b_.i32[i]));
+        svst1_s32(pg, &(r_.i32[i]), svadd_s32_x(pg, va, vb));
+        i += svcntw();
+        pg = svwhilelt_b32(i, n);
+      } while (svptest_any(svptrue_b32(), pg));
+    #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi32(a_.m256i[i], b_.m256i[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 + b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi32(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_epi32
+  #define _mm512_add_epi32(a, b) simde_mm512_add_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_add_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_add_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_epi32
+  #define _mm512_mask_add_epi32(src, k, a, b) simde_mm512_mask_add_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_add_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_add_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_add_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_epi32
+  #define _mm512_maskz_add_epi32(k, a, b) simde_mm512_maskz_add_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_add_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_add_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi64(a_.m256i[i], b_.m256i[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 + b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_add_epi64(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_epi64
+  #define _mm512_add_epi64(a, b) simde_mm512_add_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_add_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_add_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_epi64
+  #define _mm512_mask_add_epi64(src, k, a, b) simde_mm512_mask_add_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_add_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_add_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_add_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_epi64
+  #define _mm512_maskz_add_epi64(k, a, b) simde_mm512_maskz_add_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_add_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_add_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 + b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_add_ps(a_.m256[i], b_.m256[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_ps
+  #define _mm512_add_ps(a, b) simde_mm512_add_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_add_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_add_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_add_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_ps
+  #define _mm512_mask_add_ps(src, k, a, b) simde_mm512_mask_add_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_add_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_add_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_add_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_ps
+  #define _mm512_maskz_add_ps(k, a, b) simde_mm512_maskz_add_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_add_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_add_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 + b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_add_pd(a_.m256d[i], b_.m256d[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_add_pd
+  #define _mm512_add_pd(a, b) simde_mm512_add_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_add_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_add_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_add_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_add_pd
+  #define _mm512_mask_add_pd(src, k, a, b) simde_mm512_mask_add_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_add_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_add_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_add_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_add_pd
+  #define _mm512_maskz_add_pd(k, a, b) simde_mm512_maskz_add_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_ADD_H) */

--- a/2.0/simde/x86/avx512/adds.h
+++ b/2.0/simde/x86/avx512/adds.h
@@ -1,0 +1,396 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_ADDS_H)
+#define SIMDE_X86_AVX512_ADDS_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_adds_epi8(simde__m128i src, simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_adds_epi8(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi8(src, k, simde_mm_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_adds_epi8
+  #define _mm_mask_adds_epi8(src, k, a, b) simde_mm_mask_adds_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_adds_epi8(simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_adds_epi8(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi8(k, simde_mm_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_adds_epi8
+  #define _mm_maskz_adds_epi8(k, a, b) simde_mm_maskz_adds_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_adds_epi16(simde__m128i src, simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_mask_adds_epi16(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi16(src, k, simde_mm_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_adds_epi16
+  #define _mm_mask_adds_epi16(src, k, a, b) simde_mm_mask_adds_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_adds_epi16(simde__mmask8 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_maskz_adds_epi16(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi16(k, simde_mm_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_adds_epi16
+  #define _mm_maskz_adds_epi16(k, a, b) simde_mm_maskz_adds_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_adds_epi8(simde__m256i src, simde__mmask32 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_mask_adds_epi8(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi8(src, k, simde_mm256_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_adds_epi8
+  #define _mm256_mask_adds_epi8(src, k, a, b) simde_mm256_mask_adds_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_adds_epi8(simde__mmask32 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_maskz_adds_epi8(k, a, b);
+  #else
+    return simde_mm256_maskz_mov_epi8(k, simde_mm256_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_adds_epi8
+  #define _mm256_maskz_adds_epi8(k, a, b) simde_mm256_maskz_adds_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_adds_epi16(simde__m256i src, simde__mmask16 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_mask_adds_epi16(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi16(src, k, simde_mm256_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_adds_epi16
+  #define _mm256_mask_adds_epi16(src, k, a, b) simde_mm256_mask_adds_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_adds_epi16(simde__mmask16 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_maskz_adds_epi16(k, a, b);
+  #else
+    return simde_mm256_maskz_mov_epi16(k, simde_mm256_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_adds_epi16
+  #define _mm256_maskz_adds_epi16(k, a, b) simde_mm256_maskz_adds_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_adds_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_adds_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_adds_epi8(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        const int16_t tmp =
+          HEDLEY_STATIC_CAST(int16_t, a_.i8[i]) +
+          HEDLEY_STATIC_CAST(int16_t, b_.i8[i]);
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, ((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN) : INT8_MAX));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_adds_epi8
+  #define _mm512_adds_epi8(a, b) simde_mm512_adds_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_adds_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_adds_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_adds_epi8
+  #define _mm512_mask_adds_epi8(src, k, a, b) simde_mm512_mask_adds_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_adds_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_adds_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_adds_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_adds_epi8
+  #define _mm512_maskz_adds_epi8(k, a, b) simde_mm512_maskz_adds_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_adds_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_adds_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      #if !defined(HEDLEY_INTEL_VERSION)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_adds_epi16(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          const int32_t tmp =
+            HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) +
+            HEDLEY_STATIC_CAST(int32_t, b_.i16[i]);
+          r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((tmp < INT16_MAX) ? ((tmp > INT16_MIN) ? tmp : INT16_MIN) : INT16_MAX));
+        }
+      #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_adds_epi16
+  #define _mm512_adds_epi16(a, b) simde_mm512_adds_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_adds_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_adds_epi16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_adds_epi16
+  #define _mm512_mask_adds_epi16(src, k, a, b) simde_mm512_mask_adds_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_adds_epi16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_adds_epi16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_adds_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_adds_epi16
+  #define _mm512_maskz_adds_epi16(k, a, b) simde_mm512_maskz_adds_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_adds_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_adds_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+        r_.m128i[i] = simde_mm_adds_epu8(a_.m128i[i], b_.m128i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = ((UINT8_MAX - a_.u8[i]) > b_.u8[i]) ? (a_.u8[i] + b_.u8[i]) : UINT8_MAX;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_adds_epu8
+  #define _mm512_adds_epu8(a, b) simde_mm512_adds_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_adds_epu8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_adds_epu8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_adds_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_adds_epu8
+  #define _mm512_mask_adds_epu8(src, k, a, b) simde_mm512_mask_adds_epu8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_adds_epu8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_adds_epu8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_adds_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_adds_epu8
+  #define _mm512_maskz_adds_epu8(k, a, b) simde_mm512_maskz_adds_epu8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_adds_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_adds_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_adds_epu16(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = ((UINT16_MAX - a_.u16[i]) > b_.u16[i]) ? (a_.u16[i] + b_.u16[i]) : UINT16_MAX;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_adds_epu16
+  #define _mm512_adds_epu16(a, b) simde_mm512_adds_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_adds_epu16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_adds_epu16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_adds_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_adds_epu16
+  #define _mm512_mask_adds_epu16(src, k, a, b) simde_mm512_mask_adds_epu16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_adds_epu16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_adds_epu16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_adds_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_adds_epu16
+  #define _mm512_maskz_adds_epu16(k, a, b) simde_mm512_maskz_adds_epu16(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_ADDS_H) */

--- a/2.0/simde/x86/avx512/and.h
+++ b/2.0/simde/x86/avx512/and.h
@@ -1,0 +1,301 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_AND_H)
+#define SIMDE_X86_AVX512_AND_H
+
+#include "types.h"
+#include "../avx2.h"
+
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_and_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_and_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_X86_AVX_NATIVE)
+      r_.m256d[0] = simde_mm256_and_pd(a_.m256d[0], b_.m256d[0]);
+      r_.m256d[1] = simde_mm256_and_pd(a_.m256d[1], b_.m256d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_and_pd
+  #define _mm512_and_pd(a, b) simde_mm512_and_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_and_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_and_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_X86_AVX_NATIVE)
+      r_.m256[0] = simde_mm256_and_ps(a_.m256[0], b_.m256[0]);
+      r_.m256[1] = simde_mm256_and_ps(a_.m256[1], b_.m256[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_and_ps
+  #define _mm512_and_ps(a, b) simde_mm512_and_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_and_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_mask_and_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_and_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_and_ps(src, k, a, b) simde_mm512_mask_and_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_and_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_maskz_and_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_and_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_and_ps(k, a, b) simde_mm512_maskz_and_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_and_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_mask_and_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_and_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_and_pd(src, k, a, b) simde_mm512_mask_and_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_and_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_maskz_and_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_and_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_and_pd(k, a, b) simde_mm512_maskz_and_pd(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_and_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_and_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 & b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] & b_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_and_epi32
+  #define _mm512_and_epi32(a, b) simde_mm512_and_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_and_epi32(simde__m512i src, simde__mmask16 k, simde__m512i v2, simde__m512i v3) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_and_epi32(src, k, v2, v3);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_and_epi32(v2, v3));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_and_epi32
+  #define _mm512_mask_and_epi32(src, k, v2, v3) simde_mm512_mask_and_epi32(src, k, v2, v3)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_and_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_and_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_and_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_and_epi32
+  #define _mm512_maskz_and_epi32(k, a, b) simde_mm512_maskz_and_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_and_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_and_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 & b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] & b_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_and_epi64
+  #define _mm512_and_epi64(a, b) simde_mm512_and_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_and_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_and_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_and_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_and_epi64
+  #define _mm512_mask_and_epi64(src, k, a, b) simde_mm512_mask_and_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_and_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_and_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_and_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_and_epi64
+  #define _mm512_maskz_and_epi64(k, a, b) simde_mm512_maskz_and_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_and_si512 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_and_si512(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[0] = simde_mm256_and_si256(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_and_si256(a_.m256i[1], b_.m256i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] & b_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_and_si512
+  #define _mm512_and_si512(a, b) simde_mm512_and_si512(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_AND_H) */

--- a/2.0/simde/x86/avx512/andnot.h
+++ b/2.0/simde/x86/avx512/andnot.h
@@ -1,0 +1,185 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_ANDNOT_H)
+#define SIMDE_X86_AVX512_ANDNOT_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_andnot_ps(a, b) _mm512_andnot_ps(a, b)
+#else
+  #define simde_mm512_andnot_ps(a, b) simde_mm512_castsi512_ps(simde_mm512_andnot_si512(simde_mm512_castps_si512(a), simde_mm512_castps_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_andnot_ps
+  #define _mm512_andnot_ps(a, b) simde_mm512_andnot_ps(a, b)
+#endif
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_mask_andnot_ps(src, k, a, b) _mm512_mask_andnot_ps((src), (k), (a), (b))
+#else
+  #define simde_mm512_mask_andnot_ps(src, k, a, b) simde_mm512_castsi512_ps(simde_mm512_mask_andnot_epi32(simde_mm512_castps_si512(src), k, simde_mm512_castps_si512(a), simde_mm512_castps_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_andnot_ps(src, k, a, b) simde_mm512_mask_andnot_ps(src, k, a, b)
+#endif
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_maskz_andnot_ps(k, a, b) _mm512_maskz_andnot_ps((k), (a), (b))
+#else
+  #define simde_mm512_maskz_andnot_ps(k, a, b) simde_mm512_castsi512_ps(simde_mm512_maskz_andnot_epi32(k, simde_mm512_castps_si512(a), simde_mm512_castps_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_andnot_ps(k, a, b) simde_mm512_maskz_andnot_ps(k, a, b)
+#endif
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_andnot_pd(a, b) _mm512_andnot_pd(a, b)
+#else
+  #define simde_mm512_andnot_pd(a, b) simde_mm512_castsi512_pd(simde_mm512_andnot_si512(simde_mm512_castpd_si512(a), simde_mm512_castpd_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_andnot_pd
+  #define _mm512_andnot_pd(a, b) simde_mm512_andnot_pd(a, b)
+#endif
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_mask_andnot_pd(src, k, a, b) _mm512_mask_andnot_pd((src), (k), (a), (b))
+#else
+  #define simde_mm512_mask_andnot_pd(src, k, a, b) simde_mm512_castsi512_pd(simde_mm512_mask_andnot_epi64(simde_mm512_castpd_si512(src), k, simde_mm512_castpd_si512(a), simde_mm512_castpd_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_andnot_pd(src, k, a, b) simde_mm512_mask_andnot_pd(src, k, a, b)
+#endif
+
+#if defined(SIMDE_X86_AVX512DQ_NATIVE)
+  #define simde_mm512_maskz_andnot_pd(k, a, b) _mm512_maskz_andnot_pd((k), (a), (b))
+#else
+  #define simde_mm512_maskz_andnot_pd(k, a, b) simde_mm512_castsi512_pd(simde_mm512_maskz_andnot_epi64(k, simde_mm512_castpd_si512(a), simde_mm512_castpd_si512(b)))
+#endif
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_andnot_pd(k, a, b) simde_mm512_maskz_andnot_pd(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_andnot_si512 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_andnot_si512(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[0] = simde_mm256_andnot_si256(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_andnot_si256(a_.m256i[1], b_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#define simde_mm512_andnot_epi32(a, b) simde_mm512_andnot_si512(a, b)
+#define simde_mm512_andnot_epi64(a, b) simde_mm512_andnot_si512(a, b)
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_andnot_si512
+  #define _mm512_andnot_si512(a, b) simde_mm512_andnot_si512(a, b)
+  #undef _mm512_andnot_epi32
+  #define _mm512_andnot_epi32(a, b) simde_mm512_andnot_si512(a, b)
+  #undef _mm512_andnot_epi64
+  #define _mm512_andnot_epi64(a, b) simde_mm512_andnot_si512(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_andnot_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_andnot_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_andnot_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_andnot_epi32(src, k, a, b) simde_mm512_mask_andnot_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_andnot_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_andnot_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_andnot_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_andnot_epi32(k, a, b) simde_mm512_maskz_andnot_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_andnot_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_andnot_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_andnot_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_andnot_epi64(src, k, a, b) simde_mm512_mask_andnot_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_andnot_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_andnot_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_andnot_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_andnot_epi64(k, a, b) simde_mm512_maskz_andnot_epi64(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_ANDNOT_H) */

--- a/2.0/simde/x86/avx512/avg.h
+++ b/2.0/simde/x86/avx512/avg.h
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_AVG_H)
+#define SIMDE_X86_AVX512_AVG_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_avg_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_avg_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_avg_epu8
+  #define _mm512_avg_epu8(a, b) simde_mm512_avg_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_avg_epu8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_avg_epu8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_avg_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_avg_epu8
+  #define _mm512_mask_avg_epu8(src, k, a, b) simde_mm512_mask_avg_epu8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_avg_epu8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_avg_epu8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_avg_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_avg_epu8
+  #define _mm512_maskz_avg_epu8(k, a, b) simde_mm512_maskz_avg_epu8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_avg_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_avg_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_avg_epu16
+  #define _mm512_avg_epu16(a, b) simde_mm512_avg_epu16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_AVG_H) */

--- a/2.0/simde/x86/avx512/blend.h
+++ b/2.0/simde/x86/avx512/blend.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_BLEND_H)
+#define SIMDE_X86_AVX512_BLEND_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_blend_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_blend_epi32(k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(a, k, b);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_blend_epi32(k, a, b) simde_mm512_mask_blend_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_blend_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_blend_epi64(k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(a, k, b);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_blend_epi64(k, a, b) simde_mm512_mask_blend_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_blend_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_blend_ps(k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(a, k, b);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_blend_ps(k, a, b) simde_mm512_mask_blend_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_blend_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_blend_pd(k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(a, k, b);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_blend_pd(k, a, b) simde_mm512_mask_blend_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_BLEND_H) */

--- a/2.0/simde/x86/avx512/broadcast.h
+++ b/2.0/simde/x86/avx512/broadcast.h
@@ -1,0 +1,881 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_BROADCAST_H)
+#define SIMDE_X86_AVX512_BROADCAST_H
+
+#include "types.h"
+#include "../avx2.h"
+
+#include "mov.h"
+#include "cast.h"
+#include "set1.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_broadcast_f32x2 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_broadcast_f32x2(a);
+  #else
+    simde__m256_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.f32 = __builtin_shufflevector(a_.f32, a_.f32, 0, 1, 0, 1, 0, 1, 0, 1);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+         r_.f32[  i  ] = a_.f32[0];
+         r_.f32[i + 1] = a_.f32[1];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_f32x2
+  #define _mm256_broadcast_f32x2(a) simde_mm256_broadcast_f32x2(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_broadcast_f32x2(simde__m256 src, simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_mask_broadcast_f32x2(src, k, a);
+  #else
+    return simde_mm256_mask_mov_ps(src, k, simde_mm256_broadcast_f32x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_broadcast_f32x2
+  #define _mm256_mask_broadcast_f32x2(src, k, a) simde_mm256_mask_broadcast_f32x2(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskz_broadcast_f32x2(simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_maskz_broadcast_f32x2(k, a);
+  #else
+    return simde_mm256_maskz_mov_ps(k, simde_mm256_broadcast_f32x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_broadcast_f32x2
+  #define _mm256_maskz_broadcast_f32x2(k, a) simde_mm256_maskz_broadcast_f32x2(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_broadcast_f32x2 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_broadcast_f32x2(a);
+  #else
+    simde__m512_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.f32 = __builtin_shufflevector(a_.f32, a_.f32, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=2) {
+         r_.f32[  i  ] = a_.f32[0];
+         r_.f32[i + 1] = a_.f32[1];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_f32x2
+  #define _mm512_broadcast_f32x2(a) simde_mm512_broadcast_f32x2(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_broadcast_f32x2(simde__m512 src, simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_mask_broadcast_f32x2(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_broadcast_f32x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_broadcast_f32x2
+  #define _mm512_mask_broadcast_f32x2(src, k, a) simde_mm512_mask_broadcast_f32x2(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_broadcast_f32x2(simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_maskz_broadcast_f32x2(k, a);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_broadcast_f32x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_broadcast_f32x2
+  #define _mm512_maskz_broadcast_f32x2(k, a) simde_mm512_maskz_broadcast_f32x2(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_broadcast_f32x8 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_broadcast_f32x8(a);
+  #else
+    simde__m512_private r_;
+    simde__m256_private a_ = simde__m256_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.f32 = __builtin_shufflevector(a_.f32, a_.f32, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=8) {
+         r_.f32[  i  ] = a_.f32[0];
+         r_.f32[i + 1] = a_.f32[1];
+         r_.f32[i + 2] = a_.f32[2];
+         r_.f32[i + 3] = a_.f32[3];
+         r_.f32[i + 4] = a_.f32[4];
+         r_.f32[i + 5] = a_.f32[5];
+         r_.f32[i + 6] = a_.f32[6];
+         r_.f32[i + 7] = a_.f32[7];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_f32x8
+  #define _mm512_broadcast_f32x8(a) simde_mm512_broadcast_f32x8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_broadcast_f32x8(simde__m512 src, simde__mmask16 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_mask_broadcast_f32x8(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_broadcast_f32x8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_broadcast_f32x8
+  #define _mm512_mask_broadcast_f32x8(src, k, a) simde_mm512_mask_broadcast_f32x8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_broadcast_f32x8(simde__mmask16 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_maskz_broadcast_f32x8(k, a);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_broadcast_f32x8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_broadcast_f32x8
+  #define _mm512_maskz_broadcast_f32x8(k, a) simde_mm512_maskz_broadcast_f32x8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_broadcast_f64x2 (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_broadcast_f64x2(a);
+  #else
+    simde__m512d_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.f64 = __builtin_shufflevector(a_.f64, a_.f64, 0, 1, 0, 1, 0, 1, 0, 1);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i+=2) {
+         r_.f64[i]     = a_.f64[0];
+         r_.f64[i + 1] = a_.f64[1];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_f64x2
+  #define _mm512_broadcast_f64x2(a) simde_mm512_broadcast_f64x2(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_broadcast_f64x2(simde__m512d src, simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_mask_broadcast_f64x2(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_broadcast_f64x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_broadcast_f64x2
+  #define _mm512_mask_broadcast_f64x2(src, k, a) simde_mm512_mask_broadcast_f64x2(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_broadcast_f64x2(simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_maskz_broadcast_f64x2(k, a);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_broadcast_f64x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_broadcast_f64x2
+  #define _mm512_maskz_broadcast_f64x2(k, a) simde_mm512_maskz_broadcast_f64x2(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_broadcast_f32x4 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_broadcast_f32x4(a);
+  #else
+    simde__m256_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+        r_.m128_private[0] = a_;
+        r_.m128_private[1] = a_;
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector)
+      r_.f32 = __builtin_shufflevector(a_.f32, a_.f32, 0, 1, 2, 3, 0, 1, 2, 3);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 4) {
+         r_.f32[  i  ] = a_.f32[0];
+         r_.f32[i + 1] = a_.f32[1];
+         r_.f32[i + 2] = a_.f32[2];
+         r_.f32[i + 3] = a_.f32[3];
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_f32x4
+  #define _mm256_broadcast_f32x4(a) simde_mm256_broadcast_f32x4(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_broadcast_f32x4(simde__m256 src, simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_broadcast_f32x4(src, k, a);
+  #else
+    return simde_mm256_mask_mov_ps(src, k, simde_mm256_broadcast_f32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_broadcast_f32x4
+  #define _mm256_mask_broadcast_f32x4(src, k, a) simde_mm256_mask_broadcast_f32x4(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskz_broadcast_f32x4(simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_broadcast_f32x4(k, a);
+  #else
+    return simde_mm256_maskz_mov_ps(k, simde_mm256_broadcast_f32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_broadcast_f32x4
+  #define _mm256_maskz_broadcast_f32x4(k, a) simde_mm256_maskz_broadcast_f32x4(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_broadcast_f64x2 (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_broadcast_f64x2(a);
+  #else
+    simde__m256d_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    /* I don't have a bug # for this, but when compiled with clang-10 without optimization on aarch64
+     * the __builtin_shufflevector version doesn't work correctly.  clang 9 and 11 aren't a problem */
+    #if defined(SIMDE_VECTOR_SUBSCRIPT) && HEDLEY_HAS_BUILTIN(__builtin_shufflevector) && \
+        (!defined(__clang__) || (SIMDE_DETECT_CLANG_VERSION < 100000 || SIMDE_DETECT_CLANG_VERSION > 100000))
+      r_.f64 = __builtin_shufflevector(a_.f64, a_.f64, 0, 1, 0, 1);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+         r_.f64[  i  ] = a_.f64[0];
+         r_.f64[i + 1] = a_.f64[1];
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_broadcast_f64x2
+  #define _mm256_broadcast_f64x2(a) simde_mm256_broadcast_f64x2(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_broadcast_f64x2(simde__m256d src, simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_mask_broadcast_f64x2(src, k, a);
+  #else
+    return simde_mm256_mask_mov_pd(src, k, simde_mm256_broadcast_f64x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_broadcast_f64x2
+  #define _mm256_mask_broadcast_f64x2(src, k, a) simde_mm256_mask_broadcast_f64x2(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_maskz_broadcast_f64x2(simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_maskz_broadcast_f64x2(k, a);
+  #else
+    return simde_mm256_maskz_mov_pd(k, simde_mm256_broadcast_f64x2(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_broadcast_f64x2
+  #define _mm256_maskz_broadcast_f64x2(k, a) simde_mm256_maskz_broadcast_f64x2(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_broadcast_f32x4 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcast_f32x4(a);
+  #else
+    simde__m512_private r_;
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256[1] = r_.m256[0] = simde_mm256_castsi256_ps(simde_mm256_broadcastsi128_si256(simde_mm_castps_si128(a)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = a;
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_f32x4
+  #define _mm512_broadcast_f32x4(a) simde_mm512_broadcast_f32x4(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_broadcast_f32x4(simde__m512 src, simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcast_f32x4(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_broadcast_f32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcast_f32x4(src, k, a) simde_mm512_mask_broadcast_f32x4(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_broadcast_f32x4(simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcast_f32x4(k, a);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_broadcast_f32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcast_f32x4(k, a) simde_mm512_maskz_broadcast_f32x4(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_broadcast_f64x4 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcast_f64x4(a);
+  #else
+    simde__m512d_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+      r_.m256d[i] = a;
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_f64x4
+  #define _mm512_broadcast_f64x4(a) simde_mm512_broadcast_f64x4(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_broadcast_f64x4(simde__m512d src, simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcast_f64x4(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_broadcast_f64x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcast_f64x4(src, k, a) simde_mm512_mask_broadcast_f64x4(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_broadcast_f64x4(simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcast_f64x4(k, a);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_broadcast_f64x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcast_f64x4(k, a) simde_mm512_maskz_broadcast_f64x4(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcast_i32x4 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcast_i32x4(a);
+  #else
+    simde__m512i_private r_;
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[1] = r_.m256i[0] = simde_mm256_broadcastsi128_si256(a);
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[3] = r_.m128i[2] = r_.m128i[1] = r_.m128i[0] = a;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+        r_.m128i[i] = a;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_i32x4
+  #define _mm512_broadcast_i32x4(a) simde_mm512_broadcast_i32x4(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_broadcast_i32x4(simde__m512i src, simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcast_i32x4(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_broadcast_i32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcast_i32x4(src, k, a) simde_mm512_mask_broadcast_i32x4(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_broadcast_i32x4(simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcast_i32x4(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_broadcast_i32x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcast_i32x4(k, a) simde_mm512_maskz_broadcast_i32x4(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcast_i64x4 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcast_i64x4(a);
+  #else
+    simde__m512i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = a;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcast_i64x4
+  #define _mm512_broadcast_i64x4(a) simde_mm512_broadcast_i64x4(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_broadcast_i64x4(simde__m512i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcast_i64x4(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_broadcast_i64x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcast_i64x4(src, k, a) simde_mm512_mask_broadcast_i64x4(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_broadcast_i64x4(simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcast_i64x4(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_broadcast_i64x4(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcast_i64x4(k, a) simde_mm512_maskz_broadcast_i64x4(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcastd_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcastd_epi32(a);
+  #else
+    simde__m512i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[0];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastd_epi32
+  #define _mm512_broadcastd_epi32(a) simde_mm512_broadcastd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_broadcastd_epi32(simde__m512i src, simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcastd_epi32(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_broadcastd_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcastd_epi32(src, k, a) simde_mm512_mask_broadcastd_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_broadcastd_epi32(simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcastd_epi32(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_broadcastd_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcastd_epi32(k, a) simde_mm512_maskz_broadcastd_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcastq_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcastq_epi64(a);
+  #else
+    simde__m512i_private r_;
+    simde__m128i_private a_= simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[0];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastq_epi64
+  #define _mm512_broadcastq_epi64(a) simde_mm512_broadcastq_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_broadcastq_epi64(simde__m512i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcastq_epi64(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_broadcastq_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcastq_epi64(src, k, a) simde_mm512_mask_broadcastq_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_broadcastq_epi64(simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcastq_epi64(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_broadcastq_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcastq_epi64(k, a) simde_mm512_maskz_broadcastq_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_broadcastss_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcastss_ps(a);
+  #else
+    simde__m512_private r_;
+    simde__m128_private a_= simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[0];
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastss_ps
+  #define _mm512_broadcastss_ps(a) simde_mm512_broadcastss_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_broadcastss_ps(simde__m512 src, simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcastss_ps(src, k, a);
+  #else
+    simde__m512_private
+      src_ = simde__m512_to_private(src),
+      r_;
+    simde__m128_private
+      a_ = simde__m128_to_private(a);
+
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = ((k >> i) & 1) ? a_.f32[0] : src_.f32[i];
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcastss_ps(src, k, a) simde_mm512_mask_broadcastss_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_broadcastss_ps(simde__mmask16 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcastss_ps(k, a);
+  #else
+    simde__m512_private
+      r_;
+    simde__m128_private
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = ((k >> i) & 1) ? a_.f32[0] : INT32_C(0);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcastss_ps(k, a) simde_mm512_maskz_broadcastss_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_broadcastsd_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_broadcastsd_pd(a);
+  #else
+    simde__m512d_private r_;
+    simde__m128d_private a_= simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[0];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastsd_pd
+  #define _mm512_broadcastsd_pd(a) simde_mm512_broadcastsd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_broadcastsd_pd(simde__m512d src, simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_broadcastsd_pd(src, k, a);
+  #else
+    simde__m512d_private
+      src_ = simde__m512d_to_private(src),
+      r_;
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = ((k >> i) & 1) ? a_.f64[0] : src_.f64[i];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_broadcastsd_pd(src, k, a) simde_mm512_mask_broadcastsd_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_broadcastsd_pd(simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_broadcastsd_pd(k, a);
+  #else
+    simde__m512d_private
+      r_;
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = ((k >> i) & 1) ? a_.f64[0] : INT64_C(0);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_broadcastsd_pd(k, a) simde_mm512_maskz_broadcastsd_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcastb_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_broadcastb_epi8(a);
+  #else
+    simde__m128i_private a_= simde__m128i_to_private(a);
+    return simde_mm512_set1_epi8(a_.i8[0]);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastb_epi8
+  #define _mm512_broadcastb_epi8(a) simde_mm512_broadcastb_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_broadcastb_epi8 (simde__m512i src, simde__mmask64 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_broadcastb_epi8(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_broadcastb_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_broadcastb_epi8
+  #define _mm512_mask_broadcastb_epi8(src, k, a) simde_mm512_mask_broadcastb_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_broadcastb_epi8 (simde__mmask64 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_broadcastb_epi8(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_broadcastb_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_broadcastb_epi8
+  #define _mm512_maskz_broadcastb_epi8(k, a) simde_mm512_maskz_broadcastb_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_broadcastw_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_broadcastw_epi16(a);
+  #else
+    simde__m128i_private a_= simde__m128i_to_private(a);
+    return simde_mm512_set1_epi16(a_.i16[0]);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_broadcastw_epi16
+  #define _mm512_broadcastw_epi16(a) simde_mm512_broadcastw_epi16(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_BROADCAST_H) */

--- a/2.0/simde/x86/avx512/cast.h
+++ b/2.0/simde/x86/avx512/cast.h
@@ -1,0 +1,324 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CAST_H)
+#define SIMDE_X86_AVX512_CAST_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_castpd_ps (simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd_ps(a);
+  #else
+    simde__m512 r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd_ps
+  #define _mm512_castpd_ps(a) simde_mm512_castpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_castpd_si512 (simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd_si512(a);
+  #else
+    simde__m512i r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd_si512
+  #define _mm512_castpd_si512(a) simde_mm512_castpd_si512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_castps_pd (simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps_pd(a);
+  #else
+    simde__m512d r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps_pd
+  #define _mm512_castps_pd(a) simde_mm512_castps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_castps_si512 (simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps_si512(a);
+  #else
+    simde__m512i r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps_si512
+  #define _mm512_castps_si512(a) simde_mm512_castps_si512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_castsi512_ps (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi512_ps(a);
+  #else
+    simde__m512 r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi512_ps
+  #define _mm512_castsi512_ps(a) simde_mm512_castsi512_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_castsi512_pd (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi512_pd(a);
+  #else
+    simde__m512d r;
+    simde_memcpy(&r, &a, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi512_pd
+  #define _mm512_castsi512_pd(a) simde_mm512_castsi512_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_castpd128_pd512 (simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd128_pd512(a);
+  #else
+    simde__m512d_private r_;
+    r_.m128d[0] = a;
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd128_pd512
+  #define _mm512_castpd128_pd512(a) simde_mm512_castpd128_pd512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_castpd256_pd512 (simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd256_pd512(a);
+  #else
+    simde__m512d_private r_;
+    r_.m256d[0] = a;
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd256_pd512
+  #define _mm512_castpd256_pd512(a) simde_mm512_castpd256_pd512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm512_castpd512_pd128 (simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd512_pd128(a);
+  #else
+    simde__m512d_private a_ = simde__m512d_to_private(a);
+    return a_.m128d[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd512_pd128
+  #define _mm512_castpd512_pd128(a) simde_mm512_castpd512_pd128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm512_castpd512_pd256 (simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castpd512_pd256(a);
+  #else
+    simde__m512d_private a_ = simde__m512d_to_private(a);
+    return a_.m256d[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castpd512_pd256
+  #define _mm512_castpd512_pd256(a) simde_mm512_castpd512_pd256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_castps128_ps512 (simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps128_ps512(a);
+  #else
+    simde__m512_private r_;
+    r_.m128[0] = a;
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps128_ps512
+  #define _mm512_castps128_ps512(a) simde_mm512_castps128_ps512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_castps256_ps512 (simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps256_ps512(a);
+  #else
+    simde__m512_private r_;
+    r_.m256[0] = a;
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps256_ps512
+  #define _mm512_castps256_ps512(a) simde_mm512_castps256_ps512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm512_castps512_ps128 (simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps512_ps128(a);
+  #else
+    simde__m512_private a_ = simde__m512_to_private(a);
+    return a_.m128[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps512_ps128
+  #define _mm512_castps512_ps128(a) simde_mm512_castps512_ps128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm512_castps512_ps256 (simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castps512_ps256(a);
+  #else
+    simde__m512_private a_ = simde__m512_to_private(a);
+    return a_.m256[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castps512_ps256
+  #define _mm512_castps512_ps256(a) simde_mm512_castps512_ps256(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_castsi128_si512 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi128_si512(a);
+  #else
+    simde__m512i_private r_;
+    r_.m128i[0] = a;
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi128_si512
+  #define _mm512_castsi128_si512(a) simde_mm512_castsi128_si512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_castsi256_si512 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi256_si512(a);
+  #else
+    simde__m512i_private r_;
+    r_.m256i[0] = a;
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi256_si512
+  #define _mm512_castsi256_si512(a) simde_mm512_castsi256_si512(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_castsi512_si128 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi512_si128(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    return a_.m128i[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi512_si128
+  #define _mm512_castsi512_si128(a) simde_mm512_castsi512_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_castsi512_si256 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_castsi512_si256(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    return a_.m256i[0];
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_castsi512_si256
+  #define _mm512_castsi512_si256(a) simde_mm512_castsi512_si256(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CAST_H) */

--- a/2.0/simde/x86/avx512/cmp.h
+++ b/2.0/simde/x86/avx512/cmp.h
@@ -1,0 +1,589 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMP_H)
+#define SIMDE_X86_AVX512_CMP_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "mov_mask.h"
+#include "setzero.h"
+#include "setone.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_cmp_ps_mask (simde__m512 a, simde__m512 b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    simde__mmask16 r;
+    SIMDE_CONSTIFY_32_(_mm512_cmp_ps_mask, r, (HEDLEY_UNREACHABLE(), 0), imm8, a, b);
+    return r;
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      switch (imm8) {
+        case SIMDE_CMP_EQ_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+          break;
+        case SIMDE_CMP_LT_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+          break;
+        case SIMDE_CMP_LE_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+          break;
+        case SIMDE_CMP_UNORD_Q:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+              r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_NEQ_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+          break;
+        case SIMDE_CMP_NLT_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+          break;
+        case SIMDE_CMP_NLE_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+          break;
+        case SIMDE_CMP_ORD_Q:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+              r_.u32[i] = (!simde_math_isnanf(a_.f32[i]) && !simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+              }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_EQ_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+          break;
+        case SIMDE_CMP_NGE_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+          break;
+        case SIMDE_CMP_NGT_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+          break;
+        case SIMDE_CMP_FALSE_OQ:
+          r_ = simde__m512_to_private(simde_mm512_setzero_ps());
+          break;
+        case SIMDE_CMP_NEQ_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+          break;
+        case SIMDE_CMP_GE_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+          break;
+        case SIMDE_CMP_GT_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+          break;
+        case SIMDE_CMP_TRUE_UQ:
+          r_ = simde__m512_to_private(simde_x_mm512_setone_ps());
+          break;
+        case SIMDE_CMP_EQ_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+          break;
+        case SIMDE_CMP_LT_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+          break;
+        case SIMDE_CMP_LE_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+          break;
+        case SIMDE_CMP_UNORD_S:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+                r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_NEQ_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+          break;
+        case SIMDE_CMP_NLT_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+          break;
+        case SIMDE_CMP_NLE_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+          break;
+        case SIMDE_CMP_ORD_S:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+              r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? UINT32_C(0) : ~UINT32_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_EQ_US:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 == b_.f32));
+          break;
+        case SIMDE_CMP_NGE_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+          break;
+        case SIMDE_CMP_NGT_UQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+          break;
+        case SIMDE_CMP_FALSE_OS:
+          r_ = simde__m512_to_private(simde_mm512_setzero_ps());
+          break;
+        case SIMDE_CMP_NEQ_OS:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+          break;
+        case SIMDE_CMP_GE_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+          break;
+        case SIMDE_CMP_GT_OQ:
+          r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+          break;
+        case SIMDE_CMP_TRUE_US:
+          r_ = simde__m512_to_private(simde_x_mm512_setone_ps());
+          break;
+        default:
+          HEDLEY_UNREACHABLE();
+          break;
+      }
+    #else /* defined(SIMDE_VECTOR_SUBSCRIPT_OPS) */
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        switch (imm8) {
+          case SIMDE_CMP_EQ_OQ:
+            r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_LT_OS:
+            r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_LE_OS:
+            r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_UNORD_Q:
+            #if defined(simde_math_isnanf)
+              r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_NEQ_UQ:
+            r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NLT_US:
+            r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NLE_US:
+            r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_ORD_Q:
+            #if defined(simde_math_isnanf)
+              r_.u32[i] = (!simde_math_isnanf(a_.f32[i]) && !simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_EQ_UQ:
+            r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NGE_US:
+            r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NGT_US:
+            r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_FALSE_OQ:
+            r_.u32[i] = UINT32_C(0);
+            break;
+          case SIMDE_CMP_NEQ_OQ:
+            r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_GE_OS:
+            r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_GT_OS:
+            r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_TRUE_UQ:
+            r_.u32[i] = ~UINT32_C(0);
+            break;
+          case SIMDE_CMP_EQ_OS:
+            r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_LT_OQ:
+            r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_LE_OQ:
+            r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_UNORD_S:
+            #if defined(simde_math_isnanf)
+              r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_NEQ_US:
+            r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NLT_UQ:
+            r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NLE_UQ:
+            r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_ORD_S:
+            #if defined(simde_math_isnanf)
+              r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? UINT32_C(0) : ~UINT32_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_EQ_US:
+            r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NGE_UQ:
+            r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_NGT_UQ:
+            r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_FALSE_OS:
+            r_.u32[i] = UINT32_C(0);
+            break;
+          case SIMDE_CMP_NEQ_OS:
+            r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_GE_OQ:
+            r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_GT_OQ:
+            r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+            break;
+          case SIMDE_CMP_TRUE_US:
+            r_.u32[i] = ~UINT32_C(0);
+            break;
+          default:
+            HEDLEY_UNREACHABLE();
+            break;
+        }
+      }
+    #endif
+
+    return simde_mm512_movepi32_mask(simde_mm512_castps_si512(simde__m512_from_private(r_)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmp_ps_mask
+  #define _mm512_cmp_ps_mask(a, b, imm8) simde_mm512_cmp_ps_mask((a), (b), (imm8))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_cmp_pd_mask (simde__m512d a, simde__m512d b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT(imm8)
+    HEDLEY_REQUIRE_MSG(((imm8 >= 0) && (imm8 <= 31)), "imm8 must be one of the SIMDE_CMP_* macros (values: [0, 31])") {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    simde__mmask8 r;
+    SIMDE_CONSTIFY_32_(_mm512_cmp_pd_mask, r, (HEDLEY_UNREACHABLE(), 0), imm8, a, b);
+    return r;
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      switch (imm8) {
+        case SIMDE_CMP_EQ_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+          break;
+        case SIMDE_CMP_LT_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+          break;
+        case SIMDE_CMP_LE_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+          break;
+        case SIMDE_CMP_UNORD_Q:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+              r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_NEQ_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+          break;
+        case SIMDE_CMP_NLT_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+          break;
+        case SIMDE_CMP_NLE_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+          break;
+        case SIMDE_CMP_ORD_Q:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+              r_.u64[i] = (!simde_math_isnanf(a_.f64[i]) && !simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+              }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_EQ_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+          break;
+        case SIMDE_CMP_NGE_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+          break;
+        case SIMDE_CMP_NGT_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+          break;
+        case SIMDE_CMP_FALSE_OQ:
+          r_ = simde__m512d_to_private(simde_mm512_setzero_pd());
+          break;
+        case SIMDE_CMP_NEQ_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+          break;
+        case SIMDE_CMP_GE_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+          break;
+        case SIMDE_CMP_GT_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+          break;
+        case SIMDE_CMP_TRUE_UQ:
+          r_ = simde__m512d_to_private(simde_x_mm512_setone_pd());
+          break;
+        case SIMDE_CMP_EQ_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+          break;
+        case SIMDE_CMP_LT_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+          break;
+        case SIMDE_CMP_LE_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+          break;
+        case SIMDE_CMP_UNORD_S:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+                r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_NEQ_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+          break;
+        case SIMDE_CMP_NLT_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+          break;
+        case SIMDE_CMP_NLE_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+          break;
+        case SIMDE_CMP_ORD_S:
+          #if defined(simde_math_isnanf)
+            for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+              r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? UINT64_C(0) : ~UINT64_C(0);
+            }
+          #else
+            HEDLEY_UNREACHABLE();
+          #endif
+          break;
+        case SIMDE_CMP_EQ_US:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+          break;
+        case SIMDE_CMP_NGE_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+          break;
+        case SIMDE_CMP_NGT_UQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+          break;
+        case SIMDE_CMP_FALSE_OS:
+          r_ = simde__m512d_to_private(simde_mm512_setzero_pd());
+          break;
+        case SIMDE_CMP_NEQ_OS:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+          break;
+        case SIMDE_CMP_GE_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+          break;
+        case SIMDE_CMP_GT_OQ:
+          r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+          break;
+        case SIMDE_CMP_TRUE_US:
+          r_ = simde__m512d_to_private(simde_x_mm512_setone_pd());
+          break;
+        default:
+          HEDLEY_UNREACHABLE();
+          break;
+      }
+    #else /* defined(SIMDE_VECTOR_SUBSCRIPT_OPS) */
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        switch (imm8) {
+          case SIMDE_CMP_EQ_OQ:
+            r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_LT_OS:
+            r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_LE_OS:
+            r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_UNORD_Q:
+            #if defined(simde_math_isnanf)
+              r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_NEQ_UQ:
+            r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NLT_US:
+            r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NLE_US:
+            r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_ORD_Q:
+            #if defined(simde_math_isnanf)
+              r_.u64[i] = (!simde_math_isnanf(a_.f64[i]) && !simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_EQ_UQ:
+            r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NGE_US:
+            r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NGT_US:
+            r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_FALSE_OQ:
+            r_.u64[i] = UINT64_C(0);
+            break;
+          case SIMDE_CMP_NEQ_OQ:
+            r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_GE_OS:
+            r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_GT_OS:
+            r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_TRUE_UQ:
+            r_.u64[i] = ~UINT64_C(0);
+            break;
+          case SIMDE_CMP_EQ_OS:
+            r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_LT_OQ:
+            r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_LE_OQ:
+            r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_UNORD_S:
+            #if defined(simde_math_isnanf)
+              r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_NEQ_US:
+            r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NLT_UQ:
+            r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NLE_UQ:
+            r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_ORD_S:
+            #if defined(simde_math_isnanf)
+              r_.u64[i] = (simde_math_isnanf(a_.f64[i]) || simde_math_isnanf(b_.f64[i])) ? UINT64_C(0) : ~UINT64_C(0);
+            #else
+              HEDLEY_UNREACHABLE();
+            #endif
+            break;
+          case SIMDE_CMP_EQ_US:
+            r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NGE_UQ:
+            r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_NGT_UQ:
+            r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_FALSE_OS:
+            r_.u64[i] = UINT64_C(0);
+            break;
+          case SIMDE_CMP_NEQ_OS:
+            r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_GE_OQ:
+            r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_GT_OQ:
+            r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+            break;
+          case SIMDE_CMP_TRUE_US:
+            r_.u64[i] = ~UINT64_C(0);
+            break;
+          default:
+            HEDLEY_UNREACHABLE();
+            break;
+        }
+      }
+    #endif
+
+    return simde_mm512_movepi64_mask(simde_mm512_castpd_si512(simde__m512d_from_private(r_)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmp_pd_mask
+  #define _mm512_cmp_pd_mask(a, b, imm8) simde_mm512_cmp_pd_mask((a), (b), (imm8))
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMP_H) */

--- a/2.0/simde/x86/avx512/cmpeq.h
+++ b/2.0/simde/x86/avx512/cmpeq.h
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMPEQ_H)
+#define SIMDE_X86_AVX512_CMPEQ_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "mov_mask.h"
+#include "cmp.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmpeq_epi8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmpeq_epi8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        const uint32_t t = HEDLEY_STATIC_CAST(uint32_t, simde_mm256_movemask_epi8(simde_mm256_cmpeq_epi8(a_.m256i[i], b_.m256i[i])));
+        r |= HEDLEY_STATIC_CAST(uint64_t, t) << (i * 32);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.i8 == b_.i8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[i] == b_.u8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpeq_epi8_mask
+  #define _mm512_cmpeq_epi8_mask(a, b) simde_mm512_cmpeq_epi8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_cmpeq_epi32_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cmpeq_epi32_mask(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_cmpeq_epi32(a_.m256i[i], b_.m256i[i]);
+    }
+
+    return simde_mm512_movepi32_mask(simde__m512i_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpeq_epi32_mask
+  #define _mm512_cmpeq_epi32_mask(a, b) simde_mm512_cmpeq_epi32_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_mask_cmpeq_epi32_mask (simde__mmask16 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cmpeq_epi32_mask(k1, a, b);
+  #else
+    return simde_mm512_cmpeq_epi32_mask(a, b) & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cmpeq_epi32_mask
+  #define _mm512_mask_cmpeq_epi32_mask(k1, a, b) simde_mm512_mask_cmpeq_epi32_mask(k1, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_cmpeq_epi64_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cmpeq_epi64_mask(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_cmpeq_epi64(a_.m256i[i], b_.m256i[i]);
+    }
+
+    return simde_mm512_movepi64_mask(simde__m512i_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpeq_epi64_mask
+  #define _mm512_cmpeq_epi64_mask(a, b) simde_mm512_cmpeq_epi64_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_mask_cmpeq_epi64_mask (simde__mmask8 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cmpeq_epi64_mask(k1, a, b);
+  #else
+    return simde_mm512_cmpeq_epi64_mask(a, b) & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cmpeq_epi64_mask
+  #define _mm512_mask_cmpeq_epi64_mask(k1, a, b) simde_mm512_mask_cmpeq_epi64_mask(k1, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_cmpeq_ps_mask (simde__m512 a, simde__m512 b) {
+  return simde_mm512_cmp_ps_mask(a, b, SIMDE_CMP_EQ_OQ);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpeq_ps_mask
+  #define _mm512_cmpeq_ps_mask(a, b) simde_mm512_cmp_ps_mask(a, b, SIMDE_CMP_EQ_OQ)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_cmpeq_pd_mask (simde__m512d a, simde__m512d b) {
+  return simde_mm512_cmp_pd_mask(a, b, SIMDE_CMP_EQ_OQ);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpeq_pd_mask
+  #define _mm512_cmpeq_pd_mask(a, b) simde_mm512_cmp_pd_mask(a, b, SIMDE_CMP_EQ_OQ)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMPEQ_H) */

--- a/2.0/simde/x86/avx512/cmpge.h
+++ b/2.0/simde/x86/avx512/cmpge.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMPGE_H)
+#define SIMDE_X86_AVX512_CMPGE_H
+
+#include "types.h"
+#include "mov.h"
+#include "mov_mask.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmpge_epi8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmpge_epi8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.i8 >= b_.i8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] >= b_.i8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpge_epi8_mask
+  #define _mm512_cmpge_epi8_mask(a, b) simde_mm512_cmpge_epi8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmpge_epu8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmpge_epu8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.u8 >= b_.u8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[i] >= b_.u8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpge_epu8_mask
+  #define _mm512_cmpge_epu8_mask(a, b) simde_mm512_cmpge_epu8_mask(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMPGE_H) */

--- a/2.0/simde/x86/avx512/cmpgt.h
+++ b/2.0/simde/x86/avx512/cmpgt.h
@@ -1,0 +1,189 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMPGT_H)
+#define SIMDE_X86_AVX512_CMPGT_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "mov_mask.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmpgt_epi8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmpgt_epi8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256) && !defined(HEDLEY_INTEL_VERSION)
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        const uint32_t t = HEDLEY_STATIC_CAST(uint32_t, simde_mm256_movemask_epi8(simde_mm256_cmpgt_epi8(a_.m256i[i], b_.m256i[i])));
+        r |= HEDLEY_STATIC_CAST(uint64_t, t) << HEDLEY_STATIC_CAST(uint64_t, i * 32);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.i8 > b_.i8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] > b_.i8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpgt_epi8_mask
+  #define _mm512_cmpgt_epi8_mask(a, b) simde_mm512_cmpgt_epi8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmpgt_epu8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmpgt_epu8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.u8 > b_.u8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[i] > b_.u8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpgt_epu8_mask
+  #define _mm512_cmpgt_epu8_mask(a, b) simde_mm512_cmpgt_epu8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_cmpgt_epi32_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cmpgt_epi32_mask(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_cmpgt_epi32(a_.m256i[i], b_.m256i[i]);
+    }
+
+    return simde_mm512_movepi32_mask(simde__m512i_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpgt_epi32_mask
+  #define _mm512_cmpgt_epi32_mask(a, b) simde_mm512_cmpgt_epi32_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_mask_cmpgt_epi32_mask (simde__mmask16 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cmpgt_epi32_mask(k1, a, b);
+  #else
+    return simde_mm512_cmpgt_epi32_mask(a, b) & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cmpgt_epi32_mask
+  #define _mm512_mask_cmpgt_epi32_mask(k1, a, b) simde_mm512_mask_cmpgt_epi32_mask(k1, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_cmpgt_epi64_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cmpgt_epi64_mask(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_cmpgt_epi64(a_.m256i[i], b_.m256i[i]);
+    }
+
+    return simde_mm512_movepi64_mask(simde__m512i_from_private(r_));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmpgt_epi64_mask
+  #define _mm512_cmpgt_epi64_mask(a, b) simde_mm512_cmpgt_epi64_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_mask_cmpgt_epi64_mask (simde__mmask8 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cmpgt_epi64_mask(k1, a, b);
+  #else
+    return simde_mm512_cmpgt_epi64_mask(a, b) & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cmpgt_epi64_mask
+  #define _mm512_mask_cmpgt_epi64_mask(k1, a, b) simde_mm512_mask_cmpgt_epi64_mask(k1, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMPGT_H) */

--- a/2.0/simde/x86/avx512/cmple.h
+++ b/2.0/simde/x86/avx512/cmple.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMPLE_H)
+#define SIMDE_X86_AVX512_CMPLE_H
+
+#include "types.h"
+#include "mov.h"
+#include "mov_mask.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmple_epi8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmple_epi8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.i8 <= b_.i8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] <= b_.i8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmple_epi8_mask
+  #define _mm512_cmple_epi8_mask(a, b) simde_mm512_cmple_epi8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmple_epu8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmple_epu8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.u8 <= b_.u8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[i] <= b_.u8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmple_epu8_mask
+  #define _mm512_cmple_epu8_mask(a, b) simde_mm512_cmple_epu8_mask(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMPLE_H) */

--- a/2.0/simde/x86/avx512/cmplt.h
+++ b/2.0/simde/x86/avx512/cmplt.h
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CMPLT_H)
+#define SIMDE_X86_AVX512_CMPLT_H
+
+#include "types.h"
+#include "mov.h"
+#include "cmp.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_cmplt_ps_mask (simde__m512 a, simde__m512 b) {
+  return simde_mm512_cmp_ps_mask(a, b, SIMDE_CMP_LT_OQ);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmplt_ps_mask
+  #define _mm512_cmplt_ps_mask(a, b) simde_mm512_cmp_ps_mask(a, b, SIMDE_CMP_LT_OQ)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_cmplt_pd_mask (simde__m512d a, simde__m512d b) {
+  return simde_mm512_cmp_pd_mask(a, b, SIMDE_CMP_LT_OQ);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmplt_pd_mask
+  #define _mm512_cmplt_pd_mask(a, b) simde_mm512_cmp_pd_mask(a, b, SIMDE_CMP_LT_OQ)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmplt_epi8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmplt_epi8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.i8 < b_.i8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] < b_.i8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmplt_epi8_mask
+  #define _mm512_cmplt_epi8_mask(a, b) simde_mm512_cmplt_epi8_mask(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_cmplt_epu8_mask (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cmplt_epu8_mask(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask64 r = 0;
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      simde__m512i_private tmp;
+
+      tmp.i8 = HEDLEY_STATIC_CAST(__typeof__(tmp.i8), a_.u8 < b_.u8);
+      r = simde_mm512_movepi8_mask(simde__m512i_from_private(tmp));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[i] < b_.u8[i]) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cmplt_epu8_mask
+  #define _mm512_cmplt_epu8_mask(a, b) simde_mm512_cmplt_epu8_mask(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CMPLT_H) */

--- a/2.0/simde/x86/avx512/copysign.h
+++ b/2.0/simde/x86/avx512/copysign.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_COPYSIGN_H)
+#define SIMDE_X86_AVX512_COPYSIGN_H
+
+#include "types.h"
+#include "mov.h"
+#include "and.h"
+#include "andnot.h"
+#include "xor.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_x_mm512_copysign_ps(simde__m512 dest, simde__m512 src) {
+  simde__m512_private
+    r_,
+    dest_ = simde__m512_to_private(dest),
+    src_ = simde__m512_to_private(src);
+
+  #if defined(simde_math_copysignf)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_copysignf(dest_.f32[i], src_.f32[i]);
+    }
+  #else
+    simde__m512 sgnbit = simde_mm512_xor_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), simde_mm512_set1_ps(-SIMDE_FLOAT32_C(0.0)));
+    return simde_mm512_xor_ps(simde_mm512_and_ps(sgnbit, src), simde_mm512_andnot_ps(sgnbit, dest));
+  #endif
+
+  return simde__m512_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_x_mm512_copysign_pd(simde__m512d dest, simde__m512d src) {
+  simde__m512d_private
+    r_,
+    dest_ = simde__m512d_to_private(dest),
+    src_ = simde__m512d_to_private(src);
+
+  #if defined(simde_math_copysign)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
+    }
+  #else
+    simde__m512d sgnbit = simde_mm512_xor_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), simde_mm512_set1_pd(-SIMDE_FLOAT64_C(0.0)));
+    return simde_mm512_xor_pd(simde_mm512_and_pd(sgnbit, src), simde_mm512_andnot_pd(sgnbit, dest));
+  #endif
+
+  return simde__m512d_from_private(r_);
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_COPYSIGN_H) */

--- a/2.0/simde/x86/avx512/cvt.h
+++ b/2.0/simde/x86/avx512/cvt.h
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CVT_H)
+#define SIMDE_X86_AVX512_CVT_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_cvtepi16_epi8 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cvtepi16_epi8(a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i8, a_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, a_.i16[i]);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtepi16_epi8
+  #define _mm512_cvtepi16_epi8(a) simde_mm512_cvtepi16_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_mask_cvtepi16_epi8 (simde__m256i src, simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_cvtepi16_epi8(src, k, a);
+  #else
+    return simde_mm256_mask_mov_epi8(src, k, simde_mm512_cvtepi16_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cvtepi16_epi8
+  #define _mm512_mask_cvtepi16_epi8(src, k, a) simde_mm512_mask_cvtepi16_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_maskz_cvtepi16_epi8 (simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_cvtepi16_epi8(k, a);
+  #else
+    return simde_mm256_maskz_mov_epi8(k, simde_mm512_cvtepi16_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_cvtepi16_epi8
+  #define _mm512_maskz_cvtepi16_epi8(k, a) simde_mm512_maskz_cvtepi16_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_cvtepi8_epi16 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cvtepi8_epi16(a);
+  #else
+    simde__m512i_private r_;
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i16, a_.i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtepi8_epi16
+  #define _mm512_cvtepi8_epi16(a) simde_mm512_cvtepi8_epi16(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CVT_H) */

--- a/2.0/simde/x86/avx512/cvts.h
+++ b/2.0/simde/x86/avx512/cvts.h
@@ -1,0 +1,715 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_CVTS_H)
+#define SIMDE_X86_AVX512_CVTS_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsepi16_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_cvtsepi16_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i16) / sizeof(a_.i16[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i16[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i16[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtsepi16_epi8
+  #define _mm_cvtsepi16_epi8(a) simde_mm_cvtsepi16_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvtsepi16_epi8 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_cvtsepi16_epi8(a);
+  #else
+    simde__m128i_private r_;
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i16[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i16[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsepi16_epi8
+  #define _mm256_cvtsepi16_epi8(a) simde_mm256_cvtsepi16_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsepi32_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_cvtsepi32_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i32[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i32[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i32[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtsepi32_epi8
+  #define _mm_cvtsepi32_epi8(a) simde_mm_cvtsepi32_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvtsepi32_epi8 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_cvtsepi32_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i32[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i32[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i32[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsepi32_epi8
+  #define _mm256_cvtsepi32_epi8(a) simde_mm256_cvtsepi32_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsepi32_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_cvtsepi32_epi16(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i16[i] =
+          (a_.i32[i] < INT16_MIN)
+            ? (INT16_MIN)
+            : ((a_.i32[i] > INT16_MAX)
+              ? (INT16_MAX)
+              : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtsepi32_epi16
+  #define _mm_cvtsepi32_epi16(a) simde_mm_cvtsepi32_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvtsepi32_epi16 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_cvtsepi32_epi16(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i16[i] =
+          (a_.i32[i] < INT16_MIN)
+            ? (INT16_MIN)
+            : ((a_.i32[i] > INT16_MAX)
+              ? (INT16_MAX)
+              : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsepi32_epi16
+  #define _mm256_cvtsepi32_epi16(a) simde_mm256_cvtsepi32_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsepi64_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm_cvtsepi64_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i64[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i64[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i64[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtsepi64_epi8
+  #define _mm_cvtsepi64_epi8(a) simde_mm_cvtsepi64_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm256_cvtsepi64_epi8 (simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm256_cvtsepi64_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m256i_private a_ = simde__m256i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i64[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i64[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i64[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cvtsepi64_epi8
+  #define _mm256_cvtsepi64_epi8(a) simde_mm256_cvtsepi64_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_cvtsepi16_epi8 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_cvtsepi16_epi8(a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] =
+          (a_.i16[i] < INT8_MIN)
+            ? (INT8_MIN)
+            : ((a_.i16[i] > INT8_MAX)
+              ? (INT8_MAX)
+              : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi16_epi8
+  #define _mm512_cvtsepi16_epi8(a) simde_mm512_cvtsepi16_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_mask_cvtsepi16_epi8 (simde__m256i src, simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_cvtsepi16_epi8(src, k, a);
+  #else
+    return simde_mm256_mask_mov_epi8(src, k, simde_mm512_cvtsepi16_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cvtsepi16_epi8
+  #define _mm512_mask_cvtsepi16_epi8(src, k, a) simde_mm512_mask_cvtsepi16_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_maskz_cvtsepi16_epi8 (simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_cvtsepi16_epi8(k, a);
+  #else
+    return simde_mm256_maskz_mov_epi8(k, simde_mm512_cvtsepi16_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_cvtsepi16_epi8
+  #define _mm512_maskz_cvtsepi16_epi8(k, a) simde_mm512_maskz_cvtsepi16_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_cvtsepi32_epi8 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cvtsepi32_epi8(a);
+  #else
+    simde__m128i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i8[i] =
+        (a_.i32[i] < INT8_MIN)
+          ? (INT8_MIN)
+          : ((a_.i32[i] > INT8_MAX)
+            ? (INT8_MAX)
+            : HEDLEY_STATIC_CAST(int8_t, a_.i32[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi32_epi8
+  #define _mm512_cvtsepi32_epi8(a) simde_mm512_cvtsepi32_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_mask_cvtsepi32_epi8 (simde__m128i src, simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cvtsepi32_epi8(src, k, a);
+  #else
+    simde__m128i_private r_;
+    simde__m128i_private src_ = simde__m128i_to_private(src);
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i8[i] = ((k>>i) &1 ) ?
+        ((a_.i32[i] < INT8_MIN)
+        ? (INT8_MIN)
+        : ((a_.i32[i] > INT8_MAX)
+          ? (INT8_MAX)
+          : HEDLEY_STATIC_CAST(int8_t, a_.i32[i]))) : src_.i8[i] ;
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_cvtsepi32_epi8(src, k, a) simde_mm512_mask_cvtsepi32_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_maskz_cvtsepi32_epi8 (simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_cvtsepi32_epi8(k, a);
+  #else
+    simde__m128i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i8[i] = ((k>>i) &1 ) ?
+                ((a_.i32[i] < INT8_MIN)
+                  ? (INT8_MIN)
+                  : ((a_.i32[i] > INT8_MAX)
+                    ? (INT8_MAX)
+                    : HEDLEY_STATIC_CAST(int8_t, a_.i32[i]))) : INT8_C(0) ;
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_cvtsepi32_epi8(k, a) simde_mm512_maskz_cvtsepi32_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_cvtsepi32_epi16 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cvtsepi32_epi16(a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i16[i] =
+        (a_.i32[i] < INT16_MIN)
+          ? (INT16_MIN)
+          : ((a_.i32[i] > INT16_MAX)
+            ? (INT16_MAX)
+            : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi32_epi16
+  #define _mm512_cvtsepi32_epi16(a) simde_mm512_cvtsepi32_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_mask_cvtsepi32_epi16 (simde__m256i src, simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cvtsepi32_epi16(src, k, a);
+  #else
+    simde__m256i_private r_;
+    simde__m256i_private src_ = simde__m256i_to_private(src);
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i16[i] = ((k>>i) &1 ) ?
+        ((a_.i32[i] < INT16_MIN)
+        ? (INT16_MIN)
+        : ((a_.i32[i] > INT16_MAX)
+          ? (INT16_MAX)
+          : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]))) : src_.i16[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_cvtsepi32_epi16(src, k, a) simde_mm512_mask_cvtsepi32_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_maskz_cvtsepi32_epi16 (simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_cvtsepi32_epi16(k, a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r_.i16[i] = ((k>>i) &1 ) ?
+                  ((a_.i32[i] < INT16_MIN)
+                  ? (INT16_MIN)
+                  : ((a_.i32[i] > INT16_MAX)
+                      ? (INT16_MAX)
+                      : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]))) : INT16_C(0);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_cvtsepi32_epi16(k, a) simde_mm512_maskz_cvtsepi32_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_cvtsepi64_epi8 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cvtsepi64_epi8(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+       r_.i8[i] =
+        (a_.i64[i] < INT8_MIN)
+          ? (INT8_MIN)
+          : ((a_.i64[i] > INT8_MAX)
+            ? (INT8_MAX)
+            : HEDLEY_STATIC_CAST(int8_t, a_.i64[i]));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi64_epi8
+  #define _mm512_cvtsepi64_epi8(a) simde_mm512_cvtsepi64_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_mask_cvtsepi64_epi8 (simde__m128i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cvtsepi64_epi8(src, k, a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private src_ = simde__m128i_to_private(src);
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i8[i] = ((k>>i) &1 ) ?
+                ((a_.i64[i] < INT8_MIN)
+                  ? (INT8_MIN)
+                  : ((a_.i64[i] > INT8_MAX)
+                    ? (INT8_MAX)
+                    : HEDLEY_STATIC_CAST(int8_t, a_.i64[i]))) : src_.i8[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cvtsepi64_epi8
+  #define _mm512_mask_cvtsepi64_epi8(src, k, a) simde_mm512_mask_cvtsepi64_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_maskz_cvtsepi64_epi8 (simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_cvtsepi64_epi8(k, a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i8[i] = ((k>>i) &1 ) ?
+                ((a_.i64[i] < INT8_MIN)
+                  ? (INT8_MIN)
+                  : ((a_.i64[i] > INT8_MAX)
+                    ? (INT8_MAX)
+                    : HEDLEY_STATIC_CAST(int8_t, a_.i64[i]))) : INT8_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_cvtsepi64_epi8(k, a) simde_mm512_maskz_cvtsepi64_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_cvtsepi64_epi16 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cvtsepi64_epi16(a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+        r_.i16[i] =
+        (a_.i64[i] < INT16_MIN)
+          ? (INT16_MIN)
+          : ((a_.i64[i] > INT16_MAX)
+            ? (INT16_MAX)
+            : HEDLEY_STATIC_CAST(int16_t, a_.i64[i]));
+      }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi64_epi16
+  #define _mm512_cvtsepi64_epi16(a) simde_mm512_cvtsepi64_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_mask_cvtsepi64_epi16 (simde__m128i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cvtsepi64_epi16(src, k, a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m128i_private src_ = simde__m128i_to_private(src);
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i16[i] = ((k>>i) & 1) ?
+                  ((a_.i64[i] < INT16_MIN)
+                  ? (INT16_MIN)
+                  : ((a_.i64[i] > INT16_MAX)
+                      ? (INT16_MAX)
+                      : HEDLEY_STATIC_CAST(int16_t, a_.i64[i]))) : src_.i16[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cvtsepi64_epi16
+  #define _mm512_mask_cvtsepi64_epi16(src, k, a) simde_mm512_mask_cvtsepi64_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_maskz_cvtsepi64_epi16 (simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_cvtsepi64_epi16(k, a);
+  #else
+    simde__m128i_private r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i16[i] = ((k>>i) & 1) ?
+                  ((a_.i64[i] < INT16_MIN)
+                  ? (INT16_MIN)
+                  : ((a_.i64[i] > INT16_MAX)
+                      ? (INT16_MAX)
+                      : HEDLEY_STATIC_CAST(int16_t, a_.i64[i]))) : INT16_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_cvtsepi64_epi16(k, a) simde_mm512_maskz_cvtsepi64_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_cvtsepi64_epi32 (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cvtsepi64_epi32(a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+        r_.i32[i] =
+        (a_.i64[i] < INT32_MIN)
+          ? (INT32_MIN)
+          : ((a_.i64[i] > INT32_MAX)
+            ? (INT32_MAX)
+            : HEDLEY_STATIC_CAST(int32_t, a_.i64[i]));
+      }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cvtsepi64_epi32
+  #define _mm512_cvtsepi64_epi32(a) simde_mm512_cvtsepi64_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_mask_cvtsepi64_epi32 (simde__m256i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cvtsepi64_epi32(src, k, a);
+  #else
+    simde__m256i_private r_;
+    simde__m256i_private src_ = simde__m256i_to_private(src);
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i32[i] = ((k>>i) & 1) ?
+        ((a_.i64[i] < INT32_MIN)
+        ? (INT32_MIN)
+        : ((a_.i64[i] > INT32_MAX)
+          ? (INT32_MAX)
+          : HEDLEY_STATIC_CAST(int32_t, a_.i64[i]))) : src_.i32[i];
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_cvtsepi64_epi32(src, k, a) simde_mm512_mask_cvtsepi64_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_maskz_cvtsepi64_epi32 (simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_cvtsepi64_epi32(k, a);
+  #else
+    simde__m256i_private r_;
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r_.i32[i] = ((k>>i) & 1) ?
+                  ((a_.i64[i] < INT32_MIN)
+                  ? (INT32_MIN)
+                  : ((a_.i64[i] > INT32_MAX)
+                      ? (INT32_MAX)
+                      : HEDLEY_STATIC_CAST(int32_t, a_.i64[i]))) : INT32_C(0);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_cvtsepi64_epi32(k, a) simde_mm512_maskz_cvtsepi64_epi32(k, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_CVTS_H) */

--- a/2.0/simde/x86/avx512/div.h
+++ b/2.0/simde/x86/avx512/div.h
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_DIV_H)
+#define SIMDE_X86_AVX512_DIV_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_div_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 / b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_div_ps(a_.m256[i], b_.m256[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_ps
+  #define _mm512_div_ps(a, b) simde_mm512_div_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_div_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_div_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_div_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_div_ps
+  #define _mm512_mask_div_ps(src, k, a, b) simde_mm512_mask_div_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_div_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_div_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_div_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_div_ps
+  #define _mm512_maskz_div_ps(k, a, b) simde_mm512_maskz_div_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_div_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 / b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_div_pd(a_.m256d[i], b_.m256d[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_pd
+  #define _mm512_div_pd(a, b) simde_mm512_div_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_div_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_div_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_div_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_div_pd
+  #define _mm512_mask_div_pd(src, k, a, b) simde_mm512_mask_div_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_div_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_div_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_div_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_div_pd
+  #define _mm512_maskz_div_pd(k, a, b) simde_mm512_maskz_div_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_DIV_H) */

--- a/2.0/simde/x86/avx512/extract.h
+++ b/2.0/simde/x86/avx512/extract.h
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_EXTRACT_H)
+#define SIMDE_X86_AVX512_EXTRACT_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm512_extractf32x4_ps (simde__m512 a, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m512_private a_ = simde__m512_to_private(a);
+
+  /* GCC 6 generates an ICE */
+  #if defined(HEDLEY_GCC_VERSION) && !HEDLEY_GCC_VERSION_CHECK(7,0,0)
+    return a_.m128[imm8 & 3];
+  #else
+    simde__m128_private r_;
+    const size_t offset = HEDLEY_STATIC_CAST(size_t, imm8 & 3) * (sizeof(r_.f32) / sizeof(r_.f32[0]));
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[i + offset];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_extractf32x4_ps(a, imm8) _mm512_extractf32x4_ps(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_extractf32x4_ps
+  #define _mm512_extractf32x4_ps(a, imm8) simde_mm512_extractf32x4_ps(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_mask_extractf32x4_ps(src, k, a, imm8) _mm512_mask_extractf32x4_ps(src, k, a, imm8)
+#else
+  #define simde_mm512_mask_extractf32x4_ps(src, k, a, imm8) simde_mm_mask_mov_ps(src, k, simde_mm512_extractf32x4_ps(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_extractf32x4_ps
+  #define _mm512_mask_extractf32x4_ps(src, k, a, imm8) simde_mm512_mask_extractf32x4_ps(src, k, a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_maskz_extractf32x4_ps(k, a, imm8) _mm512_maskz_extractf32x4_ps(k, a, imm8)
+#else
+  #define simde_mm512_maskz_extractf32x4_ps(k, a, imm8) simde_mm_maskz_mov_ps(k, simde_mm512_extractf32x4_ps(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_extractf32x4_ps
+  #define _mm512_maskz_extractf32x4_ps(k, a, imm8) simde_mm512_maskz_extractf32x4_ps(k, a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm512_extractf64x4_pd (simde__m512d a, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 1) {
+  simde__m512d_private a_ = simde__m512d_to_private(a);
+
+  return a_.m256d[imm8 & 1];
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_extractf64x4_pd(a, imm8) _mm512_extractf64x4_pd(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_extractf64x4_pd
+  #define _mm512_extractf64x4_pd(a, imm8) simde_mm512_extractf64x4_pd(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_mask_extractf64x4_pd(src, k, a, imm8) _mm512_mask_extractf64x4_pd(src, k, a, imm8)
+#else
+  #define simde_mm512_mask_extractf64x4_pd(src, k, a, imm8) simde_mm256_mask_mov_pd(src, k, simde_mm512_extractf64x4_pd(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_extractf64x4_pd
+  #define _mm512_mask_extractf64x4_pd(src, k, a, imm8) simde_mm512_mask_extractf64x4_pd(src, k, a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_maskz_extractf64x4_pd(k, a, imm8) _mm512_maskz_extractf64x4_pd(k, a, imm8)
+#else
+  #define simde_mm512_maskz_extractf64x4_pd(k, a, imm8) simde_mm256_maskz_mov_pd(k, simde_mm512_extractf64x4_pd(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_extractf64x4_pd
+  #define _mm512_maskz_extractf64x4_pd(k, a, imm8) simde_mm512_maskz_extractf64x4_pd(k, a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm512_extracti32x4_epi32 (simde__m512i a, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m512i_private a_ = simde__m512i_to_private(a);
+
+  return a_.m128i[imm8 & 3];
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_extracti32x4_epi32(a, imm8) _mm512_extracti32x4_epi32(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_extracti32x4_epi32
+  #define _mm512_extracti32x4_epi32(a, imm8) simde_mm512_extracti32x4_epi32(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_mask_extracti32x4_epi32(src, k, a, imm8) _mm512_mask_extracti32x4_epi32(src, k, a, imm8)
+#else
+  #define simde_mm512_mask_extracti32x4_epi32(src, k, a, imm8) simde_mm_mask_mov_epi32(src, k, simde_mm512_extracti32x4_epi32(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_extracti32x4_epi32
+  #define _mm512_mask_extracti32x4_epi32(src, k, a, imm8) simde_mm512_mask_extracti32x4_epi32(src, k, a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_maskz_extracti32x4_epi32(k, a, imm8) _mm512_maskz_extracti32x4_epi32(k, a, imm8)
+#else
+  #define simde_mm512_maskz_extracti32x4_epi32(k, a, imm8) simde_mm_maskz_mov_epi32(k, simde_mm512_extracti32x4_epi32(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_extracti32x4_epi32
+  #define _mm512_maskz_extracti32x4_epi32(k, a, imm8) simde_mm512_maskz_extracti32x4_epi32(k, a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm512_extracti64x4_epi64 (simde__m512i a, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 1) {
+  simde__m512i_private a_ = simde__m512i_to_private(a);
+
+  return a_.m256i[imm8 & 1];
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_extracti64x4_epi64(a, imm8) _mm512_extracti64x4_epi64(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_extracti64x4_epi64
+  #define _mm512_extracti64x4_epi64(a, imm8) simde_mm512_extracti64x4_epi64(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_mask_extracti64x4_epi64(src, k, a, imm8) _mm512_mask_extracti64x4_epi64(src, k, a, imm8)
+#else
+  #define simde_mm512_mask_extracti64x4_epi64(src, k, a, imm8) simde_mm256_mask_mov_epi64(src, k, simde_mm512_extracti64x4_epi64(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_extracti64x4_epi64
+  #define _mm512_mask_extracti64x4_epi64(src, k, a, imm8) simde_mm512_mask_extracti64x4_epi64(src, k, a, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,0,0))
+  #define simde_mm512_maskz_extracti64x4_epi64(k, a, imm8) _mm512_maskz_extracti64x4_epi64(k, a, imm8)
+#else
+  #define simde_mm512_maskz_extracti64x4_epi64(k, a, imm8) simde_mm256_maskz_mov_epi64(k, simde_mm512_extracti64x4_epi64(a, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_extracti64x4_epi64
+  #define _mm512_maskz_extracti64x4_epi64(k, a, imm8) simde_mm512_maskz_extracti64x4_epi64(k, a, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_EXTRACT_H) */

--- a/2.0/simde/x86/avx512/fmadd.h
+++ b/2.0/simde/x86/avx512/fmadd.h
@@ -1,0 +1,136 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_FMADD_H)
+#define SIMDE_X86_AVX512_FMADD_H
+
+#include "types.h"
+#include "mov.h"
+#include "../fma.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fmadd_ps (simde__m512 a, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fmadd_ps(a, b, c);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b),
+      c_ = simde__m512_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_fmadd_ps(a_.m256[i], b_.m256[i], c_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = (a_.f32 * b_.f32) + c_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m32) / sizeof(r_.m32)) ; i++) {
+        r_.f32[i] = (a_.f32[i] * b_.f32[i]) + c_.f32[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fmadd_ps
+  #define _mm512_fmadd_ps(a, b, c) simde_mm512_fmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_fmadd_ps(simde__m512 a, simde__mmask16 k, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_fmadd_ps(a, k, b, c);
+  #else
+    return simde_mm512_mask_mov_ps(a, k, simde_mm512_fmadd_ps(a, b, c));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_fmadd_ps
+  #define _mm512_mask_fmadd_ps(a, k, b, c) simde_mm512_mask_fmadd_ps(a, k, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_fmadd_ps(simde__mmask16 k, simde__m512 a, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_fmadd_ps(k, a, b, c);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_fmadd_ps(a, b, c));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_fmadd_ps
+  #define _mm512_maskz_fmadd_ps(k, a, b, c) simde_mm512_maskz_fmadd_ps(k, a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fmadd_pd (simde__m512d a, simde__m512d b, simde__m512d c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fmadd_pd(a, b, c);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b),
+      c_ = simde__m512d_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_fmadd_pd(a_.m256d[i], b_.m256d[i], c_.m256d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = (a_.f64 * b_.f64) + c_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m64) / sizeof(r_.m64)) ; i++) {
+        r_.f64[i] = (a_.f64[i] * b_.f64[i]) + c_.f64[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fmadd_pd
+  #define _mm512_fmadd_pd(a, b, c) simde_mm512_fmadd_pd(a, b, c)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FMADD_H) */

--- a/2.0/simde/x86/avx512/fmsub.h
+++ b/2.0/simde/x86/avx512/fmsub.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      kitegi <kitegi@users.noreply.github.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_FMSUB_H)
+#define SIMDE_X86_AVX512_FMSUB_H
+
+#include "types.h"
+#include "mov.h"
+#include "../fma.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fmsub_ps (simde__m512 a, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fmsub_ps(a, b, c);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b),
+      c_ = simde__m512_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_fmsub_ps(a_.m256[i], b_.m256[i], c_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = (a_.f32 * b_.f32) - c_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m32) / sizeof(r_.m32)) ; i++) {
+        r_.f32[i] = (a_.f32[i] * b_.f32[i]) - c_.f32[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fmsub_ps
+  #define _mm512_fmsub_ps(a, b, c) simde_mm512_fmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fmsub_pd (simde__m512d a, simde__m512d b, simde__m512d c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fmsub_pd(a, b, c);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b),
+      c_ = simde__m512d_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_fmsub_pd(a_.m256d[i], b_.m256d[i], c_.m256d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = (a_.f64 * b_.f64) - c_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m64) / sizeof(r_.m64)) ; i++) {
+        r_.f64[i] = (a_.f64[i] * b_.f64[i]) - c_.f64[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fmsub_pd
+  #define _mm512_fmsub_pd(a, b, c) simde_mm512_fmsub_pd(a, b, c)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FMSUB_H) */

--- a/2.0/simde/x86/avx512/fnmadd.h
+++ b/2.0/simde/x86/avx512/fnmadd.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      kitegi <kitegi@users.noreply.github.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_FNMADD_H)
+#define SIMDE_X86_AVX512_FNMADD_H
+
+#include "types.h"
+#include "mov.h"
+#include "../fma.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fnmadd_ps (simde__m512 a, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fnmadd_ps(a, b, c);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b),
+      c_ = simde__m512_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_fnmadd_ps(a_.m256[i], b_.m256[i], c_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = -(a_.f32 * b_.f32) + c_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m32) / sizeof(r_.m32)) ; i++) {
+        r_.f32[i] = -(a_.f32[i] * b_.f32[i]) + c_.f32[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fnmadd_ps
+  #define _mm512_fnmadd_ps(a, b, c) simde_mm512_fnmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fnmadd_pd (simde__m512d a, simde__m512d b, simde__m512d c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fnmadd_pd(a, b, c);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b),
+      c_ = simde__m512d_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_fnmadd_pd(a_.m256d[i], b_.m256d[i], c_.m256d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = -(a_.f64 * b_.f64) + c_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m64) / sizeof(r_.m64)) ; i++) {
+        r_.f64[i] = -(a_.f64[i] * b_.f64[i]) + c_.f64[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fnmadd_pd
+  #define _mm512_fnmadd_pd(a, b, c) simde_mm512_fnmadd_pd(a, b, c)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FNMADD_H) */

--- a/2.0/simde/x86/avx512/fnmsub.h
+++ b/2.0/simde/x86/avx512/fnmsub.h
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      kitegi <kitegi@users.noreply.github.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_FNMSUB_H)
+#define SIMDE_X86_AVX512_FNMSUB_H
+
+#include "types.h"
+#include "mov.h"
+#include "../fma.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_fnmsub_ps (simde__m512 a, simde__m512 b, simde__m512 c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fnmsub_ps(a, b, c);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b),
+      c_ = simde__m512_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_fnmsub_ps(a_.m256[i], b_.m256[i], c_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = -(a_.f32 * b_.f32) - c_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m32) / sizeof(r_.m32)) ; i++) {
+        r_.f32[i] = -(a_.f32[i] * b_.f32[i]) - c_.f32[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fnmsub_ps
+  #define _mm512_fnmsub_ps(a, b, c) simde_mm512_fnmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_fnmsub_pd (simde__m512d a, simde__m512d b, simde__m512d c) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_fnmsub_pd(a, b, c);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b),
+      c_ = simde__m512d_to_private(c);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_fnmsub_pd(a_.m256d[i], b_.m256d[i], c_.m256d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = -(a_.f64 * b_.f64) - c_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m64) / sizeof(r_.m64)) ; i++) {
+        r_.f64[i] = -(a_.f64[i] * b_.f64[i]) - c_.f64[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_fnmsub_pd
+  #define _mm512_fnmsub_pd(a, b, c) simde_mm512_fnmsub_pd(a, b, c)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_FNMSUB_H) */

--- a/2.0/simde/x86/avx512/insert.h
+++ b/2.0/simde/x86/avx512/insert.h
@@ -1,0 +1,193 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_INSERT_H)
+#define SIMDE_X86_AVX512_INSERT_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_insertf32x4 (simde__m512 a, simde__m128 b, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m512_private a_ = simde__m512_to_private(a);
+
+  a_.m128[imm8 & 3] = b;
+
+  return simde__m512_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_insertf32x4(a, b, imm8) _mm512_insertf32x4(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_insertf32x4
+  #define _mm512_insertf32x4(a, b, imm8) simde_mm512_insertf32x4(a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,0,0))
+  #define simde_mm512_mask_insertf32x4(src, k, a, b, imm8) _mm512_mask_insertf32x4(src, k, a, b, imm8)
+#else
+  #define simde_mm512_mask_insertf32x4(src, k, a, b, imm8) simde_mm512_mask_mov_ps(src, k, simde_mm512_insertf32x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_insertf32x4
+  #define _mm512_mask_insertf32x4(src, k, a, b, imm8) simde_mm512_mask_insertf32x4(src, k, a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,0,0))
+  #define simde_mm512_maskz_insertf32x4(k, a, b, imm8) _mm512_maskz_insertf32x4(k, a, b, imm8)
+#else
+  #define simde_mm512_maskz_insertf32x4(k, a, b, imm8) simde_mm512_maskz_mov_ps(k, simde_mm512_insertf32x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_insertf32x4
+  #define _mm512_maskz_insertf32x4(k, a, b, imm8) simde_mm512_maskz_insertf32x4(k, a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_insertf64x4 (simde__m512d a, simde__m256d b, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 1) {
+  simde__m512d_private a_ = simde__m512d_to_private(a);
+
+  a_.m256d[imm8 & 1] = b;
+
+  return simde__m512d_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_insertf64x4(a, b, imm8) _mm512_insertf64x4(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_insertf64x4
+  #define _mm512_insertf64x4(a, b, imm8) simde_mm512_insertf64x4(a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_insertf64x4(src, k, a, b, imm8) _mm512_mask_insertf64x4(src, k, a, b, imm8)
+#else
+  #define simde_mm512_mask_insertf64x4(src, k, a, b, imm8) simde_mm512_mask_mov_pd(src, k, simde_mm512_insertf64x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_insertf64x4
+  #define _mm512_mask_insertf64x4(src, k, a, b, imm8) simde_mm512_mask_insertf64x4(src, k, a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_insertf64x4(k, a, b, imm8) _mm512_maskz_insertf64x4(k, a, b, imm8)
+#else
+  #define simde_mm512_maskz_insertf64x4(k, a, b, imm8) simde_mm512_maskz_mov_pd(k, simde_mm512_insertf64x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_insertf64x4
+  #define _mm512_maskz_insertf64x4(k, a, b, imm8) simde_mm512_maskz_insertf64x4(k, a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_inserti32x4 (simde__m512i a, simde__m128i b, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m512i_private a_ = simde__m512i_to_private(a);
+
+  a_.m128i[imm8 & 3] = b;
+
+  return simde__m512i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_inserti32x4(a, b, imm8) _mm512_inserti32x4(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_inserti32x4
+  #define _mm512_inserti32x4(a, b, imm8) simde_mm512_inserti32x4(a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,0,0))
+  #define simde_mm512_mask_inserti32x4(src, k, a, b, imm8) _mm512_mask_inserti32x4(src, k, a, b, imm8)
+#else
+  #define simde_mm512_mask_inserti32x4(src, k, a, b, imm8) simde_mm512_mask_mov_epi32(src, k, simde_mm512_inserti32x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_inserti32x4
+  #define _mm512_mask_inserti32x4(src, k, a, b, imm8) simde_mm512_mask_inserti32x4(src, k, a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,0,0))
+  #define simde_mm512_maskz_inserti32x4(k, a, b, imm8) _mm512_maskz_inserti32x4(k, a, b, imm8)
+#else
+  #define simde_mm512_maskz_inserti32x4(k, a, b, imm8) simde_mm512_maskz_mov_epi32(k, simde_mm512_inserti32x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_inserti32x4
+  #define _mm512_maskz_inserti32x4(k, a, b, imm8) simde_mm512_maskz_inserti32x4(k, a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_inserti64x4 (simde__m512i a, simde__m256i b, int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 1) {
+  simde__m512i_private a_ = simde__m512i_to_private(a);
+
+  a_.m256i[imm8 & 1] = b;
+
+  return simde__m512i_from_private(a_);
+}
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_inserti64x4(a, b, imm8) _mm512_inserti64x4(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_inserti64x4
+  #define _mm512_inserti64x4(a, b, imm8) simde_mm512_inserti64x4(a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_inserti64x4(src, k, a, b, imm8) _mm512_mask_inserti64x4(src, k, a, b, imm8)
+#else
+  #define simde_mm512_mask_inserti64x4(src, k, a, b, imm8) simde_mm512_mask_mov_epi64(src, k, simde_mm512_inserti64x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_inserti64x4
+  #define _mm512_mask_inserti64x4(src, k, a, b, imm8) simde_mm512_mask_inserti64x4(src, k, a, b, imm8)
+#endif
+
+#if defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_inserti64x4(k, a, b, imm8) _mm512_maskz_inserti64x4(k, a, b, imm8)
+#else
+  #define simde_mm512_maskz_inserti64x4(k, a, b, imm8) simde_mm512_maskz_mov_epi64(k, simde_mm512_inserti64x4(a, b, imm8))
+#endif
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_inserti64x4
+  #define _mm512_maskz_inserti64x4(k, a, b, imm8) simde_mm512_maskz_inserti64x4(k, a, b, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_INSERT_H) */

--- a/2.0/simde/x86/avx512/load.h
+++ b/2.0/simde/x86/avx512/load.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_LOAD_H)
+#define SIMDE_X86_AVX512_LOAD_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_load_si512 (void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_load_si512(HEDLEY_REINTERPRET_CAST(void const*, mem_addr));
+  #else
+    simde__m512i r;
+    simde_memcpy(&r, SIMDE_ASSUME_ALIGNED_AS(simde__m512i, mem_addr), sizeof(r));
+    return r;
+  #endif
+}
+#define simde_mm512_load_epi8(mem_addr) simde_mm512_load_si512(mem_addr)
+#define simde_mm512_load_epi16(mem_addr) simde_mm512_load_si512(mem_addr)
+#define simde_mm512_load_epi32(mem_addr) simde_mm512_load_si512(mem_addr)
+#define simde_mm512_load_epi64(mem_addr) simde_mm512_load_si512(mem_addr)
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_load_epi8
+  #undef _mm512_load_epi16
+  #undef _mm512_load_epi32
+  #undef _mm512_load_epi64
+  #undef _mm512_load_si512
+  #define _mm512_load_si512(a) simde_mm512_load_si512(a)
+  #define _mm512_load_epi8(a) simde_mm512_load_si512(a)
+  #define _mm512_load_epi16(a) simde_mm512_load_si512(a)
+  #define _mm512_load_epi32(a) simde_mm512_load_si512(a)
+  #define _mm512_load_epi64(a) simde_mm512_load_si512(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_LOAD_H) */

--- a/2.0/simde/x86/avx512/loadu.h
+++ b/2.0/simde/x86/avx512/loadu.h
@@ -1,0 +1,111 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_LOADU_H)
+#define SIMDE_X86_AVX512_LOADU_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_loadu_ps (void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_loadu_ps(mem_addr);
+  #else
+    simde__m512 r;
+    simde_memcpy(&r, mem_addr, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_loadu_ps
+  #define _mm512_loadu_ps(a) simde_mm512_loadu_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_loadu_pd (void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_loadu_pd(mem_addr);
+  #else
+    simde__m512d r;
+    simde_memcpy(&r, mem_addr, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_loadu_pd
+  #define _mm512_loadu_pd(a) simde_mm512_loadu_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_loadu_si512 (void const * mem_addr) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_loadu_si512(HEDLEY_REINTERPRET_CAST(void const*, mem_addr));
+  #else
+    simde__m512i r;
+
+    #if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias,3,3,0)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+      struct simde_mm512_loadu_si512_s {
+        __typeof__(r) v;
+      } __attribute__((__packed__, __may_alias__));
+      r = HEDLEY_REINTERPRET_CAST(const struct simde_mm512_loadu_si512_s *, mem_addr)->v;
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      simde_memcpy(&r, mem_addr, sizeof(r));
+    #endif
+
+    return r;
+  #endif
+}
+#define simde_mm512_loadu_epi8(mem_addr) simde_mm512_loadu_si512(mem_addr)
+#define simde_mm512_loadu_epi16(mem_addr) simde_mm512_loadu_si512(mem_addr)
+#define simde_mm512_loadu_epi32(mem_addr) simde_mm512_loadu_si512(mem_addr)
+#define simde_mm512_loadu_epi64(mem_addr) simde_mm512_loadu_si512(mem_addr)
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_loadu_epi8
+  #undef _mm512_loadu_epi16
+  #undef _mm512_loadu_epi32
+  #undef _mm512_loadu_epi64
+  #undef _mm512_loadu_si512
+  #define _mm512_loadu_si512(a) simde_mm512_loadu_si512(a)
+  #define _mm512_loadu_epi8(a) simde_mm512_loadu_si512(a)
+  #define _mm512_loadu_epi16(a) simde_mm512_loadu_si512(a)
+  #define _mm512_loadu_epi32(a) simde_mm512_loadu_si512(a)
+  #define _mm512_loadu_epi64(a) simde_mm512_loadu_si512(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_LOADU_H) */

--- a/2.0/simde/x86/avx512/lzcnt.h
+++ b/2.0/simde/x86/avx512/lzcnt.h
@@ -1,0 +1,209 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_LZCNT_H)
+#define SIMDE_X86_AVX512_LZCNT_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if \
+    ( HEDLEY_HAS_BUILTIN(__builtin_clz) || \
+      HEDLEY_GCC_VERSION_CHECK(3,4,0) || \
+      HEDLEY_ARM_VERSION_CHECK(4,1,0) ) && \
+    defined(__INT_MAX__) && defined(__LONG_MAX__) && defined(__LONG_LONG_MAX__) && \
+    defined(__INT32_MAX__) && defined(__INT64_MAX__)
+  #if __INT_MAX__ == __INT32_MAX__
+    #define simde_x_clz32(v) __builtin_clz(HEDLEY_STATIC_CAST(unsigned int, (v)))
+  #elif __LONG_MAX__ == __INT32_MAX__
+    #define simde_x_clz32(v) __builtin_clzl(HEDLEY_STATIC_CAST(unsigned long, (v)))
+  #elif __LONG_LONG_MAX__ == __INT32_MAX__
+    #define simde_x_clz32(v) __builtin_clzll(HEDLEY_STATIC_CAST(unsigned long long, (v)))
+  #endif
+
+  #if __INT_MAX__ == __INT64_MAX__
+    #define simde_x_clz64(v) __builtin_clz(HEDLEY_STATIC_CAST(unsigned int, (v)))
+  #elif __LONG_MAX__ == __INT64_MAX__
+    #define simde_x_clz64(v) __builtin_clzl(HEDLEY_STATIC_CAST(unsigned long, (v)))
+  #elif __LONG_LONG_MAX__ == __INT64_MAX__
+    #define simde_x_clz64(v) __builtin_clzll(HEDLEY_STATIC_CAST(unsigned long long, (v)))
+  #endif
+#elif HEDLEY_MSVC_VERSION_CHECK(14,0,0)
+  static int simde_x_clz32(uint32_t x) {
+    unsigned long r;
+    _BitScanReverse(&r, x);
+    return 31 - HEDLEY_STATIC_CAST(int, r);
+  }
+  #define simde_x_clz32 simde_x_clz32
+
+  static int simde_x_clz64(uint64_t x) {
+    unsigned long r;
+
+    #if defined(_M_AMD64) || defined(_M_ARM64)
+      _BitScanReverse64(&r, x);
+      return 63 - HEDLEY_STATIC_CAST(int, r);
+    #else
+      uint32_t high = HEDLEY_STATIC_CAST(uint32_t, x >> 32);
+      if (high != 0)
+        return _BitScanReverse(&r, HEDLEY_STATIC_CAST(unsigned long, high));
+      else
+        return _BitScanReverse(&r, HEDLEY_STATIC_CAST(unsigned long, x & ~UINT32_C(0))) + 32;
+    #endif
+  }
+  #define simde_x_clz64 simde_x_clz64
+#endif
+
+#if !defined(simde_x_clz32) || !defined(simde_x_clz64)
+  static uint8_t simde_x_avx512cd_lz_lookup(const uint8_t value) {
+    static const uint8_t lut[256] = {
+      7, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4,
+      3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+      2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+      2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    return lut[value];
+  };
+
+  #if !defined(simde_x_clz32)
+    static int simde_x_clz32(uint32_t x) {
+      size_t s = sizeof(x) * 8;
+      uint32_t r;
+
+      while ((s -= 8) != 0) {
+        r = x >> s;
+        if (r != 0)
+          return simde_x_avx512cd_lz_lookup(HEDLEY_STATIC_CAST(uint8_t, r)) +
+            (((sizeof(x) - 1) * 8) - s);
+      }
+
+      if (x == 0)
+        return (int) ((sizeof(x) * 8) - 1);
+      else
+        return simde_x_avx512cd_lz_lookup(HEDLEY_STATIC_CAST(uint8_t, x)) +
+          ((sizeof(x) - 1) * 8);
+    }
+  #endif
+
+  #if !defined(simde_x_clz64)
+    static int simde_x_clz64(uint64_t x) {
+      size_t s = sizeof(x) * 8;
+      uint64_t r;
+
+      while ((s -= 8) != 0) {
+        r = x >> s;
+        if (r != 0)
+          return simde_x_avx512cd_lz_lookup(HEDLEY_STATIC_CAST(uint8_t, r)) +
+            (((sizeof(x) - 1) * 8) - s);
+      }
+
+      if (x == 0)
+        return (int) ((sizeof(x) * 8) - 1);
+      else
+        return simde_x_avx512cd_lz_lookup(HEDLEY_STATIC_CAST(uint8_t, x)) +
+          ((sizeof(x) - 1) * 8);
+    }
+  #endif
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_lzcnt_epi32(simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512CD_NATIVE)
+    return _mm_lzcnt_epi32(a);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    /* https://stackoverflow.com/a/58827596/501126 */
+    a = _mm_andnot_si128(_mm_srli_epi32(a, 8), a);
+    a = _mm_castps_si128(_mm_cvtepi32_ps(a));
+    a = _mm_srli_epi32(a, 23);
+    a = _mm_subs_epu16(_mm_set1_epi32(158), a);
+    a = _mm_min_epi16(a, _mm_set1_epi32(32));
+    return a;
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0; i < (sizeof(r_.i32) / sizeof(r_.i32[0])); i++) {
+      r_.i32[i] = (HEDLEY_UNLIKELY(a_.i32[i] == 0) ? HEDLEY_STATIC_CAST(int32_t, sizeof(int32_t) * CHAR_BIT) : HEDLEY_STATIC_CAST(int32_t, simde_x_clz32(HEDLEY_STATIC_CAST(uint32_t, a_.i32[i]))));
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512CD_ENABLE_NATIVE_ALIASES)
+  #undef _mm_lzcnt_epi32
+  #define _mm_lzcnt_epi32(a) simde_mm_lzcnt_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_lzcnt_epi32(simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512CD_NATIVE)
+    return _mm_mask_lzcnt_epi32(src, k, a);
+  #else
+    return simde_mm_mask_mov_epi32(src, k, simde_mm_lzcnt_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_lzcnt_epi32
+  #define _mm_mask_lzcnt_epi32(src, k, a) simde_mm_mask_lzcnt_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_lzcnt_epi32(simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512CD_NATIVE)
+    return _mm_maskz_lzcnt_epi32(k, a);
+  #else
+    return simde_mm_maskz_mov_epi32(k, simde_mm_lzcnt_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_lzcnt_epi32
+  #define _mm_maskz_lzcnt_epi32(k, a) simde_mm_maskz_lzcnt_epi32(k, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_LZCNT_H) */

--- a/2.0/simde/x86/avx512/max.h
+++ b/2.0/simde/x86/avx512/max.h
@@ -1,0 +1,587 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MAX_H)
+#define SIMDE_X86_AVX512_MAX_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_max_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? a_.i8[i] : b_.i8[i];
+      }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#  define _mm512_max_epi8(a, b) simde_mm512_max_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_max_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_max_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epi8
+  #define _mm512_mask_max_epi8(src, k, a, b) simde_mm512_mask_max_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_max_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_max_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epi8
+  #define _mm512_maskz_max_epi8(k, a, b) simde_mm512_maskz_max_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_max_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_max_epu8(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epu8
+  #define _mm512_max_epu8(a, b) simde_mm512_max_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epu8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_max_epu8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_max_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epu8
+  #define _mm512_mask_max_epu8(src, k, a, b) simde_mm512_mask_max_epu8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epu8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_max_epu8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_max_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epu8
+  #define _mm512_maskz_max_epu8(k, a, b) simde_mm512_maskz_max_epu8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_max_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#  define _mm512_max_epi16(a, b) simde_mm512_max_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_max_epi16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_max_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epi16
+  #define _mm512_mask_max_epi16(src, k, a, b) simde_mm512_mask_max_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epi16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_max_epi16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_max_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epi16
+  #define _mm512_maskz_max_epi16(k, a, b) simde_mm512_maskz_max_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_max_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_max_epu16(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] > b_.u16[i]) ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epu16
+  #define _mm512_max_epu16(a, b) simde_mm512_max_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epu16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_max_epu16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_max_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epu16
+  #define _mm512_mask_max_epu16(src, k, a, b) simde_mm512_mask_max_epu16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epu16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_max_epu16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_max_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epu16
+  #define _mm512_maskz_max_epu16(k, a, b) simde_mm512_maskz_max_epu16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256i[0] = simde_mm256_max_epi32(a_.m256i[0], b_.m256i[0]);
+    r_.m256i[1] = simde_mm256_max_epi32(a_.m256i[1], b_.m256i[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] > b_.i32[i] ? a_.i32[i] : b_.i32[i];
+    }
+  #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epi32
+  #define _mm512_max_epi32(a, b) simde_mm512_max_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_max_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epi32
+  #define _mm512_mask_max_epi32(src, k, a, b) simde_mm512_mask_max_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_max_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epi32
+  #define _mm512_maskz_max_epi32(k, a, b) simde_mm512_maskz_max_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epu32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_epu32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256i[0] = simde_mm256_max_epu32(a_.m256i[0], b_.m256i[0]);
+    r_.m256i[1] = simde_mm256_max_epu32(a_.m256i[1], b_.m256i[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (a_.u32[i] > b_.u32[i]) ? a_.u32[i] : b_.u32[i];
+    }
+  #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epu32
+  #define _mm512_max_epu32(a, b) simde_mm512_max_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epu32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_epu32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_max_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epu32
+  #define _mm512_mask_max_epu32(src, k, a, b) simde_mm512_mask_max_epu32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epu32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_epu32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_max_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epu32
+  #define _mm512_maskz_max_epu32(k, a, b) simde_mm512_maskz_max_epu32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] > b_.i64[i] ? a_.i64[i] : b_.i64[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epi64
+  #define _mm512_max_epi64(a, b) simde_mm512_max_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_max_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epi64
+  #define _mm512_mask_max_epi64(src, k, a, b) simde_mm512_mask_max_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_max_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epi64
+  #define _mm512_maskz_max_epi64(k, a, b) simde_mm512_maskz_max_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_max_epu64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_epu64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (a_.u64[i] > b_.u64[i]) ? a_.u64[i] : b_.u64[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_epu64
+  #define _mm512_max_epu64(a, b) simde_mm512_max_epu64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_max_epu64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_epu64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_max_epu64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_epu64
+  #define _mm512_mask_max_epu64(src, k, a, b) simde_mm512_mask_max_epu64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_max_epu64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_epu64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_max_epu64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_epu64
+  #define _mm512_maskz_max_epu64(k, a, b) simde_mm512_maskz_max_epu64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_max_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256[0] = simde_mm256_max_ps(a_.m256[0], b_.m256[0]);
+    r_.m256[1] = simde_mm256_max_ps(a_.m256[1], b_.m256[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[i] > b_.f32[i] ? a_.f32[i] : b_.f32[i];
+    }
+  #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_ps
+  #define _mm512_max_ps(a, b) simde_mm512_max_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_max_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_max_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_ps
+  #define _mm512_mask_max_ps(src, k, a, b) simde_mm512_mask_max_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_max_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_max_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_ps
+  #define _mm512_maskz_max_ps(k, a, b) simde_mm512_maskz_max_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_max_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_max_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[i] > b_.f64[i] ? a_.f64[i] : b_.f64[i];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_max_pd
+  #define _mm512_max_pd(a, b) simde_mm512_max_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_max_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_max_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_max_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_max_pd
+  #define _mm512_mask_max_pd(src, k, a, b) simde_mm512_mask_max_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_max_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_max_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_max_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_max_pd
+  #define _mm512_maskz_max_pd(k, a, b) simde_mm512_maskz_max_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MAX_H) */

--- a/2.0/simde/x86/avx512/min.h
+++ b/2.0/simde/x86/avx512/min.h
@@ -1,0 +1,587 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MIN_H)
+#define SIMDE_X86_AVX512_MIN_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_min_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? a_.i8[i] : b_.i8[i];
+      }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#  define _mm512_min_epi8(a, b) simde_mm512_min_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_min_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_min_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epi8
+  #define _mm512_mask_min_epi8(src, k, a, b) simde_mm512_mask_min_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_min_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_min_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epi8
+  #define _mm512_maskz_min_epi8(k, a, b) simde_mm512_maskz_min_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_min_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_min_epu8(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epu8
+  #define _mm512_min_epu8(a, b) simde_mm512_min_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epu8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_min_epu8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_min_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epu8
+  #define _mm512_mask_min_epu8(src, k, a, b) simde_mm512_mask_min_epu8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epu8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_min_epu8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_min_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epu8
+  #define _mm512_maskz_min_epu8(k, a, b) simde_mm512_maskz_min_epu8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_min_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#  define _mm512_min_epi16(a, b) simde_mm512_min_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_min_epi16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_min_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epi16
+  #define _mm512_mask_min_epi16(src, k, a, b) simde_mm512_mask_min_epi16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epi16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_min_epi16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_min_epi16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epi16
+  #define _mm512_maskz_min_epi16(k, a, b) simde_mm512_maskz_min_epi16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_min_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_min_epu16(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] < b_.u16[i]) ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epu16
+  #define _mm512_min_epu16(a, b) simde_mm512_min_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epu16 (simde__m512i src, simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_min_epu16(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_min_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epu16
+  #define _mm512_mask_min_epu16(src, k, a, b) simde_mm512_mask_min_epu16(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epu16 (simde__mmask32 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_min_epu16(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_min_epu16(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epu16
+  #define _mm512_maskz_min_epu16(k, a, b) simde_mm512_maskz_min_epu16(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256i[0] = simde_mm256_min_epi32(a_.m256i[0], b_.m256i[0]);
+    r_.m256i[1] = simde_mm256_min_epi32(a_.m256i[1], b_.m256i[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] < b_.i32[i] ? a_.i32[i] : b_.i32[i];
+    }
+  #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epi32
+  #define _mm512_min_epi32(a, b) simde_mm512_min_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_min_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epi32
+  #define _mm512_mask_min_epi32(src, k, a, b) simde_mm512_mask_min_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+  simde_mm512_maskz_min_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_min_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epi32
+  #define _mm512_maskz_min_epi32(k, a, b) simde_mm512_maskz_min_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epu32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_epu32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256i[0] = simde_mm256_min_epu32(a_.m256i[0], b_.m256i[0]);
+    r_.m256i[1] = simde_mm256_min_epu32(a_.m256i[1], b_.m256i[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = (a_.u32[i] < b_.u32[i]) ? a_.u32[i] : b_.u32[i];
+    }
+  #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epu32
+  #define _mm512_min_epu32(a, b) simde_mm512_min_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epu32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_epu32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_min_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epu32
+  #define _mm512_mask_min_epu32(src, k, a, b) simde_mm512_mask_min_epu32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epu32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_epu32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_min_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epu32
+  #define _mm512_maskz_min_epu32(k, a, b) simde_mm512_maskz_min_epu32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] < b_.i64[i] ? a_.i64[i] : b_.i64[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epi64
+  #define _mm512_min_epi64(a, b) simde_mm512_min_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_min_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epi64
+  #define _mm512_mask_min_epi64(src, k, a, b) simde_mm512_mask_min_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_min_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epi64
+  #define _mm512_maskz_min_epi64(k, a, b) simde_mm512_maskz_min_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_min_epu64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_epu64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+      r_.u64[i] = (a_.u64[i] < b_.u64[i]) ? a_.u64[i] : b_.u64[i];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_epu64
+  #define _mm512_min_epu64(a, b) simde_mm512_min_epu64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_min_epu64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_epu64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_min_epu64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_epu64
+  #define _mm512_mask_min_epu64(src, k, a, b) simde_mm512_mask_min_epu64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_min_epu64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_epu64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_min_epu64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_epu64
+  #define _mm512_maskz_min_epu64(k, a, b) simde_mm512_maskz_min_epu64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_min_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256[0] = simde_mm256_min_ps(a_.m256[0], b_.m256[0]);
+    r_.m256[1] = simde_mm256_min_ps(a_.m256[1], b_.m256[1]);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[i] < b_.f32[i] ? a_.f32[i] : b_.f32[i];
+    }
+  #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_ps
+  #define _mm512_min_ps(a, b) simde_mm512_min_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_min_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_min_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_ps
+  #define _mm512_mask_min_ps(src, k, a, b) simde_mm512_mask_min_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_min_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_min_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_ps
+  #define _mm512_maskz_min_ps(k, a, b) simde_mm512_maskz_min_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_min_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_min_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[i] < b_.f64[i] ? a_.f64[i] : b_.f64[i];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_min_pd
+  #define _mm512_min_pd(a, b) simde_mm512_min_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_min_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_min_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_min_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_min_pd
+  #define _mm512_mask_min_pd(src, k, a, b) simde_mm512_mask_min_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_min_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_min_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_min_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_min_pd
+  #define _mm512_maskz_min_pd(k, a, b) simde_mm512_maskz_min_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MIN_H) */

--- a/2.0/simde/x86/avx512/mov.h
+++ b/2.0/simde/x86/avx512/mov.h
@@ -1,0 +1,859 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MOV_H)
+#define SIMDE_X86_AVX512_MOV_H
+
+#include "types.h"
+#include "cast.h"
+#include "set.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi8 (simde__m128i src, simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi8(src, k, a);
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi8
+  #define _mm_mask_mov_epi8(src, k, a) simde_mm_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi16 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi16(src, k, a);
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi16
+  #define _mm_mask_mov_epi16(src, k, a) simde_mm_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi32 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi32(src, k, a);
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi32
+  #define _mm_mask_mov_epi32(src, k, a) simde_mm_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_mov_epi64 (simde__m128i src, simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_epi64(src, k, a);
+  #else
+    simde__m128i_private
+      src_ = simde__m128i_to_private(src),
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    /* N.B. CM: No fallbacks as there are only two elements */
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_epi64
+  #define _mm_mask_mov_epi64(src, k, a) simde_mm_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mask_mov_pd(simde__m128d src, simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm_castsi128_pd(simde_mm_mask_mov_epi64(simde_mm_castpd_si128(src), k, simde_mm_castpd_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_pd
+  #define _mm_mask_mov_pd(src, k, a) simde_mm_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mask_mov_ps (simde__m128 src, simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm_castsi128_ps(simde_mm_mask_mov_epi32(simde_mm_castps_si128(src), k, simde_mm_castps_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_mov_ps
+  #define _mm_mask_mov_ps(src, k, a) simde_mm_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi8 (simde__m256i src, simde__mmask32 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi8(src, k, a);
+  #else
+    simde__m256i_private
+      r_,
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a);
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi8(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi8(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi8
+  #define _mm256_mask_mov_epi8(src, k, a) simde_mm256_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi16 (simde__m256i src, simde__mmask16 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi16(src, k, a);
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi16(src_.m128i[0], HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi16(src_.m128i[1], HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi16
+  #define _mm256_mask_mov_epi16(src, k, a) simde_mm256_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi32 (simde__m256i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi32(src, k, a);
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi32(src_.m128i[0], k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi32(src_.m128i[1], k >> 4, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi32
+  #define _mm256_mask_mov_epi32(src, k, a) simde_mm256_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_mov_epi64 (simde__m256i src, simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_epi64(src, k, a);
+  #else
+    simde__m256i_private
+      src_ = simde__m256i_to_private(src),
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_mask_mov_epi64(src_.m128i[0], k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_mask_mov_epi64(src_.m128i[1], k >> 2, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_epi64
+  #define _mm256_mask_mov_epi64(src, k, a) simde_mm256_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_mask_mov_pd (simde__m256d src, simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm256_castsi256_pd(simde_mm256_mask_mov_epi64(simde_mm256_castpd_si256(src), k, simde_mm256_castpd_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_pd
+  #define _mm256_mask_mov_pd(src, k, a) simde_mm256_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_mask_mov_ps (simde__m256 src, simde__mmask8 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm256_castsi256_ps(simde_mm256_mask_mov_epi32(simde_mm256_castps_si256(src), k, simde_mm256_castps_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_mov_ps
+  #define _mm256_mask_mov_ps(src, k, a) simde_mm256_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_mov_epi8(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi8(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi8(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : src_.i8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi8
+  #define _mm512_mask_mov_epi8(src, k, a) simde_mm512_mask_mov_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi16 (simde__m512i src, simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_mov_epi16(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi16(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi16(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : src_.i16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi16
+  #define _mm512_mask_mov_epi16(src, k, a) simde_mm512_mask_mov_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi32 (simde__m512i src, simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_epi32(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi32(src_.m256i[0], HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi32(src_.m256i[1], HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : src_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi32
+  #define _mm512_mask_mov_epi32(src, k, a) simde_mm512_mask_mov_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mov_epi64 (simde__m512i src, simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_epi64(src, k, a);
+  #else
+    simde__m512i_private
+      src_ = simde__m512i_to_private(src),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_mask_mov_epi64(src_.m256i[0], k     , a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_mask_mov_epi64(src_.m256i[1], k >> 4, a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : src_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_epi64
+  #define _mm512_mask_mov_epi64(src, k, a) simde_mm512_mask_mov_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_mov_pd (simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_pd(src, k, a);
+  #else
+    return simde_mm512_castsi512_pd(simde_mm512_mask_mov_epi64(simde_mm512_castpd_si512(src), k, simde_mm512_castpd_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_pd
+  #define _mm512_mask_mov_pd(src, k, a) simde_mm512_mask_mov_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_mov_ps (simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mov_ps(src, k, a);
+  #else
+    return simde_mm512_castsi512_ps(simde_mm512_mask_mov_epi32(simde_mm512_castps_si512(src), k, simde_mm512_castps_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mov_ps
+  #define _mm512_mask_mov_ps(src, k, a) simde_mm512_mask_mov_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi8 (simde__mmask16 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi8(k, a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi8
+  #define _mm_maskz_mov_epi8(k, a) simde_mm_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi16 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi16(k, a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi16
+  #define _mm_maskz_mov_epi16(k, a) simde_mm_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi32 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi32(k, a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi32
+  #define _mm_maskz_mov_epi32(k, a) simde_mm_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_mov_epi64 (simde__mmask8 k, simde__m128i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_epi64(k, a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      r_;
+
+    /* N.B. CM: No fallbacks as there are only two elements */
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_epi64
+  #define _mm_maskz_mov_epi64(k, a) simde_mm_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_maskz_mov_pd (simde__mmask8 k, simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_pd(k, a);
+  #else
+    return simde_mm_castsi128_pd(simde_mm_maskz_mov_epi64(k, simde_mm_castpd_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_pd
+  #define _mm_maskz_mov_pd(k, a) simde_mm_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_maskz_mov_ps (simde__mmask8 k, simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_mov_ps(k, a);
+  #else
+    return simde_mm_castsi128_ps(simde_mm_maskz_mov_epi32(k, simde_mm_castps_si128(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_mov_ps
+  #define _mm_maskz_mov_ps(k, a) simde_mm_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi8 (simde__mmask32 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi8(k, a);
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi8
+  #define _mm256_maskz_mov_epi8(k, a) simde_mm256_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi16 (simde__mmask16 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi16(k, a);
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi16
+  #define _mm256_maskz_mov_epi16(k, a) simde_mm256_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi32 (simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi32(k, a);
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi32(k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi32(k >> 4, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi32
+  #define _mm256_maskz_mov_epi32(k, a) simde_mm256_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_mov_epi64 (simde__mmask8 k, simde__m256i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_epi64(k, a);
+  #else
+    simde__m256i_private
+      a_ = simde__m256i_to_private(a),
+      r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_maskz_mov_epi64(k     , a_.m128i[0]);
+      r_.m128i[1] = simde_mm_maskz_mov_epi64(k >> 2, a_.m128i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_epi64
+  #define _mm256_maskz_mov_epi64(k, a) simde_mm256_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_maskz_mov_pd (simde__mmask8 k, simde__m256d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_pd(k, a);
+  #else
+    return simde_mm256_castsi256_pd(simde_mm256_maskz_mov_epi64(k, simde_mm256_castpd_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_pd
+  #define _mm256_maskz_mov_pd(k, a) simde_mm256_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_maskz_mov_ps (simde__mmask8 k, simde__m256 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_mov_ps(k, a);
+  #else
+    return simde_mm256_castsi256_ps(simde_mm256_maskz_mov_epi32(k, simde_mm256_castps_si256(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_mov_ps
+  #define _mm256_maskz_mov_ps(k, a) simde_mm256_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi8 (simde__mmask64 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_mov_epi8(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSSE3_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32), a_.m256i[1]);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? a_.i8[i] : INT8_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi8
+  #define _mm512_maskz_mov_epi8(k, a) simde_mm512_maskz_mov_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi16 (simde__mmask32 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_mov_epi16(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k      ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? a_.i16[i] : INT16_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi16
+  #define _mm512_maskz_mov_epi16(k, a) simde_mm512_maskz_mov_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi32 (simde__mmask16 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_epi32(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k     ), a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8), a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? a_.i32[i] : INT32_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi32
+  #define _mm512_maskz_mov_epi32(k, a) simde_mm512_maskz_mov_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mov_epi64 (simde__mmask8 k, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_epi64(k, a);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m256i[0] = simde_mm256_maskz_mov_epi64(k     , a_.m256i[0]);
+      r_.m256i[1] = simde_mm256_maskz_mov_epi64(k >> 4, a_.m256i[1]);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? a_.i64[i] : INT64_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_epi64
+  #define _mm512_maskz_mov_epi64(k, a) simde_mm512_maskz_mov_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_mov_pd (simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_pd(k, a);
+  #else
+    return simde_mm512_castsi512_pd(simde_mm512_maskz_mov_epi64(k, simde_mm512_castpd_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_pd
+  #define _mm512_maskz_mov_pd(k, a) simde_mm512_maskz_mov_pd(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_mov_ps (simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mov_ps(k, a);
+  #else
+    return simde_mm512_castsi512_ps(simde_mm512_maskz_mov_epi32(k, simde_mm512_castps_si512(a)));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mov_ps
+  #define _mm512_maskz_mov_ps(k, a) simde_mm512_maskz_mov_ps(k, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MOV_H) */

--- a/2.0/simde/x86/avx512/mov_mask.h
+++ b/2.0/simde/x86/avx512/mov_mask.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MOV_MASK_H)
+#define SIMDE_X86_AVX512_MOV_MASK_H
+
+#include "types.h"
+#include "../avx2.h"
+
+#include "cast.h"
+#include "set.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask64
+simde_mm512_movepi8_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movepi8_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    uint64_t r = 0;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        const uint32_t t = HEDLEY_STATIC_CAST(uint32_t, simde_mm256_movemask_epi8(a_.m256i[i]));
+        r |= HEDLEY_STATIC_CAST(uint64_t, t) << (i * 32);
+      }
+    #else
+      r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+        r |= (a_.i8[i] < 0) ? (UINT64_C(1) << i) : 0;
+      }
+    #endif
+
+    return HEDLEY_STATIC_CAST(simde__mmask64, r);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi8_mask
+  #define _mm512_movepi8_mask(a) simde_mm512_movepi8_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask32
+simde_mm512_movepi16_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movepi16_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask32 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i16) / sizeof(a_.i16[0])) ; i++) {
+      r |= (a_.i16[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi16_mask
+  #define _mm512_movepi16_mask(a) simde_mm512_movepi16_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_movepi32_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movepi32_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask16 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r |= (a_.i32[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi32_mask
+  #define _mm512_movepi32_mask(a) simde_mm512_movepi32_mask(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_movepi64_mask (simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movepi64_mask(a);
+  #else
+    simde__m512i_private a_ = simde__m512i_to_private(a);
+    simde__mmask8 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r |= (a_.i64[i] < 0) ? (UINT32_C(1) << i) : 0;
+    }
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movepi64_mask
+  #define _mm512_movepi64_mask(a) simde_mm512_movepi64_mask(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MOV_MASK_H) */

--- a/2.0/simde/x86/avx512/movm.h
+++ b/2.0/simde/x86/avx512/movm.h
@@ -1,0 +1,460 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MOVM_H)
+#define SIMDE_X86_AVX512_MOVM_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "set.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi8 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi8(k);
+  #elif defined(SIMDE_X86_SSSE3_NATIVE)
+    const simde__m128i zero = simde_mm_setzero_si128();
+    const simde__m128i bits = simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80);
+    const simde__m128i shuffle = simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_shuffle_epi8(r, shuffle);
+    r = simde_mm_cmpgt_epi8(zero, r);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      static const int8_t pos_data[] = { 7, 6, 5, 4, 3, 2, 1, 0 };
+      int8x8_t pos = vld1_s8(pos_data);
+      r_.neon_i8 = vcombine_s8(
+        vshr_n_s8(vshl_s8(vdup_n_s8(HEDLEY_STATIC_CAST(int8_t, k)), pos), 7),
+        vshr_n_s8(vshl_s8(vdup_n_s8(HEDLEY_STATIC_CAST(int8_t, k >> 8)), pos), 7));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi8
+  #define _mm_movm_epi8(k) simde_mm_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi8 (simde__mmask32 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi8(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const simde__m256i zero = simde_mm256_setzero_si256();
+    const simde__m256i bits = simde_mm256_broadcastsi128_si256(simde_mm_set_epi16(0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80));
+    const simde__m256i shuffle = simde_mm256_broadcastsi128_si256(simde_mm_set_epi8(15, 13, 11, 9, 7, 5, 3, 1, 14, 12, 10, 8, 6, 4, 2, 0));
+    simde__m256i r;
+
+    r = simde_mm256_set_m128i(_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k >> 16)), _mm_set1_epi16(HEDLEY_STATIC_CAST(short, k)));
+    r = simde_mm256_mullo_epi16(r, bits);
+    r = simde_mm256_shuffle_epi8(r, shuffle);
+    r = simde_mm256_cmpgt_epi8(zero, r);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k));
+      r_.m128i[1] = simde_mm_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi8
+  #define _mm256_movm_epi8(k) simde_mm256_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi8 (simde__mmask64 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_movm_epi8(k);
+  #else
+    simde__m512i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k));
+      r_.m256i[1] = simde_mm256_movm_epi8(HEDLEY_STATIC_CAST(simde__mmask32, k >> 32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = ((k >> i) & 1) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi8
+  #define _mm512_movm_epi8(k) simde_mm512_movm_epi8(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi16 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi16(k);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi16(0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi16(r, 15);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      static const int16_t pos_data[] = { 15, 14, 13, 12, 11, 10, 9, 8 };
+      const int16x8_t pos = vld1q_s16(pos_data);
+      r_.neon_i16 = vshrq_n_s16(vshlq_s16(vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, k)), pos), 15);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi16
+  #define _mm_movm_epi16(k) simde_mm_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi16 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi16(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m256i bits = _mm256_set_epi16(0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
+                                          0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000, INT16_MIN /* 0x8000 */);
+    __m256i r;
+
+    r = _mm256_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = _mm256_mullo_epi16(r, bits);
+    r = _mm256_srai_epi16(r, 15);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k));
+      r_.m128i[1] = simde_mm_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi16
+  #define _mm256_movm_epi16(k) simde_mm256_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi16 (simde__mmask32 k) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm512_movm_epi16(k);
+  #else
+    simde__m512i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k));
+      r_.m256i[1] = simde_mm256_movm_epi16(HEDLEY_STATIC_CAST(simde__mmask16, k >> 16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = ((k >> i) & 1) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi16
+  #define _mm512_movm_epi16(k) simde_mm512_movm_epi16(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi32 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm_movm_epi32(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i shifts = _mm_set_epi32(28, 29, 30, 31);
+    __m128i r;
+
+    r = _mm_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = _mm_sllv_epi32(r, shifts);
+    r = _mm_srai_epi32(r, 31);
+
+    return r;
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi32(0x10000000, 0x20000000, 0x40000000, INT32_MIN /* 0x80000000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      static const int32_t pos_data[] = { 31, 30, 29, 28 };
+      const int32x4_t pos = vld1q_s32(pos_data);
+      r_.neon_i32 = vshrq_n_s32(vshlq_s32(vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, k)), pos), 31);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi32
+  #define _mm_movm_epi32(k) simde_mm_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi32 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512VL_NATIVE) && defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm256_movm_epi32(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m256i shifts = _mm256_set_epi32(24, 25, 26, 27, 28, 29, 30, 31);
+    __m256i r;
+
+    r = _mm256_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = _mm256_sllv_epi32(r, shifts);
+    r = _mm256_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_movm_epi32(k     );
+      r_.m128i[1] = simde_mm_movm_epi32(k >> 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi32
+  #define _mm256_movm_epi32(k) simde_mm256_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi32 (simde__mmask16 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movm_epi32(k);
+  #else
+    simde__m512i_private r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_movm_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k     ));
+      r_.m256i[1] = simde_mm256_movm_epi32(HEDLEY_STATIC_CAST(simde__mmask8, k >> 8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ((k >> i) & 1) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi32
+  #define _mm512_movm_epi32(k) simde_mm512_movm_epi32(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_movm_epi64(k);
+    /* N.B. CM: These fallbacks may not be faster as there are only two elements */
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m128i shifts = _mm_set_epi32(30, 30, 31, 31);
+    __m128i r;
+
+    r = _mm_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = _mm_sllv_epi32(r, shifts);
+    r = _mm_srai_epi32(r, 31);
+
+    return r;
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    const simde__m128i bits = simde_mm_set_epi32(0x40000000, 0x40000000, INT32_MIN /* 0x80000000 */, INT32_MIN /* 0x80000000 */);
+    simde__m128i r;
+
+    r = simde_mm_set1_epi16(HEDLEY_STATIC_CAST(short, k));
+    r = simde_mm_mullo_epi16(r, bits);
+    r = simde_mm_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      static const int64_t pos_data[] = { 63, 62 };
+      const int64x2_t pos = vld1q_s64(pos_data);
+      r_.neon_i64 = vshrq_n_s64(vshlq_s64(vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, k)), pos), 63);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm_movm_epi64
+  #define _mm_movm_epi64(k) simde_mm_movm_epi64(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_movm_epi64(k);
+  #elif defined(SIMDE_X86_AVX2_NATIVE)
+    const __m256i shifts = _mm256_set_epi32(28, 28, 29, 29, 30, 30, 31, 31);
+    __m256i r;
+
+    r = _mm256_set1_epi32(HEDLEY_STATIC_CAST(int, k));
+    r = _mm256_sllv_epi32(r, shifts);
+    r = _mm256_srai_epi32(r, 31);
+
+    return r;
+  #else
+    simde__m256i_private r_;
+
+    /* N.B. CM: This fallback may not be faster as there are only four elements */
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      r_.m128i[0] = simde_mm_movm_epi64(k     );
+      r_.m128i[1] = simde_mm_movm_epi64(k >> 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES) && defined(SIMDE_X86_AVX512VL_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_movm_epi64
+  #define _mm256_movm_epi64(k) simde_mm256_movm_epi64(k)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_movm_epi64 (simde__mmask8 k) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_movm_epi64(k);
+  #else
+    simde__m512i_private r_;
+
+    /* N.B. CM: Without AVX2 this fallback may not be faster as there are only eight elements */
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_movm_epi64(k     );
+      r_.m256i[1] = simde_mm256_movm_epi64(k >> 4);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = ((k >> i) & 1) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_movm_epi64
+  #define _mm512_movm_epi64(k) simde_mm512_movm_epi64(k)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MOVM_H) */

--- a/2.0/simde/x86/avx512/mul.h
+++ b/2.0/simde/x86/avx512/mul.h
@@ -1,0 +1,279 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MUL_H)
+#define SIMDE_X86_AVX512_MUL_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mul_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mul_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 * b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_mul_ps(a_.m256[i], b_.m256[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mul_ps
+  #define _mm512_mul_ps(a, b) simde_mm512_mul_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_mul_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mul_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_mul_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mul_ps
+  #define _mm512_mask_mul_ps(src, k, a, b) simde_mm512_mask_mul_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_mul_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mul_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_mul_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mul_ps
+  #define _mm512_maskz_mul_ps(k, a, b) simde_mm512_maskz_mul_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mul_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mul_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 * b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_mul_pd(a_.m256d[i], b_.m256d[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mul_pd
+  #define _mm512_mul_pd(a, b) simde_mm512_mul_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_mul_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mul_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_mul_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mul_pd
+  #define _mm512_mask_mul_pd(src, k, a, b) simde_mm512_mask_mul_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_mul_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mul_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_mul_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mul_pd
+  #define _mm512_maskz_mul_pd(k, a, b) simde_mm512_maskz_mul_pd(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mul_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mul_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_SHUFFLE_VECTOR_)
+      simde__m512i_private x;
+      __typeof__(r_.i64) ta, tb;
+
+      /* Get even numbered 32-bit values */
+      x.i32 = SIMDE_SHUFFLE_VECTOR_(32, 64, a_.i32, b_.i32, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+      /* Cast to 64 bits */
+      SIMDE_CONVERT_VECTOR_(ta, x.m256i_private[0].i32);
+      SIMDE_CONVERT_VECTOR_(tb, x.m256i_private[1].i32);
+      r_.i64 = ta * tb;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = HEDLEY_STATIC_CAST(int64_t, a_.i32[i << 1]) * HEDLEY_STATIC_CAST(int64_t, b_.i32[i << 1]);
+      }
+    #endif
+      return simde__m512i_from_private(r_);
+    #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mul_epi32
+  #define _mm512_mul_epi32(a, b) simde_mm512_mul_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mul_epi32(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mul_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_mul_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mul_epi32
+  #define _mm512_mask_mul_epi32(src, k, a, b) simde_mm512_mask_mul_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mul_epi32(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mul_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_mul_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mul_epi32
+  #define _mm512_maskz_mul_epi32(k, a, b) simde_mm512_maskz_mul_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mul_epu32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mul_epu32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_CONVERT_VECTOR_) && defined(SIMDE_SHUFFLE_VECTOR_)
+      simde__m512i_private x;
+      __typeof__(r_.u64) ta, tb;
+
+      x.u32 = SIMDE_SHUFFLE_VECTOR_(32, 64, a_.u32, b_.u32, 0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30);
+      SIMDE_CONVERT_VECTOR_(ta, x.m256i_private[0].u32);
+      SIMDE_CONVERT_VECTOR_(tb, x.m256i_private[1].u32);
+      r_.u64 = ta * tb;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i << 1]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[i << 1]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mul_epu32
+  #define _mm512_mul_epu32(a, b) simde_mm512_mul_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mul_epu32(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mul_epu32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_mul_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mul_epu32
+  #define _mm512_mask_mul_epu32(src, k, a, b) simde_mm512_mask_mul_epu32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mul_epu32(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mul_epu32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_mul_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mul_epu32
+  #define _mm512_maskz_mul_epu32(k, a, b) simde_mm512_maskz_mul_epu32(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MUL_H) */

--- a/2.0/simde/x86/avx512/mulhi.h
+++ b/2.0/simde/x86/avx512/mulhi.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MULHI_H)
+#define SIMDE_X86_AVX512_MULHI_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mulhi_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mulhi_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (HEDLEY_STATIC_CAST(uint32_t, HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) >> 16));
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mulhi_epi16
+  #define _mm512_mulhi_epi16(a, b) simde_mm512_mulhi_epi16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MULHI_H) */

--- a/2.0/simde/x86/avx512/mulhrs.h
+++ b/2.0/simde/x86/avx512/mulhrs.h
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MULHRS_H)
+#define SIMDE_X86_AVX512_MULHRS_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mulhrs_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mulhrs_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, (((HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) + 0x4000) >> 15));
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mulhrs_epi16
+  #define _mm512_mulhrs_epi16(a, b) simde_mm512_mulhrs_epi16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MULHRS_H) */

--- a/2.0/simde/x86/avx512/mullo.h
+++ b/2.0/simde/x86/avx512/mullo.h
@@ -1,0 +1,117 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_MULLO_H)
+#define SIMDE_X86_AVX512_MULLO_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mullo_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mullo_epi16(a, b);
+  #else
+    simde__m512i_private
+    a_ = simde__m512i_to_private(a),
+    b_ = simde__m512i_to_private(b),
+    r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] * b_.i16[i]);
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mullo_epi16
+  #define _mm512_mullo_epi16(a, b) simde_mm512_mullo_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mullo_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mullo_epi32(a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, a_.i32[i] * b_.i32[i]);
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mullo_epi32
+  #define _mm512_mullo_epi32(a, b) simde_mm512_mullo_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_mullo_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_mullo_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_mullo_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_mullo_epi32
+  #define _mm512_mask_mullo_epi32(src, k, a, b) simde_mm512_mask_mullo_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_mullo_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_mullo_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_mullo_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_mullo_epi32
+  #define _mm512_maskz_mullo_epi32(k, a, b) simde_mm512_maskz_mullo_epi32(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_MULLO_H) */

--- a/2.0/simde/x86/avx512/negate.h
+++ b/2.0/simde/x86/avx512/negate.h
@@ -1,0 +1,88 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_NEGATE_H)
+#define SIMDE_X86_AVX512_NEGATE_H
+
+#include "types.h"
+#include "mov.h"
+#include "xor.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_x_mm512_negate_ps(simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return simde_mm512_xor_ps(a,_mm512_set1_ps(SIMDE_FLOAT32_C(-0.0)));
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if defined(SIMDE_VECTOR_NEGATE)
+      r_.f32 = -a_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = -a_.f32[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_x_mm512_negate_pd(simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return simde_mm512_xor_pd(a, _mm512_set1_pd(SIMDE_FLOAT64_C(-0.0)));
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if defined(SIMDE_VECTOR_NEGATE)
+      r_.f64 = -a_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = -a_.f64[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_NEGATE_H) */

--- a/2.0/simde/x86/avx512/or.h
+++ b/2.0/simde/x86/avx512/or.h
@@ -1,0 +1,252 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_OR_H)
+#define SIMDE_X86_AVX512_OR_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_or_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_or_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+    r_.m256[0] = simde_mm256_or_ps(a_.m256[0], b_.m256[0]);
+    r_.m256[1] = simde_mm256_or_ps(a_.m256[1], b_.m256[1]);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i32f = a_.i32f | b_.i32f;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+      r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+    }
+  #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_or_ps
+  #define _mm512_or_ps(a, b) simde_mm512_or_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_or_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_or_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256d[0] = simde_mm256_or_pd(a_.m256d[0], b_.m256d[0]);
+      r_.m256d[1] = simde_mm256_or_pd(a_.m256d[1], b_.m256d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_or_pd
+  #define _mm512_or_pd(a, b) simde_mm512_or_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_or_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_or_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 | b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] | b_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_or_epi32
+  #define _mm512_or_epi32(a, b) simde_mm512_or_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_or_epi32(simde__m512i src, simde__mmask16 k, simde__m512i v2, simde__m512i v3) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_or_epi32(src, k, v2, v3);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_or_epi32(v2, v3));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_or_epi32
+  #define _mm512_mask_or_epi32(src, k, v2, v3) simde_mm512_mask_or_epi32(src, k, v2, v3)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_or_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_or_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_or_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_or_epi32
+  #define _mm512_maskz_or_epi32(k, a, b) simde_mm512_maskz_or_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_or_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_or_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_or_si256(a_.m256i[i], b_.m256i[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 | b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] | b_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_or_epi64
+  #define _mm512_or_epi64(a, b) simde_mm512_or_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_or_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_or_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_or_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_or_epi64
+  #define _mm512_mask_or_epi64(src, k, a, b) simde_mm512_mask_or_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_or_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_or_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_or_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_or_epi64
+  #define _mm512_maskz_or_epi64(k, a, b) simde_mm512_maskz_or_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_or_si512 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_or_si512(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[0] = simde_mm256_or_si256(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_or_si256(a_.m256i[1], b_.m256i[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_or_si512
+  #define _mm512_or_si512(a, b) simde_mm512_or_si512(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_OR_H) */

--- a/2.0/simde/x86/avx512/packs.h
+++ b/2.0/simde/x86/avx512/packs.h
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_PACKS_H)
+#define SIMDE_X86_AVX512_PACKS_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_packs_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_packs_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_packs_epi16(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_packs_epi16(a_.m256i[1], b_.m256i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 4;
+      const size_t octet_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 8;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < octet_point ; i++) {
+        r_.i8[i] = (a_.i16[i] > INT8_MAX) ? INT8_MAX : ((a_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+        r_.i8[i + octet_point] = (b_.i16[i] > INT8_MAX) ? INT8_MAX : ((b_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[i]));
+        r_.i8[quarter_point + i] = (a_.i16[octet_point + i] > INT8_MAX) ? INT8_MAX : ((a_.i16[octet_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[octet_point + i]));
+        r_.i8[quarter_point + i + octet_point] = (b_.i16[octet_point + i] > INT8_MAX) ? INT8_MAX : ((b_.i16[octet_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[octet_point + i]));
+        r_.i8[halfway_point + i] = (a_.i16[quarter_point + i] > INT8_MAX) ? INT8_MAX : ((a_.i16[quarter_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[quarter_point + i]));
+        r_.i8[halfway_point + i + octet_point] = (b_.i16[quarter_point + i] > INT8_MAX) ? INT8_MAX : ((b_.i16[quarter_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[quarter_point + i]));
+        r_.i8[halfway_point + quarter_point + i]     = (a_.i16[quarter_point + octet_point + i] > INT8_MAX) ? INT8_MAX : ((a_.i16[quarter_point + octet_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[quarter_point + octet_point + i]));
+        r_.i8[halfway_point + quarter_point + i + octet_point] = (b_.i16[quarter_point + octet_point + i] > INT8_MAX) ? INT8_MAX : ((b_.i16[quarter_point + octet_point + i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[quarter_point + octet_point + i]));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_packs_epi16
+  #define _mm512_packs_epi16(a, b) simde_mm512_packs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_packs_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_packs_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_packs_epi32(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_packs_epi32(a_.m256i[1], b_.m256i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 4;
+      const size_t octet_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 8;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < octet_point ; i++) {
+        r_.i16[i] = (a_.i32[i] > INT16_MAX) ? INT16_MAX : ((a_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+        r_.i16[i + octet_point] = (b_.i32[i] > INT16_MAX) ? INT16_MAX : ((b_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[i]));
+        r_.i16[quarter_point + i] = (a_.i32[octet_point + i] > INT16_MAX) ? INT16_MAX : ((a_.i32[octet_point + i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[octet_point + i]));
+        r_.i16[quarter_point + i + octet_point] = (b_.i32[octet_point + i] > INT16_MAX) ? INT16_MAX : ((b_.i32[octet_point + i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[octet_point + i]));
+        r_.i16[halfway_point + i] = (a_.i32[quarter_point + i] > INT16_MAX) ? INT16_MAX : ((a_.i32[quarter_point +i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[quarter_point + i]));
+        r_.i16[halfway_point + i + octet_point] = (b_.i32[quarter_point + i] > INT16_MAX) ? INT16_MAX : ((b_.i32[quarter_point + i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[quarter_point +i]));
+        r_.i16[halfway_point + quarter_point + i] = (a_.i32[quarter_point + octet_point + i] > INT16_MAX) ? INT16_MAX : ((a_.i32[quarter_point + octet_point + i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[quarter_point + octet_point + i]));
+        r_.i16[halfway_point + quarter_point + i + octet_point] = (b_.i32[quarter_point + octet_point + i] > INT16_MAX) ? INT16_MAX : ((b_.i32[quarter_point + octet_point + i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[quarter_point + octet_point + i]));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_packs_epi32
+  #define _mm512_packs_epi32(a, b) simde_mm512_packs_epi32(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_PACKS_H) */

--- a/2.0/simde/x86/avx512/packus.h
+++ b/2.0/simde/x86/avx512/packus.h
@@ -1,0 +1,122 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_PACKUS_H)
+#define SIMDE_X86_AVX512_PACKUS_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_packus_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_packus_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256i[0] = simde_mm256_packus_epi16(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_packus_epi16(a_.m256i[1], b_.m256i[1]);
+    #else
+      const size_t halfway_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 4;
+      const size_t octet_point = (sizeof(r_.i8) / sizeof(r_.i8[0])) / 8;
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < octet_point ; i++) {
+        r_.u8[i]     = (a_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]));
+        r_.u8[i + octet_point] = (b_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]));
+        r_.u8[quarter_point + i]     = (a_.i16[octet_point + i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[octet_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[octet_point + i]));
+        r_.u8[quarter_point + i + octet_point] = (b_.i16[octet_point + i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[octet_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[octet_point + i]));
+        r_.u8[halfway_point + i]     = (a_.i16[quarter_point + i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[quarter_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[quarter_point + i]));
+        r_.u8[halfway_point + i + octet_point] = (b_.i16[quarter_point + i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[quarter_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[quarter_point + i]));
+        r_.u8[halfway_point + quarter_point + i]     = (a_.i16[quarter_point + octet_point + i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[quarter_point + octet_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[quarter_point + octet_point + i]));
+        r_.u8[halfway_point + quarter_point + i + octet_point] = (b_.i16[quarter_point + octet_point + i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[quarter_point + octet_point + i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[quarter_point + octet_point + i]));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_packus_epi16
+  #define _mm512_packus_epi16(a, b) simde_mm512_packus_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_packus_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_packus_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_packus_epi32(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+      const size_t quarter_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 4;
+      const size_t octet_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 8;
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < octet_point ; i++) {
+        r_.u16[i] = (a_.i32[i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[i]));
+        r_.u16[i + octet_point] = (b_.i32[i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[i]));
+        r_.u16[quarter_point + i]     = (a_.i32[octet_point + i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[octet_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[octet_point + i]));
+        r_.u16[quarter_point + i + octet_point] = (b_.i32[octet_point + i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[octet_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[octet_point + i]));
+        r_.u16[halfway_point + i] = (a_.i32[quarter_point + i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[quarter_point +i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[quarter_point + i]));
+        r_.u16[halfway_point + i + octet_point] = (b_.i32[quarter_point + i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[quarter_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[quarter_point +i]));
+        r_.u16[halfway_point + quarter_point + i]     = (a_.i32[quarter_point + octet_point + i] > UINT16_MAX) ? UINT16_MAX : ((a_.i32[quarter_point + octet_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[quarter_point + octet_point + i]));
+        r_.u16[halfway_point + quarter_point + i + octet_point] = (b_.i32[quarter_point + octet_point + i] > UINT16_MAX) ? UINT16_MAX : ((b_.i32[quarter_point + octet_point + i] < 0) ? UINT16_C(0) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[quarter_point + octet_point + i]));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_packus_epi32
+  #define _mm512_packus_epi32(a, b) simde_mm512_packus_epi32(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_PACKUS_H) */

--- a/2.0/simde/x86/avx512/permutex2var.h
+++ b/2.0/simde/x86/avx512/permutex2var.h
@@ -1,0 +1,309 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_PERMUTEX2VAR_H)
+#define SIMDE_X86_AVX512_PERMUTEX2VAR_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_permutex2var_epi32 (simde__m512i a, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_permutex2var_epi32(a, idx, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      idx_ = simde__m512i_to_private(idx),
+      b_ = simde__m512i_to_private(b),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = ((idx_.i32[i] & 0x10) ? b_ : a_).i32[idx_.i32[i] & 0x0F];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutex2var_epi32
+  #define _mm512_permutex2var_epi32(a, idx, b) simde_mm512_permutex2var_epi32(a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_permutex2var_epi32 (simde__m512i a, simde__mmask16 k, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_permutex2var_epi32(a, k, idx, b);
+  #else
+    return simde_mm512_mask_mov_epi32(a, k, simde_mm512_permutex2var_epi32(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutex2var_epi32
+#define _mm512_mask_permutex2var_epi32(a, k, idx, b) simde_mm512_mask_permutex2var_epi32(a, k, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask2_permutex2var_epi32 (simde__m512i a, simde__m512i idx, simde__mmask16 k, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask2_permutex2var_epi32(a, idx, k, b);
+  #else
+    return simde_mm512_mask_mov_epi32(idx, k, simde_mm512_permutex2var_epi32(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask2_permutex2var_epi32
+#define _mm512_mask2_permutex2var_epi32(a, idx, k, b) simde_mm512_mask2_permutex2var_epi32(a, idx, k, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_permutex2var_epi32 (simde__mmask16 k, simde__m512i a, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_permutex2var_epi32(k, a, idx, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_permutex2var_epi32(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutex2var_epi32
+#define _mm512_maskz_permutex2var_epi32(k, a, idx, b) simde_mm512_maskz_permutex2var_epi32(k, a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_permutex2var_epi64 (simde__m512i a, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_permutex2var_epi64(a, idx, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      idx_ = simde__m512i_to_private(idx),
+      b_ = simde__m512i_to_private(b),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = ((idx_.i64[i] & 0x08) ? b_ : a_).i64[idx_.i64[i] & 0x07];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutex2var_epi64
+  #define _mm512_permutex2var_epi64(a, idx, b) simde_mm512_permutex2var_epi64(a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_permutex2var_epi64 (simde__m512i a, simde__mmask8 k, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_permutex2var_epi64(a, k, idx, b);
+  #else
+    return simde_mm512_mask_mov_epi64(a, k, simde_mm512_permutex2var_epi64(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutex2var_epi64
+#define _mm512_mask_permutex2var_epi64(a, k, idx, b) simde_mm512_mask_permutex2var_epi64(a, k, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask2_permutex2var_epi64 (simde__m512i a, simde__m512i idx, simde__mmask8 k, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask2_permutex2var_epi64(a, idx, k, b);
+  #else
+    return simde_mm512_mask_mov_epi64(idx, k, simde_mm512_permutex2var_epi64(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask2_permutex2var_epi64
+#define _mm512_mask2_permutex2var_epi64(a, idx, k, b) simde_mm512_mask2_permutex2var_epi64(a, idx, k, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_permutex2var_epi64 (simde__mmask8 k, simde__m512i a, simde__m512i idx, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_permutex2var_epi64(k, a, idx, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_permutex2var_epi64(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutex2var_epi64
+#define _mm512_maskz_permutex2var_epi64(k, a, idx, b) simde_mm512_maskz_permutex2var_epi64(k, a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_permutex2var_pd (simde__m512d a, simde__m512i idx, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_permutex2var_pd(a, idx, b);
+  #else
+    simde__m512i_private idx_ = simde__m512i_to_private(idx);
+    simde__m512d_private
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = ((idx_.i64[i] & 0x08) ? b_ : a_).f64[idx_.i64[i] & 0x07];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutex2var_pd
+  #define _mm512_permutex2var_pd(a, idx, b) simde_mm512_permutex2var_pd(a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_permutex2var_pd (simde__m512d a, simde__mmask8 k, simde__m512i idx, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_permutex2var_pd(a, k, idx, b);
+  #else
+    return simde_mm512_mask_mov_pd(a, k, simde_mm512_permutex2var_pd(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutex2var_pd
+#define _mm512_mask_permutex2var_pd(a, k, idx, b) simde_mm512_mask_permutex2var_pd(a, k, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask2_permutex2var_pd (simde__m512d a, simde__m512i idx, simde__mmask8 k, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask2_permutex2var_pd(a, idx, k, b);
+  #else
+    return simde_mm512_mask_mov_pd(simde_mm512_castsi512_pd(idx), k, simde_mm512_permutex2var_pd(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask2_permutex2var_pd
+#define _mm512_mask2_permutex2var_pd(a, idx, k, b) simde_mm512_mask2_permutex2var_pd(a, idx, k, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_permutex2var_pd (simde__mmask8 k, simde__m512d a, simde__m512i idx, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_permutex2var_pd(k, a, idx, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_permutex2var_pd(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutex2var_pd
+#define _mm512_maskz_permutex2var_pd(k, a, idx, b) simde_mm512_maskz_permutex2var_pd(k, a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_permutex2var_ps (simde__m512 a, simde__m512i idx, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_permutex2var_ps(a, idx, b);
+  #else
+    simde__m512i_private idx_ = simde__m512i_to_private(idx);
+    simde__m512_private
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = ((idx_.i32[i] & 0x10) ? b_ : a_).f32[idx_.i32[i] & 0x0F];
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutex2var_ps
+  #define _mm512_permutex2var_ps(a, idx, b) simde_mm512_permutex2var_ps(a, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_permutex2var_ps (simde__m512 a, simde__mmask16 k, simde__m512i idx, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_permutex2var_ps(a, k, idx, b);
+  #else
+    return simde_mm512_mask_mov_ps(a, k, simde_mm512_permutex2var_ps(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutex2var_ps
+#define _mm512_mask_permutex2var_ps(a, k, idx, b) simde_mm512_mask_permutex2var_ps(a, k, idx, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask2_permutex2var_ps (simde__m512 a, simde__m512i idx, simde__mmask16 k, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask2_permutex2var_ps(a, idx, k, b);
+  #else
+    return simde_mm512_mask_mov_ps(simde_mm512_castsi512_ps(idx), k, simde_mm512_permutex2var_ps(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask2_permutex2var_ps
+#define _mm512_mask2_permutex2var_ps(a, idx, k, b) simde_mm512_mask2_permutex2var_ps(a, idx, k, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_permutex2var_ps (simde__mmask16 k, simde__m512 a, simde__m512i idx, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_permutex2var_ps(k, a, idx, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_permutex2var_ps(a, idx, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutex2var_ps
+#define _mm512_maskz_permutex2var_ps(k, a, idx, b) simde_mm512_maskz_permutex2var_ps(k, a, idx, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_PERMUTEX2VAR_H) */

--- a/2.0/simde/x86/avx512/permutexvar.h
+++ b/2.0/simde/x86/avx512/permutexvar.h
@@ -1,0 +1,257 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_PERMUTEXVAR_H)
+#define SIMDE_X86_AVX512_PERMUTEXVAR_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_permutexvar_epi32 (simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_permutexvar_epi32(idx, a);
+  #else
+    simde__m512i_private
+      idx_ = simde__m512i_to_private(idx),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[idx_.i32[i] & 0x0F];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutexvar_epi32
+  #define _mm512_permutexvar_epi32(idx, a) simde_mm512_permutexvar_epi32(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_permutexvar_epi32 (simde__m512i src, simde__mmask16 k, simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_permutexvar_epi32(src, k, idx, a);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_permutexvar_epi32(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutexvar_epi32
+  #define _mm512_mask_permutexvar_epi32(src, k, idx, a) simde_mm512_mask_permutexvar_epi32(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_permutexvar_epi32 (simde__mmask16 k, simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_permutexvar_epi32(k, idx, a);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_permutexvar_epi32(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutexvar_epi32
+  #define _mm512_maskz_permutexvar_epi32(k, idx, a) simde_mm512_maskz_permutexvar_epi32(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_permutexvar_epi64 (simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_permutexvar_epi64(idx, a);
+  #else
+    simde__m512i_private
+      idx_ = simde__m512i_to_private(idx),
+      a_ = simde__m512i_to_private(a),
+      r_;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[idx_.i64[i] & 7];
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutexvar_epi64
+  #define _mm512_permutexvar_epi64(idx, a) simde_mm512_permutexvar_epi64(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_permutexvar_epi64 (simde__m512i src, simde__mmask8 k, simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_permutexvar_epi64(src, k, idx, a);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_permutexvar_epi64(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutexvar_epi64
+  #define _mm512_mask_permutexvar_epi64(src, k, idx, a) simde_mm512_mask_permutexvar_epi64(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_permutexvar_epi64 (simde__mmask8 k, simde__m512i idx, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_permutexvar_epi64(k, idx, a);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_permutexvar_epi64(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutexvar_epi64
+  #define _mm512_maskz_permutexvar_epi64(k, idx, a) simde_mm512_maskz_permutexvar_epi64(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_permutexvar_pd (simde__m512i idx, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_permutexvar_pd(idx, a);
+  #else
+    simde__m512i_private idx_ = simde__m512i_to_private(idx);
+    simde__m512d_private
+      a_ = simde__m512d_to_private(a),
+      r_;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a_.f64[idx_.i64[i] & 7];
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutexvar_pd
+  #define _mm512_permutexvar_pd(idx, a) simde_mm512_permutexvar_pd(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_permutexvar_pd (simde__m512d src, simde__mmask8 k, simde__m512i idx, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_permutexvar_pd(src, k, idx, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_permutexvar_pd(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutexvar_pd
+  #define _mm512_mask_permutexvar_pd(src, k, idx, a) simde_mm512_mask_permutexvar_pd(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_permutexvar_pd (simde__mmask8 k, simde__m512i idx, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_permutexvar_pd(k, idx, a);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_permutexvar_pd(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutexvar_pd
+  #define _mm512_maskz_permutexvar_pd(k, idx, a) simde_mm512_maskz_permutexvar_pd(k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_permutexvar_ps (simde__m512i idx, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_permutexvar_ps(idx, a);
+  #else
+    simde__m512i_private idx_ = simde__m512i_to_private(idx);
+    simde__m512_private
+      a_ = simde__m512_to_private(a),
+      r_;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a_.f32[idx_.i32[i] & 0x0F];
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_permutexvar_ps
+  #define _mm512_permutexvar_ps(idx, a) simde_mm512_permutexvar_ps(idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_permutexvar_ps (simde__m512 src, simde__mmask16 k, simde__m512i idx, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_permutexvar_ps(src, k, idx, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_permutexvar_ps(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_permutexvar_ps
+  #define _mm512_mask_permutexvar_ps(src, k, idx, a) simde_mm512_mask_permutexvar_ps(src, k, idx, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_permutexvar_ps (simde__mmask16 k, simde__m512i idx, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_permutexvar_ps(k, idx, a);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_permutexvar_ps(idx, a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_permutexvar_ps
+  #define _mm512_maskz_permutexvar_ps(k, idx, a) simde_mm512_maskz_permutexvar_ps(k, idx, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_PERMUTEXVAR_H) */

--- a/2.0/simde/x86/avx512/sad.h
+++ b/2.0/simde/x86/avx512/sad.h
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SAD_H)
+#define SIMDE_X86_AVX512_SAD_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sad_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_sad_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_sad_epu8(a_.m256i[i], b_.m256i[i]);
+        }
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        uint16_t tmp = 0;
+        SIMDE_VECTORIZE_REDUCTION(+:tmp)
+        for (size_t j = 0 ; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 8) ; j++) {
+          const size_t e = j + (i * 8);
+          tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e]) : (b_.u8[e] - a_.u8[e]);
+        }
+        r_.i64[i] = tmp;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sad_epu8
+  #define _mm512_sad_epu8(a, b) simde_mm512_sad_epu8(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SAD_H) */

--- a/2.0/simde/x86/avx512/set.h
+++ b/2.0/simde/x86/avx512/set.h
@@ -1,0 +1,477 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SET_H)
+#define SIMDE_X86_AVX512_SET_H
+
+#include "types.h"
+#include "load.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set_epi16 (int16_t e31, int16_t e30, int16_t e29, int16_t e28, int16_t e27, int16_t e26, int16_t e25, int16_t e24,
+                       int16_t e23, int16_t e22, int16_t e21, int16_t e20, int16_t e19, int16_t e18, int16_t e17, int16_t e16,
+                       int16_t e15, int16_t e14, int16_t e13, int16_t e12, int16_t e11, int16_t e10, int16_t  e9, int16_t  e8,
+                       int16_t  e7, int16_t  e6, int16_t  e5, int16_t  e4, int16_t  e3, int16_t  e2, int16_t  e1, int16_t  e0) {
+  simde__m512i_private r_;
+
+  r_.i16[ 0] = e0;
+  r_.i16[ 1] = e1;
+  r_.i16[ 2] = e2;
+  r_.i16[ 3] = e3;
+  r_.i16[ 4] = e4;
+  r_.i16[ 5] = e5;
+  r_.i16[ 6] = e6;
+  r_.i16[ 7] = e7;
+  r_.i16[ 8] = e8;
+  r_.i16[ 9] = e9;
+  r_.i16[10] = e10;
+  r_.i16[11] = e11;
+  r_.i16[12] = e12;
+  r_.i16[13] = e13;
+  r_.i16[14] = e14;
+  r_.i16[15] = e15;
+  r_.i16[16] = e16;
+  r_.i16[17] = e17;
+  r_.i16[18] = e18;
+  r_.i16[19] = e19;
+  r_.i16[20] = e20;
+  r_.i16[21] = e21;
+  r_.i16[22] = e22;
+  r_.i16[23] = e23;
+  r_.i16[24] = e24;
+  r_.i16[25] = e25;
+  r_.i16[26] = e26;
+  r_.i16[27] = e27;
+  r_.i16[28] = e28;
+  r_.i16[29] = e29;
+  r_.i16[30] = e30;
+  r_.i16[31] = e31;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_epi16
+  #define _mm512_set_epi16(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_epi16(e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set_epi32 (int32_t e15, int32_t e14, int32_t e13, int32_t e12, int32_t e11, int32_t e10, int32_t  e9, int32_t  e8,
+                       int32_t  e7, int32_t  e6, int32_t  e5, int32_t  e4, int32_t  e3, int32_t  e2, int32_t  e1, int32_t  e0) {
+  simde__m512i_private r_;
+
+  r_.i32[ 0] = e0;
+  r_.i32[ 1] = e1;
+  r_.i32[ 2] = e2;
+  r_.i32[ 3] = e3;
+  r_.i32[ 4] = e4;
+  r_.i32[ 5] = e5;
+  r_.i32[ 6] = e6;
+  r_.i32[ 7] = e7;
+  r_.i32[ 8] = e8;
+  r_.i32[ 9] = e9;
+  r_.i32[10] = e10;
+  r_.i32[11] = e11;
+  r_.i32[12] = e12;
+  r_.i32[13] = e13;
+  r_.i32[14] = e14;
+  r_.i32[15] = e15;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_epi32
+  #define _mm512_set_epi32(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_epi32(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set_epi64 (int64_t e7, int64_t e6, int64_t e5, int64_t e4, int64_t e3, int64_t e2, int64_t e1, int64_t e0) {
+  simde__m512i_private r_;
+
+  r_.i64[0] = e0;
+  r_.i64[1] = e1;
+  r_.i64[2] = e2;
+  r_.i64[3] = e3;
+  r_.i64[4] = e4;
+  r_.i64[5] = e5;
+  r_.i64[6] = e6;
+  r_.i64[7] = e7;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_epi64
+  #define _mm512_set_epi64(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_epi64(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_epu8 (uint8_t e63, uint8_t e62, uint8_t e61, uint8_t e60, uint8_t e59, uint8_t e58, uint8_t e57, uint8_t e56,
+                        uint8_t e55, uint8_t e54, uint8_t e53, uint8_t e52, uint8_t e51, uint8_t e50, uint8_t e49, uint8_t e48,
+                        uint8_t e47, uint8_t e46, uint8_t e45, uint8_t e44, uint8_t e43, uint8_t e42, uint8_t e41, uint8_t e40,
+                        uint8_t e39, uint8_t e38, uint8_t e37, uint8_t e36, uint8_t e35, uint8_t e34, uint8_t e33, uint8_t e32,
+                        uint8_t e31, uint8_t e30, uint8_t e29, uint8_t e28, uint8_t e27, uint8_t e26, uint8_t e25, uint8_t e24,
+                        uint8_t e23, uint8_t e22, uint8_t e21, uint8_t e20, uint8_t e19, uint8_t e18, uint8_t e17, uint8_t e16,
+                        uint8_t e15, uint8_t e14, uint8_t e13, uint8_t e12, uint8_t e11, uint8_t e10, uint8_t  e9, uint8_t  e8,
+                        uint8_t  e7, uint8_t  e6, uint8_t  e5, uint8_t  e4, uint8_t  e3, uint8_t  e2, uint8_t  e1, uint8_t  e0) {
+  simde__m512i_private r_;
+
+  r_.u8[ 0] = e0;
+  r_.u8[ 1] = e1;
+  r_.u8[ 2] = e2;
+  r_.u8[ 3] = e3;
+  r_.u8[ 4] = e4;
+  r_.u8[ 5] = e5;
+  r_.u8[ 6] = e6;
+  r_.u8[ 7] = e7;
+  r_.u8[ 8] = e8;
+  r_.u8[ 9] = e9;
+  r_.u8[10] = e10;
+  r_.u8[11] = e11;
+  r_.u8[12] = e12;
+  r_.u8[13] = e13;
+  r_.u8[14] = e14;
+  r_.u8[15] = e15;
+  r_.u8[16] = e16;
+  r_.u8[17] = e17;
+  r_.u8[18] = e18;
+  r_.u8[19] = e19;
+  r_.u8[20] = e20;
+  r_.u8[21] = e21;
+  r_.u8[22] = e22;
+  r_.u8[23] = e23;
+  r_.u8[24] = e24;
+  r_.u8[25] = e25;
+  r_.u8[26] = e26;
+  r_.u8[27] = e27;
+  r_.u8[28] = e28;
+  r_.u8[29] = e29;
+  r_.u8[30] = e30;
+  r_.u8[31] = e31;
+  r_.u8[32] = e32;
+  r_.u8[33] = e33;
+  r_.u8[34] = e34;
+  r_.u8[35] = e35;
+  r_.u8[36] = e36;
+  r_.u8[37] = e37;
+  r_.u8[38] = e38;
+  r_.u8[39] = e39;
+  r_.u8[40] = e40;
+  r_.u8[41] = e41;
+  r_.u8[42] = e42;
+  r_.u8[43] = e43;
+  r_.u8[44] = e44;
+  r_.u8[45] = e45;
+  r_.u8[46] = e46;
+  r_.u8[47] = e47;
+  r_.u8[48] = e48;
+  r_.u8[49] = e49;
+  r_.u8[50] = e50;
+  r_.u8[51] = e51;
+  r_.u8[52] = e52;
+  r_.u8[53] = e53;
+  r_.u8[54] = e54;
+  r_.u8[55] = e55;
+  r_.u8[56] = e56;
+  r_.u8[57] = e57;
+  r_.u8[58] = e58;
+  r_.u8[59] = e59;
+  r_.u8[60] = e60;
+  r_.u8[61] = e61;
+  r_.u8[62] = e62;
+  r_.u8[63] = e63;
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_epu16 (uint16_t e31, uint16_t e30, uint16_t e29, uint16_t e28, uint16_t e27, uint16_t e26, uint16_t e25, uint16_t e24,
+                       uint16_t e23, uint16_t e22, uint16_t e21, uint16_t e20, uint16_t e19, uint16_t e18, uint16_t e17, uint16_t e16,
+                       uint16_t e15, uint16_t e14, uint16_t e13, uint16_t e12, uint16_t e11, uint16_t e10, uint16_t  e9, uint16_t  e8,
+                       uint16_t  e7, uint16_t  e6, uint16_t  e5, uint16_t  e4, uint16_t  e3, uint16_t  e2, uint16_t  e1, uint16_t  e0) {
+  simde__m512i_private r_;
+
+  r_.u16[ 0] = e0;
+  r_.u16[ 1] = e1;
+  r_.u16[ 2] = e2;
+  r_.u16[ 3] = e3;
+  r_.u16[ 4] = e4;
+  r_.u16[ 5] = e5;
+  r_.u16[ 6] = e6;
+  r_.u16[ 7] = e7;
+  r_.u16[ 8] = e8;
+  r_.u16[ 9] = e9;
+  r_.u16[10] = e10;
+  r_.u16[11] = e11;
+  r_.u16[12] = e12;
+  r_.u16[13] = e13;
+  r_.u16[14] = e14;
+  r_.u16[15] = e15;
+  r_.u16[16] = e16;
+  r_.u16[17] = e17;
+  r_.u16[18] = e18;
+  r_.u16[19] = e19;
+  r_.u16[20] = e20;
+  r_.u16[21] = e21;
+  r_.u16[22] = e22;
+  r_.u16[23] = e23;
+  r_.u16[24] = e24;
+  r_.u16[25] = e25;
+  r_.u16[26] = e26;
+  r_.u16[27] = e27;
+  r_.u16[28] = e28;
+  r_.u16[29] = e29;
+  r_.u16[30] = e30;
+  r_.u16[31] = e31;
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_epu32 (uint32_t e15, uint32_t e14, uint32_t e13, uint32_t e12, uint32_t e11, uint32_t e10, uint32_t  e9, uint32_t  e8,
+                         uint32_t  e7, uint32_t  e6, uint32_t  e5, uint32_t  e4, uint32_t  e3, uint32_t  e2, uint32_t  e1, uint32_t  e0) {
+  simde__m512i_private r_;
+
+  r_.u32[ 0] = e0;
+  r_.u32[ 1] = e1;
+  r_.u32[ 2] = e2;
+  r_.u32[ 3] = e3;
+  r_.u32[ 4] = e4;
+  r_.u32[ 5] = e5;
+  r_.u32[ 6] = e6;
+  r_.u32[ 7] = e7;
+  r_.u32[ 8] = e8;
+  r_.u32[ 9] = e9;
+  r_.u32[10] = e10;
+  r_.u32[11] = e11;
+  r_.u32[12] = e12;
+  r_.u32[13] = e13;
+  r_.u32[14] = e14;
+  r_.u32[15] = e15;
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_epu64 (uint64_t  e7, uint64_t  e6, uint64_t  e5, uint64_t  e4, uint64_t  e3, uint64_t  e2, uint64_t  e1, uint64_t  e0) {
+  simde__m512i_private r_;
+
+  r_.u64[ 0] = e0;
+  r_.u64[ 1] = e1;
+  r_.u64[ 2] = e2;
+  r_.u64[ 3] = e3;
+  r_.u64[ 4] = e4;
+  r_.u64[ 5] = e5;
+  r_.u64[ 6] = e6;
+  r_.u64[ 7] = e7;
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set_epi8 (int8_t e63, int8_t e62, int8_t e61, int8_t e60, int8_t e59, int8_t e58, int8_t e57, int8_t e56,
+                      int8_t e55, int8_t e54, int8_t e53, int8_t e52, int8_t e51, int8_t e50, int8_t e49, int8_t e48,
+                      int8_t e47, int8_t e46, int8_t e45, int8_t e44, int8_t e43, int8_t e42, int8_t e41, int8_t e40,
+                      int8_t e39, int8_t e38, int8_t e37, int8_t e36, int8_t e35, int8_t e34, int8_t e33, int8_t e32,
+                      int8_t e31, int8_t e30, int8_t e29, int8_t e28, int8_t e27, int8_t e26, int8_t e25, int8_t e24,
+                      int8_t e23, int8_t e22, int8_t e21, int8_t e20, int8_t e19, int8_t e18, int8_t e17, int8_t e16,
+                      int8_t e15, int8_t e14, int8_t e13, int8_t e12, int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+                      int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4, int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+  simde__m512i_private r_;
+
+  r_.i8[ 0] = e0;
+  r_.i8[ 1] = e1;
+  r_.i8[ 2] = e2;
+  r_.i8[ 3] = e3;
+  r_.i8[ 4] = e4;
+  r_.i8[ 5] = e5;
+  r_.i8[ 6] = e6;
+  r_.i8[ 7] = e7;
+  r_.i8[ 8] = e8;
+  r_.i8[ 9] = e9;
+  r_.i8[10] = e10;
+  r_.i8[11] = e11;
+  r_.i8[12] = e12;
+  r_.i8[13] = e13;
+  r_.i8[14] = e14;
+  r_.i8[15] = e15;
+  r_.i8[16] = e16;
+  r_.i8[17] = e17;
+  r_.i8[18] = e18;
+  r_.i8[19] = e19;
+  r_.i8[20] = e20;
+  r_.i8[21] = e21;
+  r_.i8[22] = e22;
+  r_.i8[23] = e23;
+  r_.i8[24] = e24;
+  r_.i8[25] = e25;
+  r_.i8[26] = e26;
+  r_.i8[27] = e27;
+  r_.i8[28] = e28;
+  r_.i8[29] = e29;
+  r_.i8[30] = e30;
+  r_.i8[31] = e31;
+  r_.i8[32] = e32;
+  r_.i8[33] = e33;
+  r_.i8[34] = e34;
+  r_.i8[35] = e35;
+  r_.i8[36] = e36;
+  r_.i8[37] = e37;
+  r_.i8[38] = e38;
+  r_.i8[39] = e39;
+  r_.i8[40] = e40;
+  r_.i8[41] = e41;
+  r_.i8[42] = e42;
+  r_.i8[43] = e43;
+  r_.i8[44] = e44;
+  r_.i8[45] = e45;
+  r_.i8[46] = e46;
+  r_.i8[47] = e47;
+  r_.i8[48] = e48;
+  r_.i8[49] = e49;
+  r_.i8[50] = e50;
+  r_.i8[51] = e51;
+  r_.i8[52] = e52;
+  r_.i8[53] = e53;
+  r_.i8[54] = e54;
+  r_.i8[55] = e55;
+  r_.i8[56] = e56;
+  r_.i8[57] = e57;
+  r_.i8[58] = e58;
+  r_.i8[59] = e59;
+  r_.i8[60] = e60;
+  r_.i8[61] = e61;
+  r_.i8[62] = e62;
+  r_.i8[63] = e63;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_epi8
+  #define _mm512_set_epi8(e63, e62, e61, e60, e59, e58, e57, e56, e55, e54, e53, e52, e51, e50, e49, e48, e47, e46, e45, e44, e43, e42, e41, e40, e39, e38, e37, e36, e35, e34, e33, e32, e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_epi8(e63, e62, e61, e60, e59, e58, e57, e56, e55, e54, e53, e52, e51, e50, e49, e48, e47, e46, e45, e44, e43, e42, e41, e40, e39, e38, e37, e36, e35, e34, e33, e32, e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_m128i (simde__m128i a, simde__m128i b, simde__m128i c, simde__m128i d) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    SIMDE_ALIGN(64) simde__m128i v[] = { d, c, b, a };
+    return simde_mm512_load_si512(HEDLEY_STATIC_CAST(__m512i *, HEDLEY_STATIC_CAST(void *, v)));
+  #else
+    simde__m512i_private r_;
+
+    r_.m128i[0] = d;
+    r_.m128i[1] = c;
+    r_.m128i[2] = b;
+    r_.m128i[3] = a;
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set_m256i (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    SIMDE_ALIGN(64) simde__m256i v[] = { b, a };
+    return simde_mm512_load_si512(HEDLEY_STATIC_CAST(__m512i *, HEDLEY_STATIC_CAST(void *, v)));
+  #else
+    simde__m512i_private r_;
+
+    r_.m256i[0] = b;
+    r_.m256i[1] = a;
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_set_ps (simde_float32 e15, simde_float32 e14, simde_float32 e13, simde_float32 e12,
+                    simde_float32 e11, simde_float32 e10, simde_float32  e9, simde_float32  e8,
+                    simde_float32  e7, simde_float32  e6, simde_float32  e5, simde_float32  e4,
+                    simde_float32  e3, simde_float32  e2, simde_float32  e1, simde_float32  e0) {
+  simde__m512_private r_;
+
+  r_.f32[ 0] = e0;
+  r_.f32[ 1] = e1;
+  r_.f32[ 2] = e2;
+  r_.f32[ 3] = e3;
+  r_.f32[ 4] = e4;
+  r_.f32[ 5] = e5;
+  r_.f32[ 6] = e6;
+  r_.f32[ 7] = e7;
+  r_.f32[ 8] = e8;
+  r_.f32[ 9] = e9;
+  r_.f32[10] = e10;
+  r_.f32[11] = e11;
+  r_.f32[12] = e12;
+  r_.f32[13] = e13;
+  r_.f32[14] = e14;
+  r_.f32[15] = e15;
+
+  return simde__m512_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_ps
+  #define _mm512_set_ps(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_ps(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_set_pd (simde_float64 e7, simde_float64 e6, simde_float64 e5, simde_float64 e4, simde_float64 e3, simde_float64 e2, simde_float64 e1, simde_float64 e0) {
+  simde__m512d_private r_;
+
+  r_.f64[0] = e0;
+  r_.f64[1] = e1;
+  r_.f64[2] = e2;
+  r_.f64[3] = e3;
+  r_.f64[4] = e4;
+  r_.f64[5] = e5;
+  r_.f64[6] = e6;
+  r_.f64[7] = e7;
+
+  return simde__m512d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set_pd
+  #define _mm512_set_pd(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_set_pd(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SET_H) */

--- a/2.0/simde/x86/avx512/set1.h
+++ b/2.0/simde/x86/avx512/set1.h
@@ -1,0 +1,323 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SET1_H)
+#define SIMDE_X86_AVX512_SET1_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set1_epi8 (int8_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_epi8(a);
+  #else
+    simde__m512i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = a;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_epi8
+  #define _mm512_set1_epi8(a) simde_mm512_set1_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_set1_epi8(simde__m512i src, simde__mmask64 k, int8_t a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_set1_epi8(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_set1_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_set1_epi8(src, k, a) simde_mm512_mask_set1_epi8(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_set1_epi8(simde__mmask64 k, int8_t a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_set1_epi8(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_set1_epi8(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_set1_epi8(k, a) simde_mm512_maskz_set1_epi8(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set1_epi16 (int16_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_epi16(a);
+  #else
+    simde__m512i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_epi16
+  #define _mm512_set1_epi16(a) simde_mm512_set1_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_set1_epi16(simde__m512i src, simde__mmask32 k, int16_t a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_set1_epi16(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi16(src, k, simde_mm512_set1_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_set1_epi16(src, k, a) simde_mm512_mask_set1_epi16(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_set1_epi16(simde__mmask32 k, int16_t a) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_set1_epi16(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi16(k, simde_mm512_set1_epi16(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_set1_epi16(k, a) simde_mm512_maskz_set1_epi16(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set1_epi32 (int32_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_epi32(a);
+  #else
+    simde__m512i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_epi32
+  #define _mm512_set1_epi32(a) simde_mm512_set1_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_set1_epi32(simde__m512i src, simde__mmask16 k, int32_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_set1_epi32(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_set1_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_set1_epi32(src, k, a) simde_mm512_mask_set1_epi32(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_set1_epi32(simde__mmask16 k, int32_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_set1_epi32(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_set1_epi32(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_set1_epi32(k, a) simde_mm512_maskz_set1_epi32(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set1_epi64 (int64_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_epi64(a);
+  #else
+    simde__m512i_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_epi64
+  #define _mm512_set1_epi64(a) simde_mm512_set1_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_set1_epi64(simde__m512i src, simde__mmask8 k, int64_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_set1_epi64(src, k, a);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_set1_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_mask_set1_epi64(src, k, a) simde_mm512_mask_set1_epi64(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_set1_epi64(simde__mmask8 k, int64_t a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_set1_epi64(k, a);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_set1_epi64(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#define _mm512_maskz_set1_epi64(k, a) simde_mm512_maskz_set1_epi64(k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set1_epu8 (uint8_t a) {
+  simde__m512i_private r_;
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+    r_.u8[i] = a;
+  }
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set1_epu16 (uint16_t a) {
+  simde__m512i_private r_;
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+    r_.u16[i] = a;
+  }
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set1_epu32 (uint32_t a) {
+  simde__m512i_private r_;
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+    r_.u32[i] = a;
+  }
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_set1_epu64 (uint64_t a) {
+  simde__m512i_private r_;
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+    r_.u64[i] = a;
+  }
+
+  return simde__m512i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_set1_ps (simde_float32 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_ps(a);
+  #else
+    simde__m512_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = a;
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_ps
+  #define _mm512_set1_ps(a) simde_mm512_set1_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_set1_pd (simde_float64 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_set1_pd(a);
+  #else
+    simde__m512d_private r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = a;
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set1_pd
+  #define _mm512_set1_pd(a) simde_mm512_set1_pd(a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SET1_H) */

--- a/2.0/simde/x86/avx512/set4.h
+++ b/2.0/simde/x86/avx512/set4.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SET4_H)
+#define SIMDE_X86_AVX512_SET4_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set4_epi32 (int32_t d, int32_t c, int32_t b, int32_t a) {
+  simde__m512i_private r_;
+
+  r_.i32[ 0] = a;
+  r_.i32[ 1] = b;
+  r_.i32[ 2] = c;
+  r_.i32[ 3] = d;
+  r_.i32[ 4] = a;
+  r_.i32[ 5] = b;
+  r_.i32[ 6] = c;
+  r_.i32[ 7] = d;
+  r_.i32[ 8] = a;
+  r_.i32[ 9] = b;
+  r_.i32[10] = c;
+  r_.i32[11] = d;
+  r_.i32[12] = a;
+  r_.i32[13] = b;
+  r_.i32[14] = c;
+  r_.i32[15] = d;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set4_epi32
+  #define _mm512_set4_epi32(d,c,b,a) simde_mm512_set4_epi32(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_set4_epi64 (int64_t d, int64_t c, int64_t b, int64_t a) {
+  simde__m512i_private r_;
+
+  r_.i64[0] = a;
+  r_.i64[1] = b;
+  r_.i64[2] = c;
+  r_.i64[3] = d;
+  r_.i64[4] = a;
+  r_.i64[5] = b;
+  r_.i64[6] = c;
+  r_.i64[7] = d;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set4_epi64
+  #define _mm512_set4_epi64(d,c,b,a) simde_mm512_set4_epi64(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_set4_ps (simde_float32 d, simde_float32 c, simde_float32 b, simde_float32 a) {
+  simde__m512_private r_;
+
+  r_.f32[ 0] = a;
+  r_.f32[ 1] = b;
+  r_.f32[ 2] = c;
+  r_.f32[ 3] = d;
+  r_.f32[ 4] = a;
+  r_.f32[ 5] = b;
+  r_.f32[ 6] = c;
+  r_.f32[ 7] = d;
+  r_.f32[ 8] = a;
+  r_.f32[ 9] = b;
+  r_.f32[10] = c;
+  r_.f32[11] = d;
+  r_.f32[12] = a;
+  r_.f32[13] = b;
+  r_.f32[14] = c;
+  r_.f32[15] = d;
+
+  return simde__m512_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set4_ps
+  #define _mm512_set4_ps(d,c,b,a) simde_mm512_set4_ps(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_set4_pd (simde_float64 d, simde_float64 c, simde_float64 b, simde_float64 a) {
+  simde__m512d_private r_;
+
+  r_.f64[0] = a;
+  r_.f64[1] = b;
+  r_.f64[2] = c;
+  r_.f64[3] = d;
+  r_.f64[4] = a;
+  r_.f64[5] = b;
+  r_.f64[6] = c;
+  r_.f64[7] = d;
+
+  return simde__m512d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_set4_pd
+  #define _mm512_set4_pd(d,c,b,a) simde_mm512_set4_pd(d,c,b,a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SET4_H) */

--- a/2.0/simde/x86/avx512/setone.h
+++ b/2.0/simde/x86/avx512/setone.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SETONE_H)
+#define SIMDE_X86_AVX512_SETONE_H
+
+#include "types.h"
+#include "cast.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_setone_si512(void) {
+  simde__m512i_private r_;
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+    r_.i32f[i] = ~HEDLEY_STATIC_CAST(int_fast32_t, 0);
+  }
+
+  return simde__m512i_from_private(r_);
+}
+#define simde_x_mm512_setone_epi32() simde_x_mm512_setone_si512()
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_x_mm512_setone_ps(void) {
+  return simde_mm512_castsi512_ps(simde_x_mm512_setone_si512());
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_x_mm512_setone_pd(void) {
+  return simde_mm512_castsi512_pd(simde_x_mm512_setone_si512());
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SETONE_H) */

--- a/2.0/simde/x86/avx512/setr.h
+++ b/2.0/simde/x86/avx512/setr.h
@@ -1,0 +1,144 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SETR_H)
+#define SIMDE_X86_AVX512_SETR_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_setr_epi32 (int32_t e15, int32_t e14, int32_t e13, int32_t e12, int32_t e11, int32_t e10, int32_t  e9, int32_t  e8,
+                       int32_t  e7, int32_t  e6, int32_t  e5, int32_t  e4, int32_t  e3, int32_t  e2, int32_t  e1, int32_t  e0) {
+  simde__m512i_private r_;
+
+  r_.i32[ 0] = e15;
+  r_.i32[ 1] = e14;
+  r_.i32[ 2] = e13;
+  r_.i32[ 3] = e12;
+  r_.i32[ 4] = e11;
+  r_.i32[ 5] = e10;
+  r_.i32[ 6] = e9;
+  r_.i32[ 7] = e8;
+  r_.i32[ 8] = e7;
+  r_.i32[ 9] = e6;
+  r_.i32[10] = e5;
+  r_.i32[11] = e4;
+  r_.i32[12] = e3;
+  r_.i32[13] = e2;
+  r_.i32[14] = e1;
+  r_.i32[15] = e0;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr_epi32
+  #define _mm512_setr_epi32(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_setr_epi32(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_setr_epi64 (int64_t e7, int64_t e6, int64_t e5, int64_t e4, int64_t e3, int64_t e2, int64_t e1, int64_t e0) {
+  simde__m512i_private r_;
+
+  r_.i64[0] = e7;
+  r_.i64[1] = e6;
+  r_.i64[2] = e5;
+  r_.i64[3] = e4;
+  r_.i64[4] = e3;
+  r_.i64[5] = e2;
+  r_.i64[6] = e1;
+  r_.i64[7] = e0;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr_epi64
+  #define _mm512_setr_epi64(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_setr_epi64(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_setr_ps (simde_float32 e15, simde_float32 e14, simde_float32 e13, simde_float32 e12,
+                    simde_float32 e11, simde_float32 e10, simde_float32  e9, simde_float32  e8,
+                    simde_float32  e7, simde_float32  e6, simde_float32  e5, simde_float32  e4,
+                    simde_float32  e3, simde_float32  e2, simde_float32  e1, simde_float32  e0) {
+  simde__m512_private r_;
+
+  r_.f32[ 0] = e15;
+  r_.f32[ 1] = e14;
+  r_.f32[ 2] = e13;
+  r_.f32[ 3] = e12;
+  r_.f32[ 4] = e11;
+  r_.f32[ 5] = e10;
+  r_.f32[ 6] = e9;
+  r_.f32[ 7] = e8;
+  r_.f32[ 8] = e7;
+  r_.f32[ 9] = e6;
+  r_.f32[10] = e5;
+  r_.f32[11] = e4;
+  r_.f32[12] = e3;
+  r_.f32[13] = e2;
+  r_.f32[14] = e1;
+  r_.f32[15] = e0;
+
+  return simde__m512_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr_ps
+  #define _mm512_setr_ps(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_setr_ps(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_setr_pd (simde_float64 e7, simde_float64 e6, simde_float64 e5, simde_float64 e4, simde_float64 e3, simde_float64 e2, simde_float64 e1, simde_float64 e0) {
+  simde__m512d_private r_;
+
+  r_.f64[0] = e7;
+  r_.f64[1] = e6;
+  r_.f64[2] = e5;
+  r_.f64[3] = e4;
+  r_.f64[4] = e3;
+  r_.f64[5] = e2;
+  r_.f64[6] = e1;
+  r_.f64[7] = e0;
+
+  return simde__m512d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr_pd
+  #define _mm512_setr_pd(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm512_setr_pd(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SETR_H) */

--- a/2.0/simde/x86/avx512/setr4.h
+++ b/2.0/simde/x86/avx512/setr4.h
@@ -1,0 +1,140 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SETR4_H)
+#define SIMDE_X86_AVX512_SETR4_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_setr4_epi32 (int32_t d, int32_t c, int32_t b, int32_t a) {
+  simde__m512i_private r_;
+
+  r_.i32[ 0] = d;
+  r_.i32[ 1] = c;
+  r_.i32[ 2] = b;
+  r_.i32[ 3] = a;
+  r_.i32[ 4] = d;
+  r_.i32[ 5] = c;
+  r_.i32[ 6] = b;
+  r_.i32[ 7] = a;
+  r_.i32[ 8] = d;
+  r_.i32[ 9] = c;
+  r_.i32[10] = b;
+  r_.i32[11] = a;
+  r_.i32[12] = d;
+  r_.i32[13] = c;
+  r_.i32[14] = b;
+  r_.i32[15] = a;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr4_epi32
+  #define _mm512_setr4_epi32(d,c,b,a) simde_mm512_setr4_epi32(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_setr4_epi64 (int64_t d, int64_t c, int64_t b, int64_t a) {
+  simde__m512i_private r_;
+
+  r_.i64[0] = d;
+  r_.i64[1] = c;
+  r_.i64[2] = b;
+  r_.i64[3] = a;
+  r_.i64[4] = d;
+  r_.i64[5] = c;
+  r_.i64[6] = b;
+  r_.i64[7] = a;
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr4_epi64
+  #define _mm512_setr4_epi64(d,c,b,a) simde_mm512_setr4_epi64(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_setr4_ps (simde_float32 d, simde_float32 c, simde_float32 b, simde_float32 a) {
+  simde__m512_private r_;
+
+  r_.f32[ 0] = d;
+  r_.f32[ 1] = c;
+  r_.f32[ 2] = b;
+  r_.f32[ 3] = a;
+  r_.f32[ 4] = d;
+  r_.f32[ 5] = c;
+  r_.f32[ 6] = b;
+  r_.f32[ 7] = a;
+  r_.f32[ 8] = d;
+  r_.f32[ 9] = c;
+  r_.f32[10] = b;
+  r_.f32[11] = a;
+  r_.f32[12] = d;
+  r_.f32[13] = c;
+  r_.f32[14] = b;
+  r_.f32[15] = a;
+
+  return simde__m512_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr4_ps
+  #define _mm512_setr4_ps(d,c,b,a) simde_mm512_setr4_ps(d,c,b,a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_setr4_pd (simde_float64 d, simde_float64 c, simde_float64 b, simde_float64 a) {
+  simde__m512d_private r_;
+
+  r_.f64[0] = d;
+  r_.f64[1] = c;
+  r_.f64[2] = b;
+  r_.f64[3] = a;
+  r_.f64[4] = d;
+  r_.f64[5] = c;
+  r_.f64[6] = b;
+  r_.f64[7] = a;
+
+  return simde__m512d_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setr4_pd
+  #define _mm512_setr4_pd(d,c,b,a) simde_mm512_setr4_pd(d,c,b,a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SETR4_H) */

--- a/2.0/simde/x86/avx512/setzero.h
+++ b/2.0/simde/x86/avx512/setzero.h
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SETZERO_H)
+#define SIMDE_X86_AVX512_SETZERO_H
+
+#include "types.h"
+#include "cast.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_setzero_si512(void) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_setzero_si512();
+  #else
+    simde__m512i r;
+    simde_memset(&r, 0, sizeof(r));
+    return r;
+  #endif
+}
+#define simde_mm512_setzero_epi32() simde_mm512_setzero_si512()
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setzero_si512
+  #define _mm512_setzero_si512() simde_mm512_setzero_si512()
+  #undef _mm512_setzero_epi32
+  #define _mm512_setzero_epi32() simde_mm512_setzero_si512()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_setzero_ps(void) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_setzero_ps();
+  #else
+    return simde_mm512_castsi512_ps(simde_mm512_setzero_si512());
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setzero_si512
+  #define _mm512_setzero_si512() simde_mm512_setzero_si512()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_setzero_pd(void) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_setzero_pd();
+  #else
+    return simde_mm512_castsi512_pd(simde_mm512_setzero_si512());
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_setzero_si512
+  #define _mm512_setzero_si512() simde_mm512_setzero_si512()
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SETZERO_H) */

--- a/2.0/simde/x86/avx512/shuffle.h
+++ b/2.0/simde/x86/avx512/shuffle.h
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SHUFFLE_H)
+#define SIMDE_X86_AVX512_SHUFFLE_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_shuffle_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_shuffle_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+    for (size_t i = 0 ; i < (sizeof(a_.m256i) / sizeof(a_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_mm256_shuffle_epi8(a_.m256i[i], b_.m256i[i]);
+    }
+  #else
+  SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      r_.u8[i] = (b_.u8[i] & 0x80) ? 0 : a_.u8[(b_.u8[i] & 0x0f) + (i & 0x30)];
+    }
+  #endif
+
+  return simde__m512i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_shuffle_epi8
+  #define _mm512_shuffle_epi8(a, b) simde_mm512_shuffle_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_shuffle_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_shuffle_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_shuffle_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_shuffle_epi8
+  #define _mm512_mask_shuffle_epi8(src, k, a, b) simde_mm512_mask_shuffle_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_shuffle_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_shuffle_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_shuffle_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_shuffle_epi8
+  #define _mm512_maskz_shuffle_epi8(k, a, b) simde_mm512_maskz_shuffle_epi8(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SHUFFLE_H) */

--- a/2.0/simde/x86/avx512/sll.h
+++ b/2.0/simde/x86/avx512/sll.h
@@ -1,0 +1,219 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SLL_H)
+#define SIMDE_X86_AVX512_SLL_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "setzero.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sll_epi16 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_sll_epi16(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sll_epi16(a_.m256i[i], count);
+      }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 15)
+        return simde_mm512_setzero_si512();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i16 = a_.i16 << HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sll_epi16
+  #define _mm512_sll_epi16(a, count) simde_mm512_sll_epi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sll_epi32 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sll_epi32(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_sll_epi32(a_.m256i[i], count);
+        }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 31)
+        return simde_mm512_setzero_si512();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i32 = a_.i32 << HEDLEY_STATIC_CAST(int32_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, a_.i32[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sll_epi32
+  #define _mm512_sll_epi32(a, count) simde_mm512_sll_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_sll_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sll_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_sll_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sll_epi32
+  #define _mm512_mask_sll_epi32(src, k, a, b) simde_mm512_mask_sll_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_sll_epi32(simde__mmask16 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sll_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_sll_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sll_epi32
+  #define _mm512_maskz_sll_epi32(k, a, b) simde_mm512_maskz_sll_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sll_epi64 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sll_epi64(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_sll_epi64(a_.m256i[i], count);
+        }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 63)
+        return simde_mm512_setzero_si512();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i64 = a_.i64 << HEDLEY_STATIC_CAST(int64_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.i64[i] = HEDLEY_STATIC_CAST(int64_t, a_.i64[i] << (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sll_epi64
+  #define _mm512_sll_epi64(a, count) simde_mm512_sll_epi64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_sll_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sll_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_sll_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sll_epi64
+  #define _mm512_mask_sll_epi64(src, k, a, b) simde_mm512_mask_sll_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_sll_epi64(simde__mmask8 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sll_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_sll_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sll_epi64
+  #define _mm512_maskz_sll_epi64(k, a, b) simde_mm512_maskz_sll_epi64(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SLL_H) */

--- a/2.0/simde/x86/avx512/slli.h
+++ b/2.0/simde/x86/avx512/slli.h
@@ -1,0 +1,179 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ *   2020      Christopher Moore <moore@free.fr>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SLLI_H)
+#define SIMDE_X86_AVX512_SLLI_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "setzero.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_slli_epi16 (simde__m512i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_16_(_mm512_slli_epi16, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_slli_epi16(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      if(imm8 < 16)
+        r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 << HEDLEY_STATIC_CAST(int16_t, imm8)));
+      else
+        return simde_mm512_setzero_si512();
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (imm8 < 16) ? HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << (imm8 & 0xff)) : 0;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_slli_epi16
+  #define _mm512_slli_epi16(a, imm8) simde_mm512_slli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_slli_epi32 (simde__m512i a, unsigned int imm8) {
+  /* I guess the restriction was added in 6.4, back-ported to 5.5, then
+   * removed (fixed) in 7? */
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_32_(_mm512_slli_epi32, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512F_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_slli_epi32(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    /* The Intel Intrinsics Guide says that only the 8 LSBits of imm8 are
+    * used.  In this case we should do "imm8 &= 0xff".  However in
+    * practice all bits are used. */
+    if (imm8 > 31) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_X86_AVX2_NATIVE)
+        r_.m256i[0] = simde_mm256_slli_epi32(a_.m256i[0], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m256i[1] = simde_mm256_slli_epi32(a_.m256i[1], HEDLEY_STATIC_CAST(int, imm8));
+      #elif defined(SIMDE_X86_SSE2_NATIVE)
+        r_.m128i[0] = simde_mm_slli_epi32(a_.m128i[0], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[1] = simde_mm_slli_epi32(a_.m128i[1], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[2] = simde_mm_slli_epi32(a_.m128i[2], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[3] = simde_mm_slli_epi32(a_.m128i[3], HEDLEY_STATIC_CAST(int, imm8));
+      #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u32 = a_.u32 << imm8;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+          r_.u32[i] = a_.u32[i] << imm8;
+        }
+      #endif
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_slli_epi32
+  #define _mm512_slli_epi32(a, imm8) simde_mm512_slli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_slli_epi64 (simde__m512i a, unsigned int imm8) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_64_(_mm512_slli_epi64, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512F_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_slli_epi64(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    /* The Intel Intrinsics Guide says that only the 8 LSBits of imm8 are
+    * used.  In this case we should do "imm8 &= 0xff".  However in
+    * practice all bits are used. */
+    if (imm8 > 63) {
+      simde_memset(&r_, 0, sizeof(r_));
+    } else {
+      #if defined(SIMDE_X86_AVX2_NATIVE)
+        r_.m256i[0] = simde_mm256_slli_epi64(a_.m256i[0], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m256i[1] = simde_mm256_slli_epi64(a_.m256i[1], HEDLEY_STATIC_CAST(int, imm8));
+      #elif defined(SIMDE_X86_SSE2_NATIVE)
+        r_.m128i[0] = simde_mm_slli_epi64(a_.m128i[0], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[1] = simde_mm_slli_epi64(a_.m128i[1], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[2] = simde_mm_slli_epi64(a_.m128i[2], HEDLEY_STATIC_CAST(int, imm8));
+        r_.m128i[3] = simde_mm_slli_epi64(a_.m128i[3], HEDLEY_STATIC_CAST(int, imm8));
+      #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u64 = a_.u64 << imm8;
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+          r_.u64[i] = a_.u64[i] << imm8;
+        }
+      #endif
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_slli_epi64
+  #define _mm512_slli_epi64(a, imm8) simde_mm512_slli_epi64(a, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SLLI_H) */

--- a/2.0/simde/x86/avx512/sllv.h
+++ b/2.0/simde/x86/avx512/sllv.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SLLV_H)
+#define SIMDE_X86_AVX512_SLLV_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sllv_epi16 (simde__m512i a, simde__m512i b) {
+  simde__m512i_private
+    a_ = simde__m512i_to_private(a),
+    b_ = simde__m512i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u16 = HEDLEY_STATIC_CAST(__typeof__(r_.u16), (b_.u16 < 16) & (a_.u16 << b_.u16));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = (b_.u16[i] < 16) ? HEDLEY_STATIC_CAST(uint16_t, (a_.u16[i] << b_.u16[i])) : 0;
+    }
+  #endif
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512BW_NATIVE)
+  #define simde_mm512_sllv_epi16(a, b) _mm512_sllv_epi16(a, b)
+#endif
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sllv_epi16
+  #define _mm512_sllv_epi16(a, b) simde_mm512_sllv_epi16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SLLV_H) */

--- a/2.0/simde/x86/avx512/sqrt.h
+++ b/2.0/simde/x86/avx512/sqrt.h
@@ -1,0 +1,127 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SQRT_H)
+#define SIMDE_X86_AVX512_SQRT_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sqrt_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sqrt_ps(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if defined(SIMDE_X86_AVX_NATIVE)
+      r_.m256[0] = simde_mm256_sqrt_ps(a_.m256[0]);
+      r_.m256[1] = simde_mm256_sqrt_ps(a_.m256[1]);
+    #elif defined(simde_math_sqrtf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sqrtf(a_.f32[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#  define _mm512_sqrt_ps(a) simde_mm512_sqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sqrt_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sqrt_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_sqrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sqrt_ps
+  #define _mm512_mask_sqrt_ps(src, k, a) simde_mm512_mask_sqrt_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sqrt_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sqrt_pd(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if defined(SIMDE_X86_AVX_NATIVE)
+      r_.m256d[0] = simde_mm256_sqrt_pd(a_.m256d[0]);
+      r_.m256d[1] = simde_mm256_sqrt_pd(a_.m256d[1]);
+    #elif defined(simde_math_sqrt)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sqrt(a_.f64[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+#  define _mm512_sqrt_pd(a) simde_mm512_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sqrt_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sqrt_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_sqrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sqrt_pd
+  #define _mm512_mask_sqrt_pd(src, k, a) simde_mm512_mask_sqrt_pd(src, k, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SQRT_H) */

--- a/2.0/simde/x86/avx512/sra.h
+++ b/2.0/simde/x86/avx512/sra.h
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRA_H)
+#define SIMDE_X86_AVX512_SRA_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sra_epi16 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_sra_epi16(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sra_epi16(a_.m256i[i], count);
+      }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+
+      if (shift > 15) shift = 15;
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = a_.i16[i] >> shift;
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sra_epi16
+  #define _mm512_sra_epi16(a, count) simde_mm512_sra_epi16(a, count)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRA_H) */

--- a/2.0/simde/x86/avx512/srai.h
+++ b/2.0/simde/x86/avx512/srai.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRAI_H)
+#define SIMDE_X86_AVX512_SRAI_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srai_epi16 (simde__m512i a, const int imm8) {
+  simde__m512i_private
+    r_,
+    a_ = simde__m512i_to_private(a);
+  unsigned int shift = HEDLEY_STATIC_CAST(unsigned int, imm8);
+
+  if (shift > 15) shift = 15;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[i] >> shift;
+    }
+  #endif
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512BW_NATIVE)
+#  define simde_mm512_srai_epi16(a, imm8) _mm512_srai_epi16(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srai_epi16
+  #define _mm512_srai_epi16(a, imm8) simde_mm512_srai_epi16(a, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRAI_H) */

--- a/2.0/simde/x86/avx512/srav.h
+++ b/2.0/simde/x86/avx512/srav.h
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRAV_H)
+#define SIMDE_X86_AVX512_SRAV_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srav_epi16 (simde__m512i a, simde__m512i count) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_srav_epi16(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      count_ = simde__m512i_to_private(count);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      uint32_t shift = HEDLEY_STATIC_CAST(uint32_t, count_.i16[i]);
+      if (shift > 16) shift = 15;
+      r_.i16[i] = a_.i16[i] >> shift;
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srav_epi16
+  #define _mm512_srav_epi16(a, count) simde_mm512_srav_epi16(a, count)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRAV_H) */

--- a/2.0/simde/x86/avx512/srl.h
+++ b/2.0/simde/x86/avx512/srl.h
@@ -1,0 +1,216 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRL_H)
+#define SIMDE_X86_AVX512_SRL_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srl_epi16 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_srl_epi16(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_srl_epi16(a_.m256i[i], count);
+      }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t , (count_.i64[0] > 16 ? 16 : count_.i64[0]));
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.u16 = a_.u16 >> HEDLEY_STATIC_CAST(int16_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.u16[i] = a_.u16[i] >> (shift);
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srl_epi16
+  #define _mm512_srl_epi16(a, count) simde_mm512_srl_epi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srl_epi32 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_srl_epi32(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_srl_epi32(a_.m256i[i], count);
+        }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 31)
+        return simde_mm512_setzero_si512();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i32 = a_.i32 >> HEDLEY_STATIC_CAST(int32_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, a_.i32[i] >> (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srl_epi32
+  #define _mm512_srl_epi32(a, count) simde_mm512_srl_epi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_srl_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_srl_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_srl_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_srl_epi32
+  #define _mm512_mask_srl_epi32(src, k, a, b) simde_mm512_mask_srl_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_srl_epi32(simde__mmask16 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_srl_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_srl_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_srl_epi32
+  #define _mm512_maskz_srl_epi32(k, a, b) simde_mm512_maskz_srl_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srl_epi64 (simde__m512i a, simde__m128i count) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_srl_epi64(a, count);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_srl_epi64(a_.m256i[i], count);
+        }
+    #else
+      simde__m128i_private
+        count_ = simde__m128i_to_private(count);
+
+      uint64_t shift = HEDLEY_STATIC_CAST(uint64_t, count_.i64[0]);
+      if (shift > 63)
+        return simde_mm512_setzero_si512();
+
+      #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+        r_.i64 = a_.i64 >> HEDLEY_STATIC_CAST(int64_t, shift);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.i64[i] = HEDLEY_STATIC_CAST(int64_t, a_.i64[i] >> (shift));
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srl_epi64
+  #define _mm512_srl_epi64(a, count) simde_mm512_srl_epi64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_srl_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_srl_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_srl_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_srl_epi64
+  #define _mm512_mask_srl_epi64(src, k, a, b) simde_mm512_mask_srl_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_srl_epi64(simde__mmask8 k, simde__m512i a, simde__m128i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_srl_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_srl_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_srl_epi64
+  #define _mm512_maskz_srl_epi64(k, a, b) simde_mm512_maskz_srl_epi64(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRL_H) */

--- a/2.0/simde/x86/avx512/srli.h
+++ b/2.0/simde/x86/avx512/srli.h
@@ -1,0 +1,180 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRLI_H)
+#define SIMDE_X86_AVX512_SRLI_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+#include "setzero.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srli_epi16 (simde__m512i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_16_(_mm512_srli_epi16, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512BW_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_srli_epi16(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    if (HEDLEY_STATIC_CAST(unsigned int, imm8) > 15)
+      return simde_mm512_setzero_si512();
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u16 = a_.u16 >> HEDLEY_STATIC_CAST(int16_t, imm8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] >> imm8;
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_NATIVE)
+  #define simde_mm512_srli_epi16(a, imm8) _mm512_srli_epi16(a, imm8)
+#endif
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srli_epi16
+  #define _mm512_srli_epi16(a, imm8) simde_mm512_srli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srli_epi32 (simde__m512i a, unsigned int imm8) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_32_(_mm512_srli_epi32, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512F_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_srli_epi32(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[0] = simde_mm256_srli_epi32(a_.m256i[0], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m256i[1] = simde_mm256_srli_epi32(a_.m256i[1], HEDLEY_STATIC_CAST(int, imm8));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_srli_epi32(a_.m128i[0], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[1] = simde_mm_srli_epi32(a_.m128i[1], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[2] = simde_mm_srli_epi32(a_.m128i[2], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[3] = simde_mm_srli_epi32(a_.m128i[3], HEDLEY_STATIC_CAST(int, imm8));
+    #else
+      if (imm8 > 31) {
+        simde_memset(&r_, 0, sizeof(r_));
+      } else {
+        #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+          r_.u32 = a_.u32 >> imm8;
+        #else
+          SIMDE_VECTORIZE
+          for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+            r_.u32[i] = a_.u32[i] >> imm8;
+          }
+        #endif
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srli_epi32
+  #define _mm512_srli_epi32(a, imm8) simde_mm512_srli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srli_epi64 (simde__m512i a, unsigned int imm8) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && (defined(HEDLEY_GCC_VERSION) && ((__GNUC__ == 5 && __GNUC_MINOR__ == 5) || (__GNUC__ == 6 && __GNUC_MINOR__ >= 4)))
+    simde__m512i r;
+
+    SIMDE_CONSTIFY_64_(_mm512_srli_epi64, r, simde_mm512_setzero_si512(), imm8, a);
+
+    return r;
+  #elif defined(SIMDE_X86_AVX512F_NATIVE)
+    return SIMDE_BUG_IGNORE_SIGN_CONVERSION(_mm512_srli_epi64(a, imm8));
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a);
+
+    #if defined(SIMDE_X86_AVX2_NATIVE)
+      r_.m256i[0] = simde_mm256_srli_epi64(a_.m256i[0], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m256i[1] = simde_mm256_srli_epi64(a_.m256i[1], HEDLEY_STATIC_CAST(int, imm8));
+    #elif defined(SIMDE_X86_SSE2_NATIVE)
+      r_.m128i[0] = simde_mm_srli_epi64(a_.m128i[0], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[1] = simde_mm_srli_epi64(a_.m128i[1], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[2] = simde_mm_srli_epi64(a_.m128i[2], HEDLEY_STATIC_CAST(int, imm8));
+      r_.m128i[3] = simde_mm_srli_epi64(a_.m128i[3], HEDLEY_STATIC_CAST(int, imm8));
+    #else
+      /* The Intel Intrinsics Guide says that only the 8 LSBits of imm8 are
+      * used.  In this case we should do "imm8 &= 0xff" here.  However in
+      * practice all bits are used. */
+      if (imm8 > 63) {
+        simde_memset(&r_, 0, sizeof(r_));
+      } else {
+        #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+          r_.u64 = a_.u64 >> imm8;
+        #else
+          SIMDE_VECTORIZE
+          for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+            r_.u64[i] = a_.u64[i] >> imm8;
+          }
+        #endif
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srli_epi64
+  #define _mm512_srli_epi64(a, imm8) simde_mm512_srli_epi64(a, imm8)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRLI_H) */

--- a/2.0/simde/x86/avx512/srlv.h
+++ b/2.0/simde/x86/avx512/srlv.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SRLV_H)
+#define SIMDE_X86_AVX512_SRLV_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_srlv_epi16 (simde__m512i a, simde__m512i b) {
+  simde__m512i_private
+    a_ = simde__m512i_to_private(a),
+    b_ = simde__m512i_to_private(b),
+    r_;
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u16 = HEDLEY_STATIC_CAST(__typeof__(r_.u16), (b_.u16 < 16) & (a_.u16 >> b_.u16));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      r_.u16[i] = (b_.u16[i] < 16) ? (a_.u16[i] >> b_.u16[i]) : 0;
+    }
+  #endif
+
+  return simde__m512i_from_private(r_);
+}
+#if defined(SIMDE_X86_AVX512BW_NATIVE)
+  #define simde_mm512_srlv_epi16(a, b) _mm512_srlv_epi16(a, b)
+#endif
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_srlv_epi16
+  #define _mm512_srlv_epi16(a, b) simde_mm512_srlv_epi16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SRLV_H) */

--- a/2.0/simde/x86/avx512/store.h
+++ b/2.0/simde/x86/avx512/store.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_STORE_H)
+#define SIMDE_X86_AVX512_STORE_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_store_ps (void * mem_addr, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_store_ps(mem_addr, a);
+  #else
+    simde_memcpy(SIMDE_ASSUME_ALIGNED_AS(simde__m512, mem_addr), &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_store_ps
+  #define _mm512_store_ps(mem_addr, a) simde_mm512_store_ps(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_store_pd (void * mem_addr, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_store_pd(mem_addr, a);
+  #else
+    simde_memcpy(SIMDE_ASSUME_ALIGNED_AS(simde__m512d, mem_addr), &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_store_pd
+  #define _mm512_store_pd(mem_addr, a) simde_mm512_store_pd(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_store_si512 (void * mem_addr, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_store_si512(HEDLEY_REINTERPRET_CAST(void*, mem_addr), a);
+  #else
+    simde_memcpy(SIMDE_ASSUME_ALIGNED_AS(simde__m512i, mem_addr), &a, sizeof(a));
+  #endif
+}
+#define simde_mm512_store_epi8(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+#define simde_mm512_store_epi16(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+#define simde_mm512_store_epi32(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+#define simde_mm512_store_epi64(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_store_epi8
+  #undef _mm512_store_epi16
+  #undef _mm512_store_epi32
+  #undef _mm512_store_epi64
+  #undef _mm512_store_si512
+  #define _mm512_store_si512(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+  #define _mm512_store_epi8(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+  #define _mm512_store_epi16(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+  #define _mm512_store_epi32(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+  #define _mm512_store_epi64(mem_addr, a) simde_mm512_store_si512(mem_addr, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_STORE_H) */

--- a/2.0/simde/x86/avx512/storeu.h
+++ b/2.0/simde/x86/avx512/storeu.h
@@ -1,0 +1,93 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_STOREU_H)
+#define SIMDE_X86_AVX512_STOREU_H
+
+#include "types.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_storeu_ps (void * mem_addr, simde__m512 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_storeu_ps(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_storeu_ps
+  #define _mm512_storeu_ps(mem_addr, a) simde_mm512_storeu_ps(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_storeu_pd (void * mem_addr, simde__m512d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_storeu_pd(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_storeu_pd
+  #define _mm512_storeu_pd(mem_addr, a) simde_mm512_storeu_pd(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm512_storeu_si512 (void * mem_addr, simde__m512i a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    _mm512_storeu_si512(HEDLEY_REINTERPRET_CAST(void*, mem_addr), a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#define simde_mm512_storeu_epi8(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+#define simde_mm512_storeu_epi16(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+#define simde_mm512_storeu_epi32(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+#define simde_mm512_storeu_epi64(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_storeu_epi8
+  #undef _mm512_storeu_epi16
+  #undef _mm512_storeu_epi32
+  #undef _mm512_storeu_epi64
+  #undef _mm512_storeu_si512
+  #define _mm512_storeu_si512(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+  #define _mm512_storeu_epi8(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+  #define _mm512_storeu_epi16(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+  #define _mm512_storeu_epi32(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+  #define _mm512_storeu_epi64(mem_addr, a) simde_mm512_storeu_si512(mem_addr, a)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_STOREU_H) */

--- a/2.0/simde/x86/avx512/sub.h
+++ b/2.0/simde/x86/avx512/sub.h
@@ -1,0 +1,351 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SUB_H)
+#define SIMDE_X86_AVX512_SUB_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sub_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_sub_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 - b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sub_epi8(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_epi8
+  #define _mm512_sub_epi8(a, b) simde_mm512_sub_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_sub_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_sub_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_sub_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sub_epi8
+  #define _mm512_mask_sub_epi8(src, k, a, b) simde_mm512_mask_sub_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_sub_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_sub_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_sub_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sub_epi8
+  #define _mm512_maskz_sub_epi8(k, a, b) simde_mm512_maskz_sub_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sub_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_sub_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 - b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sub_epi16(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_epi16
+  #define _mm512_sub_epi16(a, b) simde_mm512_sub_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sub_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sub_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 - b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sub_epi32(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_epi32
+  #define _mm512_sub_epi32(a, b) simde_mm512_sub_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_sub_epi32 (simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sub_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_sub_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sub_epi32
+  #define _mm512_mask_sub_epi32(src, k, a, b) simde_mm512_mask_sub_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_sub_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sub_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_sub_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sub_epi32
+  #define _mm512_maskz_sub_epi32(k, a, b) simde_mm512_maskz_sub_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_sub_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sub_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_sub_epi64(a_.m256i[i], b_.m256i[i]);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_epi64
+  #define _mm512_sub_epi64(a, b) simde_mm512_sub_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_sub_epi64 (simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sub_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_sub_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sub_epi64
+  #define _mm512_mask_sub_epi64(src, k, a, b) simde_mm512_mask_sub_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_sub_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sub_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_sub_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sub_epi64
+  #define _mm512_maskz_sub_epi64(k, a, b) simde_mm512_maskz_sub_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sub_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sub_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 - b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_sub_ps(a_.m256[i], b_.m256[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_ps
+  #define _mm512_sub_ps(a, b) simde_mm512_sub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sub_ps (simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sub_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_sub_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sub_ps
+  #define _mm512_mask_sub_ps(src, k, a, b) simde_mm512_mask_sub_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_sub_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sub_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_sub_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sub_ps
+  #define _mm512_maskz_sub_ps(k, a, b) simde_mm512_maskz_sub_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sub_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sub_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 - b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_sub_pd(a_.m256d[i], b_.m256d[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sub_pd
+  #define _mm512_sub_pd(a, b) simde_mm512_sub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sub_pd (simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sub_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_sub_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sub_pd
+  #define _mm512_mask_sub_pd(src, k, a, b) simde_mm512_mask_sub_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_sub_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_sub_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_sub_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_sub_pd
+  #define _mm512_maskz_sub_pd(k, a, b) simde_mm512_maskz_sub_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SUB_H) */

--- a/2.0/simde/x86/avx512/subs.h
+++ b/2.0/simde/x86/avx512/subs.h
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_SUBS_H)
+#define SIMDE_X86_AVX512_SUBS_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_subs_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_subs_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_subs_epi8(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        const int16_t tmp =
+          HEDLEY_STATIC_CAST(int16_t, a_.i8[i]) -
+          HEDLEY_STATIC_CAST(int16_t, b_.i8[i]);
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, ((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN) : INT8_MAX));
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_subs_epi8
+  #define _mm512_subs_epi8(a, b) simde_mm512_subs_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_subs_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_subs_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_subs_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_subs_epi8
+  #define _mm512_mask_subs_epi8(src, k, a, b) simde_mm512_mask_subs_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_subs_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_subs_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_subs_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_subs_epi8
+  #define _mm512_maskz_subs_epi8(k, a, b) simde_mm512_maskz_subs_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_subs_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_subs_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+      #if !defined(HEDLEY_INTEL_VERSION)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_subs_epi16(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          const int32_t tmp =
+            HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) -
+            HEDLEY_STATIC_CAST(int32_t, b_.i16[i]);
+          r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((tmp < INT16_MAX) ? ((tmp > INT16_MIN) ? tmp : INT16_MIN) : INT16_MAX));
+        }
+      #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_subs_epi16
+  #define _mm512_subs_epi16(a, b) simde_mm512_subs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_subs_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_subs_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+        r_.m128i[i] = simde_mm_subs_epu8(a_.m128i[i], b_.m128i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? (a_.u8[i] - b_.u8[i]) : UINT8_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_subs_epu8
+  #define _mm512_subs_epu8(a, b) simde_mm512_subs_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_subs_epu8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_mask_subs_epu8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_subs_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_subs_epu8
+  #define _mm512_mask_subs_epu8(src, k, a, b) simde_mm512_mask_subs_epu8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_subs_epu8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_maskz_subs_epu8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_subs_epu8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_subs_epu8
+  #define _mm512_maskz_subs_epu8(k, a, b) simde_mm512_maskz_subs_epu8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_subs_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_subs_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(HEDLEY_INTEL_VERSION)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_subs_epu16(a_.m256i[i], b_.m256i[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] > b_.u16[i]) ? (a_.u16[i] - b_.u16[i]) : UINT16_C(0);
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_subs_epu16
+  #define _mm512_subs_epu16(a, b) simde_mm512_subs_epu16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_SUBS_H) */

--- a/2.0/simde/x86/avx512/test.h
+++ b/2.0/simde/x86/avx512/test.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_TEST_H)
+#define SIMDE_X86_AVX512_TEST_H
+
+#include "types.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask16
+simde_mm512_mask_test_epi32_mask (simde__mmask16 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_test_epi32_mask(k1, a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask16 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i32) / sizeof(a_.i32[0])) ; i++) {
+      r |= HEDLEY_STATIC_CAST(simde__mmask16, !!(a_.i32[i] & b_.i32[i]) << i);
+    }
+
+    return r & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_test_epi32_mask
+  #define _mm512_mask_test_epi32_mask(k1, a, b) simde_mm512_mask_test_epi32_mask(k1, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__mmask8
+simde_mm512_mask_test_epi64_mask (simde__mmask8 k1, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_test_epi64_mask(k1, a, b);
+  #else
+    simde__m512i_private
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+    simde__mmask8 r = 0;
+
+    SIMDE_VECTORIZE_REDUCTION(|:r)
+    for (size_t i = 0 ; i < (sizeof(a_.i64) / sizeof(a_.i64[0])) ; i++) {
+      r |= !!(a_.i64[i] & b_.i64[i]) << i;
+    }
+
+    return r & k1;
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_test_epi64_mask
+  #define _mm512_mask_test_epi64_mask(k1, a, b) simde_mm512_mask_test_epi64_mask(k1, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_TEST_H) */

--- a/2.0/simde/x86/avx512/types.h
+++ b/2.0/simde/x86/avx512/types.h
@@ -1,0 +1,380 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *  2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_TYPES_H)
+#define SIMDE_X86_AVX512_TYPES_H
+
+#include "../avx.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+/* The problem is that Microsoft doesn't support 64-byte aligned parameters, except for
+ * __m512/__m512i/__m512d.  Since our private union has an __m512 member it will be 64-byte
+ * aligned even if we reduce the alignment requirements of other members.
+ *
+ * Even if we're on x86 and use the native AVX-512 types for arguments/return values, the
+ * to/from private functions will break, and I'm not willing to change their APIs to use
+ * pointers (which would also require more verbose code on the caller side) just to make
+ * MSVC happy.
+ *
+ * If you want to use AVX-512 in SIMDe, you'll need to either upgrade to MSVC 2017 or later,
+ * or upgrade to a different compiler (clang-cl, perhaps?).  If you have an idea of how to
+ * fix this without requiring API changes (except transparently through macros), patches
+ * are welcome.
+ */
+
+#  if defined(HEDLEY_MSVC_VERSION) && !HEDLEY_MSVC_VERSION_CHECK(19,10,0)
+#    if defined(SIMDE_X86_AVX512F_NATIVE)
+#      undef SIMDE_X86_AVX512F_NATIVE
+#      pragma message("Native AVX-512 support requires MSVC 2017 or later.  See comment above (in code) for details.")
+#    endif
+#    define SIMDE_AVX512_ALIGN SIMDE_ALIGN(32)
+#  else
+#    define SIMDE_AVX512_ALIGN SIMDE_ALIGN(64)
+#  endif
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_AVX512_ALIGN int8_t          i8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int16_t        i16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int32_t        i32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int64_t        i64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint8_t         u8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint16_t       u16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint32_t       u32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint64_t       u64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_uint128 u128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_float64  f64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_AVX512_ALIGN int8_t          i8[64];
+    SIMDE_AVX512_ALIGN int16_t        i16[32];
+    SIMDE_AVX512_ALIGN int32_t        i32[16];
+    SIMDE_AVX512_ALIGN int64_t        i64[8];
+    SIMDE_AVX512_ALIGN uint8_t         u8[64];
+    SIMDE_AVX512_ALIGN uint16_t       u16[32];
+    SIMDE_AVX512_ALIGN uint32_t       u32[16];
+    SIMDE_AVX512_ALIGN uint64_t       u64[8];
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f[64 / sizeof(int_fast32_t)];
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f[64 / sizeof(uint_fast32_t)];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128[4];
+    SIMDE_AVX512_ALIGN simde_uint128 u128[4];
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32[16];
+    SIMDE_AVX512_ALIGN simde_float64  f64[8];
+  #endif
+
+    SIMDE_AVX512_ALIGN simde__m128_private m128_private[4];
+    SIMDE_AVX512_ALIGN simde__m128         m128[4];
+    SIMDE_AVX512_ALIGN simde__m256_private m256_private[2];
+    SIMDE_AVX512_ALIGN simde__m256         m256[2];
+
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    SIMDE_AVX512_ALIGN __m512         n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[4];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[4];
+    #endif
+  #endif
+} simde__m512_private;
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_AVX512_ALIGN int8_t          i8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int16_t        i16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int32_t        i32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int64_t        i64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint8_t         u8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint16_t       u16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint32_t       u32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint64_t       u64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_uint128 u128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_float64  f64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_AVX512_ALIGN int8_t          i8[64];
+    SIMDE_AVX512_ALIGN int16_t        i16[32];
+    SIMDE_AVX512_ALIGN int32_t        i32[16];
+    SIMDE_AVX512_ALIGN int64_t        i64[8];
+    SIMDE_AVX512_ALIGN uint8_t         u8[64];
+    SIMDE_AVX512_ALIGN uint16_t       u16[32];
+    SIMDE_AVX512_ALIGN uint32_t       u32[16];
+    SIMDE_AVX512_ALIGN uint64_t       u64[8];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128[4];
+    SIMDE_AVX512_ALIGN simde_uint128 u128[4];
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32[16];
+    SIMDE_AVX512_ALIGN simde_float64  f64[8];
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f[64 / sizeof(int_fast32_t)];
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f[64 / sizeof(uint_fast32_t)];
+  #endif
+
+    SIMDE_AVX512_ALIGN simde__m128d_private m128d_private[4];
+    SIMDE_AVX512_ALIGN simde__m128d         m128d[4];
+    SIMDE_AVX512_ALIGN simde__m256d_private m256d_private[2];
+    SIMDE_AVX512_ALIGN simde__m256d         m256d[2];
+
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    SIMDE_AVX512_ALIGN __m512d        n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[4];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[4];
+    #endif
+  #endif
+} simde__m512d_private;
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_AVX512_ALIGN int8_t          i8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int16_t        i16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int32_t        i32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int64_t        i64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint8_t         u8 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint16_t       u16 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint32_t       u32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint64_t       u64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_uint128 u128 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN simde_float64  f64 SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_AVX512_ALIGN int8_t          i8[64];
+    SIMDE_AVX512_ALIGN int16_t        i16[32];
+    SIMDE_AVX512_ALIGN int32_t        i32[16];
+    SIMDE_AVX512_ALIGN int64_t        i64[8];
+    SIMDE_AVX512_ALIGN uint8_t         u8[64];
+    SIMDE_AVX512_ALIGN uint16_t       u16[32];
+    SIMDE_AVX512_ALIGN uint32_t       u32[16];
+    SIMDE_AVX512_ALIGN uint64_t       u64[8];
+    SIMDE_AVX512_ALIGN int_fast32_t  i32f[64 / sizeof(int_fast32_t)];
+    SIMDE_AVX512_ALIGN uint_fast32_t u32f[64 / sizeof(uint_fast32_t)];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_AVX512_ALIGN simde_int128  i128[4];
+    SIMDE_AVX512_ALIGN simde_uint128 u128[4];
+    #endif
+    SIMDE_AVX512_ALIGN simde_float32  f32[16];
+    SIMDE_AVX512_ALIGN simde_float64  f64[8];
+  #endif
+
+    SIMDE_AVX512_ALIGN simde__m128i_private m128i_private[4];
+    SIMDE_AVX512_ALIGN simde__m128i         m128i[4];
+    SIMDE_AVX512_ALIGN simde__m256i_private m256i_private[2];
+    SIMDE_AVX512_ALIGN simde__m256i         m256i[2];
+
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    SIMDE_AVX512_ALIGN __m512i        n;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32[4];
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32[4];
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64[4];
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64[4];
+    #endif
+  #endif
+} simde__m512i_private;
+
+/* Intel uses the same header (immintrin.h) for everything AVX and
+ * later.  If native aliases are enabled, and the machine has native
+ * support for AVX imintrin.h will already have been included, which
+ * means simde__m512* will already have been defined.  So, even
+ * if the machine doesn't support AVX512F we need to use the native
+ * type; it has already been defined.
+ *
+ * However, we also can't just assume that including immintrin.h does
+ * actually define these.  It could be a compiler which supports AVX
+ * but not AVX512F, such as GCC < 4.9 or VS < 2017.  That's why we
+ * check to see if _MM_CMPINT_GE is defined; it's part of AVX512F,
+ * so we assume that if it's present AVX-512F has already been
+ * declared.
+ *
+ * Note that the choice of _MM_CMPINT_GE is deliberate; while GCC
+ * uses the preprocessor to define all the _MM_CMPINT_* members,
+ * in most compilers they are simply normal enum members.  However,
+ * all compilers I've looked at use an object-like macro for
+ * _MM_CMPINT_GE, which is defined to _MM_CMPINT_NLT.  _MM_CMPINT_NLT
+ * is included in case a compiler does the reverse, though I haven't
+ * run into one which does.
+ *
+ * As for the ICC check, unlike other compilers, merely using the
+ * AVX-512 types causes ICC to generate AVX-512 instructions. */
+#if (defined(_MM_CMPINT_GE) || defined(_MM_CMPINT_NLT)) && (defined(SIMDE_X86_AVX512F_NATIVE) || !defined(HEDLEY_INTEL_VERSION))
+  typedef __m512 simde__m512;
+  typedef __m512i simde__m512i;
+  typedef __m512d simde__m512d;
+
+  typedef __mmask8 simde__mmask8;
+  typedef __mmask16 simde__mmask16;
+#else
+ #if defined(SIMDE_VECTOR_SUBSCRIPT)
+   typedef simde_float32 simde__m512  SIMDE_AVX512_ALIGN SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+   typedef int_fast32_t  simde__m512i SIMDE_AVX512_ALIGN SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+   typedef simde_float64 simde__m512d SIMDE_AVX512_ALIGN SIMDE_VECTOR(64) SIMDE_MAY_ALIAS;
+  #else
+    typedef simde__m512_private  simde__m512;
+    typedef simde__m512i_private simde__m512i;
+    typedef simde__m512d_private simde__m512d;
+  #endif
+
+  typedef uint8_t simde__mmask8;
+  typedef uint16_t simde__mmask16;
+#endif
+
+/* These are really part of AVX-512VL / AVX-512BW (in GCC __mmask32 is
+ * in avx512vlintrin.h and __mmask64 is in avx512bwintrin.h, in clang
+ * both are in avx512bwintrin.h), not AVX-512F.  However, we don't have
+ * a good (not-compiler-specific) way to detect if these headers have
+ * been included.  In compilers which support AVX-512F but not
+ * AVX-512BW/VL (e.g., GCC 4.9) we need typedefs since __mmask{32,64)
+ * won't exist.
+ *
+ * AFAICT __mmask{32,64} are always just typedefs to uint{32,64}_t
+ * in all compilers, so it's safe to use these instead of typedefs to
+ * __mmask{16,32}. If you run into a problem with this please file an
+ * issue and we'll try to figure out a work-around. */
+typedef uint32_t simde__mmask32;
+typedef uint64_t simde__mmask64;
+
+#if !defined(SIMDE_X86_AVX512F_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+  #if !defined(HEDLEY_INTEL_VERSION)
+    typedef simde__m512 __m512;
+    typedef simde__m512i __m512i;
+    typedef simde__m512d __m512d;
+  #else
+    #define __m512 simde__m512
+    #define __m512i simde__m512i
+    #define __m512d simde__m512d
+  #endif
+#endif
+
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512), "simde__m512 size incorrect");
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512_private), "simde__m512_private size incorrect");
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512i), "simde__m512i size incorrect");
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512i_private), "simde__m512i_private size incorrect");
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512d), "simde__m512d size incorrect");
+HEDLEY_STATIC_ASSERT(64 == sizeof(simde__m512d_private), "simde__m512d_private size incorrect");
+#if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512) == 32, "simde__m512 is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512_private) == 32, "simde__m512_private is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512i) == 32, "simde__m512i is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512i_private) == 32, "simde__m512i_private is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512d) == 32, "simde__m512d is not 32-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m512d_private) == 32, "simde__m512d_private is not 32-byte aligned");
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde__m512_from_private(simde__m512_private v) {
+  simde__m512 r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512_private
+simde__m512_to_private(simde__m512 v) {
+  simde__m512_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde__m512i_from_private(simde__m512i_private v) {
+  simde__m512i r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i_private
+simde__m512i_to_private(simde__m512i v) {
+  simde__m512i_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde__m512d_from_private(simde__m512d_private v) {
+  simde__m512d r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d_private
+simde__m512d_to_private(simde__m512d v) {
+  simde__m512d_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_TYPES_H) */

--- a/2.0/simde/x86/avx512/unpackhi.h
+++ b/2.0/simde/x86/avx512/unpackhi.h
@@ -1,0 +1,324 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_UNPACKHI_H)
+#define SIMDE_X86_AVX512_UNPACKHI_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpackhi_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_unpackhi_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 64, a_.i8, b_.i8,
+                                     8,  72,   9,  73,  10,  74,  11,  75,
+                                    12,  76,  13,  77,  14,  78,  15,  79,
+                                    24,  88,  25,  89,  26,  90,  27,  91,
+                                    28,  92,  29,  93,  30,  94,  31,  95,
+                                    40, 104,  41, 105,  42, 106,  43, 107,
+                                    44, 108,  45, 109,  46, 110,  47, 111,
+                                    56, 120,  57, 121,  58, 122,  59, 123,
+                                    60, 124,  61, 125,  62, 126,  63, 127);
+    #else
+      r_.m256i[0] = simde_mm256_unpackhi_epi8(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpackhi_epi8(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_epi8
+  #define _mm512_unpackhi_epi8(a, b) simde_mm512_unpackhi_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpackhi_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_unpackhi_epi16(a, b);
+  #else
+    simde__m512i_private
+        r_,
+        a_ = simde__m512i_to_private(a),
+        b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 =SIMDE_SHUFFLE_VECTOR_(16, 64, a_.i16, b_.i16,
+                                     4, 36,  5, 37,  6, 38,  7, 39, 12, 44, 13, 45, 14, 46, 15, 47,
+                                    20, 52, 21, 53, 22, 54, 23, 55, 28, 60, 29, 61, 30, 62, 31, 63);
+    #else
+      r_.m256i[0] = simde_mm256_unpackhi_epi16(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpackhi_epi16(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_epi16
+  #define _mm512_unpackhi_epi16(a, b) simde_mm512_unpackhi_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpackhi_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_unpackhi_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 64, a_.i32, b_.i32,
+                                    2, 18, 3 , 19,  6, 22, 7, 23,
+                                    10, 26, 11, 27,  14, 30, 15, 31);
+    #else
+      r_.m256i[0] = simde_mm256_unpackhi_epi32(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpackhi_epi32(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_epi32
+  #define _mm512_unpackhi_epi32(a, b) simde_mm512_unpackhi_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_unpackhi_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_unpackhi_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_unpackhi_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_unpackhi_epi32
+  #define _mm512_mask_unpackhi_epi32(src, k, a, b) simde_mm512_mask_unpackhi_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_unpackhi_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_unpackhi_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_unpackhi_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_unpackhi_epi32
+  #define _mm512_maskz_unpackhi_epi32(k, a, b) simde_mm512_maskz_unpackhi_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpackhi_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_unpackhi_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 64, a_.i64, b_.i64, 1, 9,  3, 11,  5, 13,  7, 15);
+    #else
+      r_.m256i[0] = simde_mm256_unpackhi_epi64(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpackhi_epi64(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_epi64
+  #define _mm512_unpackhi_epi64(a, b) simde_mm512_unpackhi_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_unpackhi_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_unpackhi_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_unpackhi_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_unpackhi_epi64
+  #define _mm512_mask_unpackhi_epi64(src, k, a, b) simde_mm512_mask_unpackhi_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_unpackhi_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_unpackhi_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_unpackhi_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_unpackhi_epi64
+  #define _mm512_maskz_unpackhi_epi64(k, a, b) simde_mm512_maskz_unpackhi_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_unpackhi_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_unpackhi_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 64, a_.f32, b_.f32,
+                                    2, 18, 3 , 19,  6, 22, 7, 23,
+                                    10, 26, 11, 27,  14, 30, 15, 31);
+    #else
+      r_.m256[0] = simde_mm256_unpackhi_ps(a_.m256[0], b_.m256[0]);
+      r_.m256[1] = simde_mm256_unpackhi_ps(a_.m256[1], b_.m256[1]);
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_ps
+  #define _mm512_unpackhi_ps(a, b) simde_mm512_unpackhi_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_unpackhi_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_unpackhi_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_unpackhi_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_unpackhi_ps
+  #define _mm512_mask_unpackhi_ps(src, k, a, b) simde_mm512_mask_unpackhi_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_maskz_unpackhi_ps(simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_unpackhi_ps(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_ps(k, simde_mm512_unpackhi_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_unpackhi_ps
+  #define _mm512_maskz_unpackhi_ps(k, a, b) simde_mm512_maskz_unpackhi_ps(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_unpackhi_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_unpackhi_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 64, a_.f64, b_.f64, 1, 9,  3, 11,  5, 13,  7, 15);
+    #else
+      r_.m256d[0] = simde_mm256_unpackhi_pd(a_.m256d[0], b_.m256d[0]);
+      r_.m256d[1] = simde_mm256_unpackhi_pd(a_.m256d[1], b_.m256d[1]);
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpackhi_pd
+  #define _mm512_unpackhi_pd(a, b) simde_mm512_unpackhi_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_unpackhi_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_unpackhi_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_unpackhi_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_unpackhi_pd
+  #define _mm512_mask_unpackhi_pd(src, k, a, b) simde_mm512_mask_unpackhi_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_maskz_unpackhi_pd(simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_unpackhi_pd(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_pd(k, simde_mm512_unpackhi_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_unpackhi_pd
+  #define _mm512_maskz_unpackhi_pd(k, a, b) simde_mm512_maskz_unpackhi_pd(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_UNPACKHI_H) */

--- a/2.0/simde/x86/avx512/unpacklo.h
+++ b/2.0/simde/x86/avx512/unpacklo.h
@@ -1,0 +1,104 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_UNPACKLO_H)
+#define SIMDE_X86_AVX512_UNPACKLO_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpacklo_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_unpacklo_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 64, a_.i8, b_.i8,
+                                    0,   64,  1,  65,  2,  66,  3,  67,
+                                    4,   68,  5,  69,  6,  70,  7,  71,
+                                    16,  80, 17,  81, 18,  82, 19,  83,
+                                    20,  84, 21,  85, 22,  86, 23,  87,
+                                    32,  96, 33,  97, 34,  98, 35,  99,
+                                    36, 100, 37, 101, 38, 102, 39, 103,
+                                    48, 112, 49, 113, 50, 114, 51, 115,
+                                    52, 116, 53, 117, 54, 118, 55, 119);
+    #else
+      r_.m256i[0] = simde_mm256_unpacklo_epi8(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpacklo_epi8(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpacklo_epi8
+  #define _mm512_unpacklo_epi8(a, b) simde_mm512_unpacklo_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_unpacklo_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    return _mm512_unpacklo_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 =SIMDE_SHUFFLE_VECTOR_(16, 64, a_.i16, b_.i16,
+                                    0,  32,  1, 33,  2, 34,  3, 35,  8, 40,  9, 41, 10, 42, 11, 43,
+                                    16, 48, 17, 49, 18, 50, 19, 51, 24, 56, 25, 57, 26, 58, 27, 59);
+    #else
+      r_.m256i[0] = simde_mm256_unpacklo_epi16(a_.m256i[0], b_.m256i[0]);
+      r_.m256i[1] = simde_mm256_unpacklo_epi16(a_.m256i[1], b_.m256i[1]);
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512BW_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_unpacklo_epi16
+  #define _mm512_unpacklo_epi16(a, b) simde_mm512_unpacklo_epi16(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_UNPACKLO_H) */

--- a/2.0/simde/x86/avx512/xor.h
+++ b/2.0/simde/x86/avx512/xor.h
@@ -1,0 +1,263 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_AVX512_XOR_H)
+#define SIMDE_X86_AVX512_XOR_H
+
+#include "types.h"
+#include "../avx2.h"
+#include "mov.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_xor_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_xor_ps(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    /* TODO: generate reduced case to give to Intel */
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256) && !defined(HEDLEY_INTEL_VERSION)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_xor_ps(a_.m256[i], b_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_xor_ps
+  #define _mm512_xor_ps(a, b) simde_mm512_xor_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_xor_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_AVX512DQ_NATIVE)
+    return _mm512_xor_pd(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      r_.m256d[0] = simde_mm256_xor_pd(a_.m256d[0], b_.m256d[0]);
+      r_.m256d[1] = simde_mm256_xor_pd(a_.m256d[1], b_.m256d[1]);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512DQ_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_xor_pd
+  #define _mm512_xor_pd(a, b) simde_mm512_xor_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_xor_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_xor_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_xor_si256(a_.m256i[i], b_.m256i[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 ^ b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] ^ b_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_xor_epi32
+  #define _mm512_xor_epi32(a, b) simde_mm512_xor_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_xor_epi32(simde__m512i src, simde__mmask16 k, simde__m512i v2, simde__m512i v3) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_xor_epi32(src, k, v2, v3);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_xor_epi32(v2, v3));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_xor_epi32
+  #define _mm512_mask_xor_epi32(src, k, v2, v3) simde_mm512_mask_xor_epi32(src, k, v2, v3)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_xor_epi32(simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_xor_epi32(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi32(k, simde_mm512_xor_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_xor_epi32
+  #define _mm512_maskz_xor_epi32(k, a, b) simde_mm512_maskz_xor_epi32(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_xor_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_xor_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+        r_.m256i[i] = simde_mm256_xor_si256(a_.m256i[i], b_.m256i[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 ^ b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] ^ b_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_xor_epi64
+  #define _mm512_xor_epi64(a, b) simde_mm512_xor_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_xor_epi64(simde__m512i src, simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_xor_epi64(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi64(src, k, simde_mm512_xor_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_xor_epi64
+  #define _mm512_mask_xor_epi64(src, k, a, b) simde_mm512_mask_xor_epi64(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_xor_epi64(simde__mmask8 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_xor_epi64(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi64(k, simde_mm512_xor_epi64(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_xor_epi64
+  #define _mm512_maskz_xor_epi64(k, a, b) simde_mm512_maskz_xor_epi64(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_xor_si512 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_xor_si512(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    r_.m256i[0] = simde_mm256_xor_si256(a_.m256i[0], b_.m256i[0]);
+    r_.m256i[1] = simde_mm256_xor_si256(a_.m256i[1], b_.m256i[1]);
+  #elif defined(SIMDE_X86_SSE2_NATIVE)
+    r_.m128i[0] = simde_mm_xor_si128(a_.m128i[0], b_.m128i[0]);
+    r_.m128i[1] = simde_mm_xor_si128(a_.m128i[1], b_.m128i[1]);
+    r_.m128i[2] = simde_mm_xor_si128(a_.m128i[2], b_.m128i[2]);
+    r_.m128i[3] = simde_mm_xor_si128(a_.m128i[3], b_.m128i[3]);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i32f = a_.i32f ^ b_.i32f;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+      r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+    }
+  #endif
+
+  return simde__m512i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_AVX512F_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_xor_si512
+  #define _mm512_xor_si512(a, b) simde_mm512_xor_si512(a, b)
+#endif
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_XOR_H) */

--- a/2.0/simde/x86/avx512/xorsign.h
+++ b/2.0/simde/x86/avx512/xorsign.h
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+/* This is a SIMDe extension which is not part of AVX-512.  It exists
+ * because a lot of numerical methods in SIMDe have algoriths which do
+ * something like:
+ *
+ *   float sgn = input < 0 ? -1 : 1;
+ *   ...
+ *   return res * sgn;
+ *
+ * Which can be replaced with a much more efficient call to xorsign:
+ *
+ *   return simde_x_mm512_xorsign_ps(res, input);
+ *
+ * While this was originally intended for use in SIMDe, please feel
+ * free to use it in your code.
+ */
+
+#if !defined(SIMDE_X86_AVX512_XORSIGN_H)
+#define SIMDE_X86_AVX512_XORSIGN_H
+
+#include "types.h"
+#include "mov.h"
+#include "and.h"
+#include "xor.h"
+#include "set1.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_x_mm512_xorsign_ps(simde__m512 dest, simde__m512 src) {
+  return simde_mm512_xor_ps(simde_mm512_and_ps(simde_mm512_set1_ps(-0.0f), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_x_mm512_xorsign_pd(simde__m512d dest, simde__m512d src) {
+  return simde_mm512_xor_pd(simde_mm512_and_pd(simde_mm512_set1_pd(-0.0), src), dest);
+}
+
+SIMDE_END_DECLS_
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_AVX512_XORSIGN_H) */

--- a/2.0/simde/x86/fma.h
+++ b/2.0/simde/x86/fma.h
@@ -1,0 +1,724 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2019      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_FMA_H)
+#define SIMDE_X86_FMA_H
+
+#include "avx.h"
+
+#if !defined(SIMDE_X86_FMA_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+#  define SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmadd_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_pd(a, b, c);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c),
+      r_;
+
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_madd(a_.altivec_f64, b_.altivec_f64, c_.altivec_f64);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmlaq_f64(c_.neon_f64, b_.neon_f64, a_.neon_f64);
+    #elif defined(simde_math_fma) && (defined(__FP_FAST_FMA) || defined(FP_FAST_FMA))
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_fma(a_.f64[i], b_.f64[i], c_.f64[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] * b_.f64[i]) + c_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmadd_pd
+  #define _mm_fmadd_pd(a, b, c) simde_mm_fmadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fmadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmadd_pd(a, b, c);
+  #else
+    return simde_mm256_add_pd(simde_mm256_mul_pd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmadd_pd
+  #define _mm256_fmadd_pd(a, b, c) simde_mm256_fmadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmadd_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_ps(a, b, c);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c),
+      r_;
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_fmaf(a_.f32[i], b_.f32[i], c_.f32[i]);
+      }
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f32 = vec_madd(a_.altivec_f32, b_.altivec_f32, c_.altivec_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE)
+      r_.neon_f32 = vmlaq_f32(c_.neon_f32, b_.neon_f32, a_.neon_f32);
+    #elif defined(simde_math_fmaf) && (defined(__FP_FAST_FMAF) || defined(FP_FAST_FMAF))
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_fma(a_.f32[i], b_.f32[i], c_.f32[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (a_.f32[i] * b_.f32[i]) + c_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmadd_ps
+  #define _mm_fmadd_ps(a, b, c) simde_mm_fmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fmadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmadd_ps(a, b, c);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+    simde__m256_private
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      c_ = simde__m256_to_private(c),
+      r_;
+
+    for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+      r_.m128[i] = simde_mm_fmadd_ps(a_.m128[i], b_.m128[i], c_.m128[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #else
+    return simde_mm256_add_ps(simde_mm256_mul_ps(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmadd_ps
+  #define _mm256_fmadd_ps(a, b, c) simde_mm256_fmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmadd_sd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_sd(a, b, c);
+  #else
+    return simde_mm_add_sd(simde_mm_mul_sd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmadd_sd
+  #define _mm_fmadd_sd(a, b, c) simde_mm_fmadd_sd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmadd_ss (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmadd_ss(a, b, c);
+  #else
+    return simde_mm_add_ss(simde_mm_mul_ss(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmadd_ss
+  #define _mm_fmadd_ss(a, b, c) simde_mm_fmadd_ss(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmaddsub_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmaddsub_pd(a, b, c);
+  #else
+    return simde_mm_addsub_pd(simde_mm_mul_pd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmaddsub_pd
+  #define _mm_fmaddsub_pd(a, b, c) simde_mm_fmaddsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fmaddsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmaddsub_pd(a, b, c);
+  #else
+    return simde_mm256_addsub_pd(simde_mm256_mul_pd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmaddsub_pd
+  #define _mm256_fmaddsub_pd(a, b, c) simde_mm256_fmaddsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmaddsub_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmaddsub_ps(a, b, c);
+  #else
+    return simde_mm_addsub_ps(simde_mm_mul_ps(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmaddsub_ps
+  #define _mm_fmaddsub_ps(a, b, c) simde_mm_fmaddsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fmaddsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmaddsub_ps(a, b, c);
+  #else
+    return simde_mm256_addsub_ps(simde_mm256_mul_ps(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmaddsub_ps
+  #define _mm256_fmaddsub_ps(a, b, c) simde_mm256_fmaddsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmsub_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsub_pd(a, b, c);
+  #else
+    return simde_mm_sub_pd(simde_mm_mul_pd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsub_pd
+  #define _mm_fmsub_pd(a, b, c) simde_mm_fmsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fmsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmsub_pd(a, b, c);
+  #else
+    return simde_mm256_sub_pd(simde_mm256_mul_pd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmsub_pd
+  #define _mm256_fmsub_pd(a, b, c) simde_mm256_fmsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmsub_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsub_ps(a, b, c);
+  #else
+    return simde_mm_sub_ps(simde_mm_mul_ps(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsub_ps
+  #define _mm_fmsub_ps(a, b, c) simde_mm_fmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fmsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmsub_ps(a, b, c);
+  #else
+    return simde_mm256_sub_ps(simde_mm256_mul_ps(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmsub_ps
+  #define _mm256_fmsub_ps(a, b, c) simde_mm256_fmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmsub_sd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsub_sd(a, b, c);
+  #else
+    return simde_mm_sub_sd(simde_mm_mul_sd(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsub_sd
+  #define _mm_fmsub_sd(a, b, c) simde_mm_fmsub_sd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmsub_ss (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsub_ss(a, b, c);
+  #else
+    return simde_mm_sub_ss(simde_mm_mul_ss(a, b), c);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsub_ss
+  #define _mm_fmsub_ss(a, b, c) simde_mm_fmsub_ss(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fmsubadd_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsubadd_pd(a, b, c);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+      r_.f64[  i  ] = (a_.f64[  i  ] * b_.f64[  i  ]) + c_.f64[  i  ];
+      r_.f64[i + 1] = (a_.f64[i + 1] * b_.f64[i + 1]) - c_.f64[i + 1];
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsubadd_pd
+  #define _mm_fmsubadd_pd(a, b, c) simde_mm_fmsubadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fmsubadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmsubadd_pd(a, b, c);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b),
+      c_ = simde__m256d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+      r_.f64[  i  ] = (a_.f64[  i  ] * b_.f64[  i  ]) + c_.f64[  i  ];
+      r_.f64[i + 1] = (a_.f64[i + 1] * b_.f64[i + 1]) - c_.f64[i + 1];
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmsubadd_pd
+  #define _mm256_fmsubadd_pd(a, b, c) simde_mm256_fmsubadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fmsubadd_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fmsubadd_ps(a, b, c);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+      r_.f32[  i  ] = (a_.f32[  i  ] * b_.f32[  i  ]) + c_.f32[  i  ];
+      r_.f32[i + 1] = (a_.f32[i + 1] * b_.f32[i + 1]) - c_.f32[i + 1];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fmsubadd_ps
+  #define _mm_fmsubadd_ps(a, b, c) simde_mm_fmsubadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fmsubadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fmsubadd_ps(a, b, c);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      c_ = simde__m256_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+      r_.f32[  i  ] = (a_.f32[  i  ] * b_.f32[  i  ]) + c_.f32[  i  ];
+      r_.f32[i + 1] = (a_.f32[i + 1] * b_.f32[i + 1]) - c_.f32[i + 1];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fmsubadd_ps
+  #define _mm256_fmsubadd_ps(a, b, c) simde_mm256_fmsubadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fnmadd_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmadd_pd(a, b, c);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = -(a_.f64[i] * b_.f64[i]) + c_.f64[i];
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmadd_pd
+  #define _mm_fnmadd_pd(a, b, c) simde_mm_fnmadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fnmadd_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fnmadd_pd(a, b, c);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b),
+      c_ = simde__m256d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = -(a_.f64[i] * b_.f64[i]) + c_.f64[i];
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fnmadd_pd
+  #define _mm256_fnmadd_pd(a, b, c) simde_mm256_fnmadd_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fnmadd_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmadd_ps(a, b, c);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = -(a_.f32[i] * b_.f32[i]) + c_.f32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmadd_ps
+  #define _mm_fnmadd_ps(a, b, c) simde_mm_fnmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fnmadd_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fnmadd_ps(a, b, c);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      c_ = simde__m256_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = -(a_.f32[i] * b_.f32[i]) + c_.f32[i];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fnmadd_ps
+  #define _mm256_fnmadd_ps(a, b, c) simde_mm256_fnmadd_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fnmadd_sd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmadd_sd(a, b, c);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c);
+
+    r_ = a_;
+    r_.f64[0] = -(a_.f64[0] * b_.f64[0]) + c_.f64[0];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmadd_sd
+  #define _mm_fnmadd_sd(a, b, c) simde_mm_fnmadd_sd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fnmadd_ss (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmadd_ss(a, b, c);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c);
+
+    r_ = a_;
+    r_.f32[0] = -(a_.f32[0] * b_.f32[0]) + c_.f32[0];
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmadd_ss
+  #define _mm_fnmadd_ss(a, b, c) simde_mm_fnmadd_ss(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fnmsub_pd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmsub_pd(a, b, c);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = -(a_.f64[i] * b_.f64[i]) - c_.f64[i];
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmsub_pd
+  #define _mm_fnmsub_pd(a, b, c) simde_mm_fnmsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_fnmsub_pd (simde__m256d a, simde__m256d b, simde__m256d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fnmsub_pd(a, b, c);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b),
+      c_ = simde__m256d_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = -(a_.f64[i] * b_.f64[i]) - c_.f64[i];
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fnmsub_pd
+  #define _mm256_fnmsub_pd(a, b, c) simde_mm256_fnmsub_pd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fnmsub_ps (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmsub_ps(a, b, c);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = -(a_.f32[i] * b_.f32[i]) - c_.f32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmsub_ps
+  #define _mm_fnmsub_ps(a, b, c) simde_mm_fnmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_fnmsub_ps (simde__m256 a, simde__m256 b, simde__m256 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm256_fnmsub_ps(a, b, c);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b),
+      c_ = simde__m256_to_private(c);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = -(a_.f32[i] * b_.f32[i]) - c_.f32[i];
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_fnmsub_ps
+  #define _mm256_fnmsub_ps(a, b, c) simde_mm256_fnmsub_ps(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_fnmsub_sd (simde__m128d a, simde__m128d b, simde__m128d c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmsub_sd(a, b, c);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      c_ = simde__m128d_to_private(c);
+
+    r_ = a_;
+    r_.f64[0] = -(a_.f64[0] * b_.f64[0]) - c_.f64[0];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmsub_sd
+  #define _mm_fnmsub_sd(a, b, c) simde_mm_fnmsub_sd(a, b, c)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_fnmsub_ss (simde__m128 a, simde__m128 b, simde__m128 c) {
+  #if defined(SIMDE_X86_FMA_NATIVE)
+    return _mm_fnmsub_ss(a, b, c);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      c_ = simde__m128_to_private(c);
+
+    r_ = simde__m128_to_private(a);
+    r_.f32[0] = -(a_.f32[0] * b_.f32[0]) - c_.f32[0];
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_FMA_ENABLE_NATIVE_ALIASES)
+  #undef _mm_fnmsub_ss
+  #define _mm_fnmsub_ss(a, b, c) simde_mm_fnmsub_ss(a, b, c)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_FMA_H) */

--- a/2.0/simde/x86/gfni.h
+++ b/2.0/simde/x86/gfni.h
@@ -1,0 +1,802 @@
+/* Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Christopher Moore <moore@free.fr>
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_GFNI_H)
+#define SIMDE_X86_GFNI_H
+
+#include "avx512/add.h"
+#include "avx512/and.h"
+#include "avx512/cmpeq.h"
+#include "avx512/cmpge.h"
+#include "avx512/cmpgt.h"
+#include "avx512/broadcast.h"
+#include "avx512/permutex2var.h"
+#include "avx512/mov.h"
+#include "avx512/mov_mask.h"
+#include "avx512/set.h"
+#include "avx512/set1.h"
+#include "avx512/setzero.h"
+#include "avx512/shuffle.h"
+#include "avx512/srli.h"
+#include "avx512/xor.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+/* In all the *gf2p8affine* intrinsics the argument b must be a compile-time constant so we must use macros and simde_x_mm* helper functions */
+
+/* N.B. The _mm*gf2p8affineinv_epi64_epi8 and _mm*gf2p8mul_epi8 intrinsics are for a Field Generator Polynomial (FGP) (aka reduction polynomial) of 0x11B */
+/* Only the _mm*gf2p8affine_epi64_epi8 intrinsics do not assume this specific FGP */
+
+/* Computing the inverse of an GF element is expensive so use this LUT for an FGP of 0x11B */
+
+static const union {
+  uint8_t      u8[256];
+  simde__m128i m128i[16];
+} simde_x_gf2p8inverse_lut = {
+  {
+   0x00, 0x01, 0x8d, 0xf6, 0xcb, 0x52, 0x7b, 0xd1, 0xe8, 0x4f, 0x29, 0xc0, 0xb0, 0xe1, 0xe5, 0xc7,
+   0x74, 0xb4, 0xaa, 0x4b, 0x99, 0x2b, 0x60, 0x5f, 0x58, 0x3f, 0xfd, 0xcc, 0xff, 0x40, 0xee, 0xb2,
+   0x3a, 0x6e, 0x5a, 0xf1, 0x55, 0x4d, 0xa8, 0xc9, 0xc1, 0x0a, 0x98, 0x15, 0x30, 0x44, 0xa2, 0xc2,
+   0x2c, 0x45, 0x92, 0x6c, 0xf3, 0x39, 0x66, 0x42, 0xf2, 0x35, 0x20, 0x6f, 0x77, 0xbb, 0x59, 0x19,
+   0x1d, 0xfe, 0x37, 0x67, 0x2d, 0x31, 0xf5, 0x69, 0xa7, 0x64, 0xab, 0x13, 0x54, 0x25, 0xe9, 0x09,
+   0xed, 0x5c, 0x05, 0xca, 0x4c, 0x24, 0x87, 0xbf, 0x18, 0x3e, 0x22, 0xf0, 0x51, 0xec, 0x61, 0x17,
+   0x16, 0x5e, 0xaf, 0xd3, 0x49, 0xa6, 0x36, 0x43, 0xf4, 0x47, 0x91, 0xdf, 0x33, 0x93, 0x21, 0x3b,
+   0x79, 0xb7, 0x97, 0x85, 0x10, 0xb5, 0xba, 0x3c, 0xb6, 0x70, 0xd0, 0x06, 0xa1, 0xfa, 0x81, 0x82,
+   0x83, 0x7e, 0x7f, 0x80, 0x96, 0x73, 0xbe, 0x56, 0x9b, 0x9e, 0x95, 0xd9, 0xf7, 0x02, 0xb9, 0xa4,
+   0xde, 0x6a, 0x32, 0x6d, 0xd8, 0x8a, 0x84, 0x72, 0x2a, 0x14, 0x9f, 0x88, 0xf9, 0xdc, 0x89, 0x9a,
+   0xfb, 0x7c, 0x2e, 0xc3, 0x8f, 0xb8, 0x65, 0x48, 0x26, 0xc8, 0x12, 0x4a, 0xce, 0xe7, 0xd2, 0x62,
+   0x0c, 0xe0, 0x1f, 0xef, 0x11, 0x75, 0x78, 0x71, 0xa5, 0x8e, 0x76, 0x3d, 0xbd, 0xbc, 0x86, 0x57,
+   0x0b, 0x28, 0x2f, 0xa3, 0xda, 0xd4, 0xe4, 0x0f, 0xa9, 0x27, 0x53, 0x04, 0x1b, 0xfc, 0xac, 0xe6,
+   0x7a, 0x07, 0xae, 0x63, 0xc5, 0xdb, 0xe2, 0xea, 0x94, 0x8b, 0xc4, 0xd5, 0x9d, 0xf8, 0x90, 0x6b,
+   0xb1, 0x0d, 0xd6, 0xeb, 0xc6, 0x0e, 0xcf, 0xad, 0x08, 0x4e, 0xd7, 0xe3, 0x5d, 0x50, 0x1e, 0xb3,
+   0x5b, 0x23, 0x38, 0x34, 0x68, 0x46, 0x03, 0x8c, 0xdd, 0x9c, 0x7d, 0xa0, 0xcd, 0x1a, 0x41, 0x1c
+  }
+};
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8matrix_multiply_epi64_epi8 (simde__m128i x, simde__m128i A) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    simde__m128i r, a, p;
+    const simde__m128i byte_select = simde_x_mm_set_epu64x(UINT64_C(0xFDFDFDFDFDFDFDFD), UINT64_C(0xFEFEFEFEFEFEFEFE));
+    const simde__m128i zero = simde_mm_setzero_si128();
+
+    a = simde_mm_shuffle_epi8(A, simde_x_mm_set_epu64x(UINT64_C(0x08090A0B0C0D0E0F), UINT64_C(0x0001020304050607)));
+    r = zero;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      p = simde_mm_insert_epi16(zero, simde_mm_movemask_epi8(a), 1);
+      p = simde_mm_shuffle_epi8(p, simde_mm_sign_epi8(byte_select, x));
+      r = simde_mm_xor_si128(r, p);
+      a = simde_mm_add_epi8(a, a);
+      x = simde_mm_add_epi8(x, x);
+    }
+
+    return r;
+  #else
+    simde__m128i_private
+      r_,
+      x_ = simde__m128i_to_private(x),
+      A_ = simde__m128i_to_private(A);
+    const uint64_t ones = UINT64_C(0x0101010101010101);
+    const uint64_t mask = UINT64_C(0x0102040810204080);
+    uint64_t q;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      q = simde_endian_bswap64_le(A_.u64[i / 8]);
+      q &= HEDLEY_STATIC_CAST(uint64_t, x_.u8[i]) * ones;
+      q ^= q >> 4;
+      q ^= q >> 2;
+      q ^= q >> 1;
+      q &= ones;
+      q *= 255;
+      q &= mask;
+      q |= q >> 32;
+      q |= q >> 16;
+      q |= q >> 8;
+      r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, q);
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8matrix_multiply_epi64_epi8 (simde__m256i x, simde__m256i A) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i r, a, p;
+    const simde__m256i byte_select = simde_x_mm256_set_epu64x(UINT64_C(0x0303030303030303), UINT64_C(0x0202020202020202),
+                                                              UINT64_C(0x0101010101010101), UINT64_C(0x0000000000000000));
+    a = simde_mm256_shuffle_epi8(A, simde_mm256_broadcastsi128_si256(simde_x_mm_set_epu64x(UINT64_C(0x08090A0B0C0D0E0F), UINT64_C(0x0001020304050607))));
+    r = simde_mm256_setzero_si256();
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      p = simde_mm256_set1_epi32(simde_mm256_movemask_epi8(a));
+      p = simde_mm256_shuffle_epi8(p, byte_select);
+      p = simde_mm256_xor_si256(r, p);
+      r = simde_mm256_blendv_epi8(r, p, x);
+      a = simde_mm256_add_epi8(a, a);
+      x = simde_mm256_add_epi8(x, x);
+    }
+
+    return r;
+  #else
+    simde__m256i_private
+      r_,
+      x_ = simde__m256i_to_private(x),
+      A_ = simde__m256i_to_private(A);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_gf2p8matrix_multiply_epi64_epi8(x_.m128i[i], A_.m128i[i]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_gf2p8matrix_multiply_epi64_epi8 (simde__m512i x, simde__m512i A) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    simde__m512i r, a, p;
+    const simde__m512i byte_select = simde_x_mm512_set_epu64(UINT64_C(0x0707070707070707), UINT64_C(0x0606060606060606), UINT64_C(0x0505050505050505), UINT64_C(0x0404040404040404),
+                                                             UINT64_C(0x0303030303030303), UINT64_C(0x0202020202020202), UINT64_C(0x0101010101010101), UINT64_C(0X0000000000000000));
+    a = simde_mm512_shuffle_epi8(A, simde_mm512_broadcast_i32x4(simde_x_mm_set_epu64x(UINT64_C(0x08090A0B0C0D0E0F), UINT64_C(0x0001020304050607))));
+    r = simde_mm512_setzero_si512();
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      p = simde_mm512_set1_epi64(HEDLEY_STATIC_CAST(int64_t, simde_mm512_movepi8_mask(a)));
+      p = simde_mm512_maskz_shuffle_epi8(simde_mm512_movepi8_mask(x), p, byte_select);
+      r = simde_mm512_xor_si512(r, p);
+      a = simde_mm512_add_epi8(a, a);
+      x = simde_mm512_add_epi8(x, x);
+    }
+
+    return r;
+  #else
+    simde__m512i_private
+      r_,
+      x_ = simde__m512i_to_private(x),
+      A_ = simde__m512i_to_private(A);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_x_mm256_gf2p8matrix_multiply_epi64_epi8(x_.m256i[i], A_.m256i[i]);
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_gf2p8inverse_epi8 (simde__m128i x) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    /* N.B. CM: this fallback may not be faster */
+    simde__m128i r, u, t, test;
+    const simde__m128i sixteens = simde_mm_set1_epi8(16);
+    const simde__m128i masked_x = simde_mm_and_si128(x, simde_mm_set1_epi8(0x0F));
+
+    test = simde_mm_set1_epi8(INT8_MIN /* 0x80 */);
+    x = simde_mm_xor_si128(x, test);
+    r = simde_mm_shuffle_epi8(simde_x_gf2p8inverse_lut.m128i[0], masked_x);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 1 ; i < 16 ; i++) {
+      t = simde_mm_shuffle_epi8(simde_x_gf2p8inverse_lut.m128i[i], masked_x);
+      test = simde_mm_add_epi8(test, sixteens);
+      u = simde_mm_cmplt_epi8(x, test);
+      r = simde_mm_blendv_epi8(t, r, u);
+    }
+
+    return r;
+  #else
+    simde__m128i_private
+      r_,
+      x_ = simde__m128i_to_private(x);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      r_.u8[i] = simde_x_gf2p8inverse_lut.u8[x_.u8[i]];
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_x_mm256_gf2p8inverse_epi8 (simde__m256i x) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    /* N.B. CM: this fallback may not be faster */
+    simde__m256i r, u, t, test;
+    const simde__m256i sixteens = simde_mm256_set1_epi8(16);
+    const simde__m256i masked_x = simde_mm256_and_si256(x, simde_mm256_set1_epi8(0x0F));
+
+    test = simde_mm256_set1_epi8(INT8_MIN /* 0x80 */);
+    x = simde_mm256_xor_si256(x, test);
+    r = simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p8inverse_lut.m128i[0]), masked_x);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 1 ; i < 16 ; i++) {
+      t = simde_mm256_shuffle_epi8(simde_mm256_broadcastsi128_si256(simde_x_gf2p8inverse_lut.m128i[i]), masked_x);
+      test = simde_mm256_add_epi8(test, sixteens);
+      u = simde_mm256_cmpgt_epi8(test, x);
+      r = simde_mm256_blendv_epi8(t, r, u);
+    }
+
+    return r;
+  #else
+    simde__m256i_private
+      r_,
+      x_ = simde__m256i_to_private(x);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_x_mm_gf2p8inverse_epi8(x_.m128i[i]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_x_mm512_gf2p8inverse_epi8 (simde__m512i x) {
+  /* N.B. CM: TODO: later add VBMI version using just two _mm512_permutex2var_epi8 and friends */
+  /* But except for Cannon Lake all processors with VBMI also have GFNI */
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    /* N.B. CM: this fallback may not be faster */
+    simde__m512i r, test;
+    const simde__m512i sixteens = simde_mm512_set1_epi8(16);
+    const simde__m512i masked_x = simde_mm512_and_si512(x, simde_mm512_set1_epi8(0x0F));
+
+    r = simde_mm512_shuffle_epi8(simde_mm512_broadcast_i32x4(simde_x_gf2p8inverse_lut.m128i[0]), masked_x);
+    test = sixteens;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 1 ; i < 16 ; i++) {
+      r = simde_mm512_mask_shuffle_epi8(r, simde_mm512_cmpge_epu8_mask(x, test), simde_mm512_broadcast_i32x4(simde_x_gf2p8inverse_lut.m128i[i]), masked_x);
+      test = simde_mm512_add_epi8(test, sixteens);
+    }
+
+    return r;
+  #else
+    simde__m512i_private
+      r_,
+      x_ = simde__m512i_to_private(x);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+      r_.m256i[i] = simde_x_mm256_gf2p8inverse_epi8(x_.m256i[i]);
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+
+#define simde_x_mm_gf2p8matrix_multiply_inverse_epi64_epi8(x, A) simde_x_mm_gf2p8matrix_multiply_epi64_epi8(simde_x_mm_gf2p8inverse_epi8(x), A)
+#define simde_x_mm256_gf2p8matrix_multiply_inverse_epi64_epi8(x, A) simde_x_mm256_gf2p8matrix_multiply_epi64_epi8(simde_x_mm256_gf2p8inverse_epi8(x), A)
+#define simde_x_mm512_gf2p8matrix_multiply_inverse_epi64_epi8(x, A) simde_x_mm512_gf2p8matrix_multiply_epi64_epi8(simde_x_mm512_gf2p8inverse_epi8(x), A)
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_gf2p8affine_epi64_epi8 (simde__m128i x, simde__m128i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm_xor_si128(simde_x_mm_gf2p8matrix_multiply_epi64_epi8(x, A), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_gf2p8affine_epi64_epi8(x, A, b) _mm_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_gf2p8affine_epi64_epi8
+  #define _mm_gf2p8affine_epi64_epi8(x, A, b) simde_mm_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_gf2p8affine_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm256_xor_si256(simde_x_mm256_gf2p8matrix_multiply_epi64_epi8(x, A), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_gf2p8affine_epi64_epi8(x, A, b) _mm256_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_gf2p8affine_epi64_epi8
+  #define _mm256_gf2p8affine_epi64_epi8(x, A, b) simde_mm256_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_gf2p8affine_epi64_epi8 (simde__m512i x, simde__m512i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm512_xor_si512(simde_x_mm512_gf2p8matrix_multiply_epi64_epi8(x, A), simde_mm512_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_gf2p8affine_epi64_epi8(x, A, b) _mm512_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_gf2p8affine_epi64_epi8
+  #define _mm512_gf2p8affine_epi64_epi8(x, A, b) simde_mm512_gf2p8affine_epi64_epi8(x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) _mm_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm_mask_mov_epi8(src, k, simde_mm_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_gf2p8affine_epi64_epi8
+  #define _mm_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) _mm256_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm256_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm256_mask_mov_epi8(src, k, simde_mm256_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_gf2p8affine_epi64_epi8
+  #define _mm256_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm256_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) _mm512_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm512_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm512_mask_mov_epi8(src, k, simde_mm512_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_gf2p8affine_epi64_epi8
+  #define _mm512_mask_gf2p8affine_epi64_epi8(src, k, x, A, b) simde_mm512_mask_gf2p8affine_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_maskz_gf2p8affine_epi64_epi8(k, x, A, b) _mm_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm_maskz_mov_epi8(k, simde_mm_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_gf2p8affine_epi64_epi8
+  #define _mm_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_maskz_gf2p8affine_epi64_epi8(k, x, A, b) _mm256_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm256_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm256_maskz_mov_epi8(k, simde_mm256_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_gf2p8affine_epi64_epi8
+  #define _mm256_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm256_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_gf2p8affine_epi64_epi8(k, x, A, b) _mm512_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm512_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm512_maskz_mov_epi8(k, simde_mm512_gf2p8affine_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_gf2p8affine_epi64_epi8
+  #define _mm512_maskz_gf2p8affine_epi64_epi8(k, x, A, b) simde_mm512_maskz_gf2p8affine_epi64_epi8(k, x, A, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_gf2p8affineinv_epi64_epi8 (simde__m128i x, simde__m128i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm_xor_si128(simde_x_mm_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_gf2p8affineinv_epi64_epi8(x, A, b) _mm_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_gf2p8affineinv_epi64_epi8
+  #define _mm_gf2p8affineinv_epi64_epi8(x, A, b) simde_mm_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_gf2p8affineinv_epi64_epi8 (simde__m256i x, simde__m256i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm256_xor_si256(simde_x_mm256_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm256_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_gf2p8affineinv_epi64_epi8(x, A, b) _mm256_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_gf2p8affineinv_epi64_epi8
+  #define _mm256_gf2p8affineinv_epi64_epi8(x, A, b) simde_mm256_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_gf2p8affineinv_epi64_epi8 (simde__m512i x, simde__m512i A, int b)
+    SIMDE_REQUIRE_CONSTANT_RANGE(b, 0, 255) {
+  return simde_mm512_xor_si512(simde_x_mm512_gf2p8matrix_multiply_inverse_epi64_epi8(x, A), simde_mm512_set1_epi8(HEDLEY_STATIC_CAST(int8_t, b)));
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_gf2p8affineinv_epi64_epi8(x, A, b) _mm512_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_gf2p8affineinv_epi64_epi8
+  #define _mm512_gf2p8affineinv_epi64_epi8(x, A, b) simde_mm512_gf2p8affineinv_epi64_epi8(x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) _mm_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm_mask_mov_epi8(src, k, simde_mm_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_gf2p8affineinv_epi64_epi8
+  #define _mm_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) _mm256_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm256_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm256_mask_mov_epi8(src, k, simde_mm256_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_gf2p8affineinv_epi64_epi8
+  #define _mm256_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm256_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) _mm512_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#else
+  #define simde_mm512_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm512_mask_mov_epi8(src, k, simde_mm512_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_gf2p8affineinv_epi64_epi8
+  #define _mm512_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b) simde_mm512_mask_gf2p8affineinv_epi64_epi8(src, k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) _mm_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm_maskz_mov_epi8(k, simde_mm_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_gf2p8affineinv_epi64_epi8
+  #define _mm_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) _mm256_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm256_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm256_maskz_mov_epi8(k, simde_mm256_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_gf2p8affineinv_epi64_epi8
+  #define _mm256_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm256_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#endif
+
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) _mm512_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#else
+  #define simde_mm512_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm512_maskz_mov_epi8(k, simde_mm512_gf2p8affineinv_epi64_epi8(x, A, b))
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_gf2p8affineinv_epi64_epi8
+  #define _mm512_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b) simde_mm512_maskz_gf2p8affineinv_epi64_epi8(k, x, A, b)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i simde_mm_gf2p8mul_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    simde__m128i r, t;
+    const simde__m128i zero = simde_mm_setzero_si128();
+    const simde__m128i ones = simde_mm_set1_epi8(0x01);
+
+    /* The field generator polynomial is 0x11B but we drop the 0x100 bit */
+    const simde__m128i fgp = simde_mm_set1_epi8(0x1B);
+
+    r = zero;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      t = simde_mm_and_si128(b, ones);
+      t = simde_mm_cmpeq_epi8(t, ones);
+      t = simde_mm_and_si128(a, t);
+      r = simde_mm_xor_si128(r, t);
+      t = simde_mm_cmpgt_epi8(zero, a);
+      t = simde_mm_and_si128(fgp, t);
+      a = simde_mm_add_epi8(a, a);
+      a = simde_mm_xor_si128(a, t);
+      b = simde_mm_srli_epi64(b, 1);
+    }
+
+    return r;
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    /* The field generator polynomial is 0x11B but we drop the 0x100 bit */
+    const uint8_t fgp = 0x1B;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+      r_.u8[i] = 0;
+      while ((a_.u8[i] != 0) && (b_.u8[i] != 0)) {
+        if (b_.u8[i] & 1)
+          r_.u8[i] ^= a_.u8[i];
+
+        if (a_.u8[i] & 0x80)
+          a_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, (a_.u8[i] << 1) ^ fgp);
+        else
+          a_.u8[i] <<= 1;
+
+        b_.u8[i] >>= 1;
+      }
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm_gf2p8mul_epi8(a, b) _mm_gf2p8mul_epi8(a, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_gf2p8mul_epi8
+  #define _mm_gf2p8mul_epi8(a, b) simde_mm_gf2p8mul_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_gf2p8mul_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_AVX2_NATIVE)
+    simde__m256i r, t;
+    const simde__m256i zero = simde_mm256_setzero_si256();
+    const simde__m256i ones = simde_mm256_set1_epi8(0x01);
+
+    /* The field generator polynomial is 0x11B but we drop the 0x100 bit */
+    const simde__m256i fgp = simde_mm256_set1_epi8(0x1B);
+
+    r = zero;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      t = simde_mm256_and_si256(b, ones);
+      t = simde_mm256_cmpeq_epi8(t, ones);
+      t = simde_mm256_and_si256(a, t);
+      r = simde_mm256_xor_si256(r, t);
+      t = simde_mm256_cmpgt_epi8(zero, a);
+      t = simde_mm256_and_si256(fgp, t);
+      a = simde_mm256_add_epi8(a, a);
+      a = simde_mm256_xor_si256(a, t);
+      b = simde_mm256_srli_epi64(b, 1);
+    }
+
+    return r;
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_mm_gf2p8mul_epi8(a_.m128i[i], b_.m128i[i]);
+    }
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+  #define simde_mm256_gf2p8mul_epi8(a, b) _mm256_gf2p8mul_epi8(a, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_gf2p8mul_epi8
+  #define _mm256_gf2p8mul_epi8(a, b) simde_mm256_gf2p8mul_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_gf2p8mul_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_AVX512BW_NATIVE)
+    simde__m512i r, t;
+    simde__mmask64 m;
+    const simde__m512i zero = simde_mm512_setzero_si512();
+    const simde__m512i ones = simde_mm512_set1_epi8(0x01);
+
+    /* The field generator polynomial is 0x11B but we drop the 0x100 bit */
+    const simde__m512i fgp = simde_mm512_set1_epi8(0x1B);
+
+    r = zero;
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (int i = 0 ; i < 8 ; i++) {
+      t = simde_mm512_and_si512(b, ones);
+      m = simde_mm512_cmpeq_epi8_mask(t, ones);
+      t = simde_mm512_maskz_mov_epi8(m, a);
+      r = simde_mm512_xor_si512(r, t);
+      m = simde_mm512_cmpgt_epi8_mask(zero, a);
+      a = simde_mm512_add_epi8(a, a);
+      t = simde_mm512_maskz_mov_epi8(m, fgp);
+      a = simde_mm512_xor_si512(a, t);
+      b = simde_mm512_srli_epi64(b, 1);
+    }
+
+    return r;
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if !defined(__INTEL_COMPILER)
+      SIMDE_VECTORIZE
+    #endif
+    for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+      r_.m128i[i] = simde_mm_gf2p8mul_epi8(a_.m128i[i], b_.m128i[i]);
+    }
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+  #define simde_mm512_gf2p8mul_epi8(a, b) _mm512_gf2p8mul_epi8(a, b)
+#endif
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_gf2p8mul_epi8
+  #define _mm512_gf2p8mul_epi8(a, b) simde_mm512_gf2p8mul_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mask_gf2p8mul_epi8 (simde__m128i src, simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_mask_gf2p8mul_epi8(src, k, a, b);
+  #else
+    return simde_mm_mask_mov_epi8(src, k, simde_mm_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mask_gf2p8mul_epi8
+  #define _mm_mask_gf2p8mul_epi8(src, k, a, b) simde_mm_mask_gf2p8mul_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_mask_gf2p8mul_epi8 (simde__m256i src, simde__mmask32 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_mask_gf2p8mul_epi8(src, k, a, b);
+  #else
+    return simde_mm256_mask_mov_epi8(src, k, simde_mm256_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_mask_gf2p8mul_epi8
+  #define _mm256_mask_gf2p8mul_epi8(src, k, a, b) simde_mm256_mask_gf2p8mul_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_gf2p8mul_epi8 (simde__m512i src, simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_gf2p8mul_epi8(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi8(src, k, simde_mm512_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_gf2p8mul_epi8
+  #define _mm512_mask_gf2p8mul_epi8(src, k, a, b) simde_mm512_mask_gf2p8mul_epi8(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maskz_gf2p8mul_epi8 (simde__mmask16 k, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm_maskz_gf2p8mul_epi8(k, a, b);
+  #else
+    return simde_mm_maskz_mov_epi8(k, simde_mm_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm_maskz_gf2p8mul_epi8
+  #define _mm_maskz_gf2p8mul_epi8(k, a, b) simde_mm_maskz_gf2p8mul_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_maskz_gf2p8mul_epi8 (simde__mmask32 k, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512VL_NATIVE)
+    return _mm256_maskz_gf2p8mul_epi8(k, a, b);
+  #else
+    return  simde_mm256_maskz_mov_epi8(k, simde_mm256_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_maskz_gf2p8mul_epi8
+  #define _mm256_maskz_gf2p8mul_epi8(k, a, b) simde_mm256_maskz_gf2p8mul_epi8(k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_maskz_gf2p8mul_epi8 (simde__mmask64 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_GFNI_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_maskz_gf2p8mul_epi8(k, a, b);
+  #else
+    return simde_mm512_maskz_mov_epi8(k, simde_mm512_gf2p8mul_epi8(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_GFNI_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_maskz_gf2p8mul_epi8
+  #define _mm512_maskz_gf2p8mul_epi8(k, a, b) simde_mm512_maskz_gf2p8mul_epi8(k, a, b)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_GFNI_H) */

--- a/2.0/simde/x86/mmx.h
+++ b/2.0/simde/x86/mmx.h
@@ -1,0 +1,2280 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_MMX_H)
+#define SIMDE_X86_MMX_H
+
+#include "../simde-common.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+
+#if defined(SIMDE_X86_MMX_NATIVE)
+  #define SIMDE_X86_MMX_USE_NATIVE_TYPE
+#elif defined(SIMDE_X86_SSE_NATIVE)
+  #define SIMDE_X86_MMX_USE_NATIVE_TYPE
+#endif
+
+#if defined(SIMDE_X86_MMX_USE_NATIVE_TYPE)
+  #include <mmintrin.h>
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #include <arm_neon.h>
+#endif
+
+#include <stdint.h>
+#include <limits.h>
+
+SIMDE_BEGIN_DECLS_
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(8) int8_t          i8 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) int16_t        i16 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) int32_t        i32 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) int64_t        i64 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) uint8_t         u8 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) uint16_t       u16 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) uint32_t       u32 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) uint64_t       u64 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) simde_float32  f32 SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) int_fast32_t  i32f SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(8) uint_fast32_t u32f SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(8) int8_t          i8[8];
+    SIMDE_ALIGN(8) int16_t        i16[4];
+    SIMDE_ALIGN(8) int32_t        i32[2];
+    SIMDE_ALIGN(8) int64_t        i64[1];
+    SIMDE_ALIGN(8) uint8_t         u8[8];
+    SIMDE_ALIGN(8) uint16_t       u16[4];
+    SIMDE_ALIGN(8) uint32_t       u32[2];
+    SIMDE_ALIGN(8) uint64_t       u64[1];
+    SIMDE_ALIGN(8) simde_float32  f32[2];
+    SIMDE_ALIGN(8) int_fast32_t  i32f[8 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(8) uint_fast32_t u32f[8 / sizeof(uint_fast32_t)];
+  #endif
+
+  #if defined(SIMDE_X86_MMX_USE_NATIVE_TYPE)
+    __m64          n;
+  #endif
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    int8x8_t       neon_i8;
+    int16x4_t      neon_i16;
+    int32x2_t      neon_i32;
+    int64x1_t      neon_i64;
+    uint8x8_t      neon_u8;
+    uint16x4_t     neon_u16;
+    uint32x2_t     neon_u32;
+    uint64x1_t     neon_u64;
+    float32x2_t    neon_f32;
+  #endif
+} simde__m64_private;
+
+#if defined(SIMDE_X86_MMX_USE_NATIVE_TYPE)
+  typedef __m64 simde__m64;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  typedef int32x2_t simde__m64;
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+  typedef int32_t simde__m64 SIMDE_ALIGN(8) SIMDE_VECTOR(8) SIMDE_MAY_ALIAS;
+#else
+  typedef simde__m64_private simde__m64;
+#endif
+
+#if !defined(SIMDE_X86_MMX_USE_NATIVE_TYPE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+  #define SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES
+  typedef simde__m64 __m64;
+#endif
+
+HEDLEY_STATIC_ASSERT(8 == sizeof(simde__m64), "__m64 size incorrect");
+HEDLEY_STATIC_ASSERT(8 == sizeof(simde__m64_private), "__m64 size incorrect");
+#if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m64) == 8, "simde__m64 is not 8-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m64_private) == 8, "simde__m64_private is not 8-byte aligned");
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde__m64_from_private(simde__m64_private v) {
+  simde__m64 r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64_private
+simde__m64_to_private(simde__m64 v) {
+  simde__m64_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+#define SIMDE_X86_GENERATE_CONVERSION_FUNCTION(simde_type, source_type, isax, fragment) \
+  SIMDE_FUNCTION_ATTRIBUTES \
+  simde__##simde_type \
+  simde__##simde_type##_from_##isax##_##fragment(source_type value) { \
+    simde__##simde_type##_private r_; \
+    r_.isax##_##fragment = value; \
+    return simde__##simde_type##_from_private(r_); \
+  } \
+  \
+  SIMDE_FUNCTION_ATTRIBUTES \
+  source_type \
+  simde__##simde_type##_to_##isax##_##fragment(simde__##simde_type value) { \
+    simde__##simde_type##_private r_ = simde__##simde_type##_to_private(value); \
+    return r_.isax##_##fragment; \
+  }
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, int8x8_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, int16x4_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, int32x2_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, int64x1_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, uint8x8_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, uint16x4_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, uint32x2_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, uint64x1_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m64, float32x2_t, neon, f32)
+#endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_add_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vadd_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 + b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] + b_.i8[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddb(a, b) simde_mm_add_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_add_pi8(a, b) simde_mm_add_pi8(a, b)
+#  define _m_paddb(a, b) simde_m_paddb(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_add_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i16 = vadd_s16(a_.neon_i16, b_.neon_i16);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i16 = a_.i16 + b_.i16;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[i] + b_.i16[i];
+    }
+  #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddw(a, b) simde_mm_add_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_add_pi16(a, b) simde_mm_add_pi16(a, b)
+#  define _m_paddw(a, b) simde_mm_add_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_add_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vadd_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 + b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] + b_.i32[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddd(a, b) simde_mm_add_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_add_pi32(a, b) simde_mm_add_pi32(a, b)
+#  define _m_paddd(a, b) simde_mm_add_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_adds_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pi8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqadd_s8(a_.neon_i8, b_.neon_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        if ((((b_.i8[i]) > 0) && ((a_.i8[i]) > (INT8_MAX - (b_.i8[i]))))) {
+          r_.i8[i] = INT8_MAX;
+        } else if ((((b_.i8[i]) < 0) && ((a_.i8[i]) < (INT8_MIN - (b_.i8[i]))))) {
+          r_.i8[i] = INT8_MIN;
+        } else {
+          r_.i8[i] = (a_.i8[i]) + (b_.i8[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddsb(a, b) simde_mm_adds_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_adds_pi8(a, b) simde_mm_adds_pi8(a, b)
+#  define _m_paddsb(a, b) simde_mm_adds_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_adds_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pu8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqadd_u8(a_.neon_u8, b_.neon_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        const uint_fast16_t x = HEDLEY_STATIC_CAST(uint_fast16_t, a_.u8[i]) + HEDLEY_STATIC_CAST(uint_fast16_t, b_.u8[i]);
+        if (x > UINT8_MAX)
+          r_.u8[i] = UINT8_MAX;
+        else
+          r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, x);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddusb(a, b) simde_mm_adds_pu8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_adds_pu8(a, b) simde_mm_adds_pu8(a, b)
+#  define _m_paddusb(a, b) simde_mm_adds_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_adds_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqadd_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if ((((b_.i16[i]) > 0) && ((a_.i16[i]) > (INT16_MAX - (b_.i16[i]))))) {
+          r_.i16[i] = INT16_MAX;
+        } else if ((((b_.i16[i]) < 0) && ((a_.i16[i]) < (SHRT_MIN - (b_.i16[i]))))) {
+          r_.i16[i] = SHRT_MIN;
+        } else {
+          r_.i16[i] = (a_.i16[i]) + (b_.i16[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddsw(a, b) simde_mm_adds_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_adds_pi16(a, b) simde_mm_adds_pi16(a, b)
+#  define _m_paddsw(a, b) simde_mm_adds_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_adds_pu16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_adds_pu16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqadd_u16(a_.neon_u16, b_.neon_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const uint32_t x = a_.u16[i] + b_.u16[i];
+        if (x > UINT16_MAX)
+          r_.u16[i] = UINT16_MAX;
+        else
+          r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, x);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_paddusw(a, b) simde_mm_adds_pu16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_adds_pu16(a, b) simde_mm_adds_pu16(a, b)
+#  define _m_paddusw(a, b) simde_mm_adds_pu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_and_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_and_si64(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vand_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 & b_.i64;
+    #else
+      r_.i64[0] = a_.i64[0] & b_.i64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pand(a, b) simde_mm_and_si64(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_and_si64(a, b) simde_mm_and_si64(a, b)
+#  define _m_pand(a, b) simde_mm_and_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_andnot_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_andnot_si64(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbic_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      r_.u64[0] = (~(a_.u64[0])) & (b_.u64[0]);
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pandn(a, b) simde_mm_andnot_si64(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_andnot_si64(a, b) simde_mm_andnot_si64(a, b)
+#  define _m_pandn(a, b) simde_mm_andnot_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpeq_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vceq_s8(a_.neon_i8, b_.neon_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpeqb(a, b) simde_mm_cmpeq_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpeq_pi8(a, b) simde_mm_cmpeq_pi8(a, b)
+#  define _m_pcmpeqb(a, b) simde_mm_cmpeq_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpeq_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vceq_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpeqw(a, b) simde_mm_cmpeq_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpeq_pi16(a, b) simde_mm_cmpeq_pi16(a, b)
+#  define _m_pcmpeqw(a, b) simde_mm_cmpeq_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpeq_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpeq_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vceq_s32(a_.neon_i32, b_.neon_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpeqd(a, b) simde_mm_cmpeq_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpeq_pi32(a, b) simde_mm_cmpeq_pi32(a, b)
+#  define _m_pcmpeqd(a, b) simde_mm_cmpeq_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpgt_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcgt_s8(a_.neon_i8, b_.neon_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpgtb(a, b) simde_mm_cmpgt_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpgt_pi8(a, b) simde_mm_cmpgt_pi8(a, b)
+#  define _m_pcmpgtb(a, b) simde_mm_cmpgt_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpgt_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vcgt_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpgtw(a, b) simde_mm_cmpgt_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpgt_pi16(a, b) simde_mm_cmpgt_pi16(a, b)
+#  define _m_pcmpgtw(a, b) simde_mm_cmpgt_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cmpgt_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cmpgt_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcgt_s32(a_.neon_i32, b_.neon_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pcmpgtd(a, b) simde_mm_cmpgt_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpgt_pi32(a, b) simde_mm_cmpgt_pi32(a, b)
+#  define _m_pcmpgtd(a, b) simde_mm_cmpgt_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtm64_si64 (simde__m64 a) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(__PGI)
+    return _mm_cvtm64_si64(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wvector-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+        #pragma clang diagnostic ignored "-Wvector-conversion"
+      #endif
+      return vget_lane_s64(a_.neon_i64, 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      return a_.i64[0];
+    #endif
+  #endif
+}
+#define simde_m_to_int64(a) simde_mm_cvtm64_si64(a)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtm64_si64(a) simde_mm_cvtm64_si64(a)
+#  define _m_to_int64(a) simde_mm_cvtm64_si64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtsi32_si64 (int32_t a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtsi32_si64(a);
+  #else
+    simde__m64_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int32_t av[sizeof(r_.neon_i32) / sizeof(r_.neon_i32[0])] = { a, 0 };
+      r_.neon_i32 = vld1_s32(av);
+    #else
+      r_.i32[0] = a;
+      r_.i32[1] = 0;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_from_int(a) simde_mm_cvtsi32_si64(a)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtsi32_si64(a) simde_mm_cvtsi32_si64(a)
+#  define _m_from_int(a) simde_mm_cvtsi32_si64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtsi64_m64 (int64_t a) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(__PGI)
+    return _mm_cvtsi64_m64(a);
+  #else
+    simde__m64_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vld1_s64(&a);
+    #else
+      r_.i64[0] = a;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_from_int64(a) simde_mm_cvtsi64_m64(a)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtsi64_m64(a) simde_mm_cvtsi64_m64(a)
+#  define _m_from_int64(a) simde_mm_cvtsi64_m64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtsi64_si32 (simde__m64 a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtsi64_si32(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wvector-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+        #pragma clang diagnostic ignored "-Wvector-conversion"
+      #endif
+      return vget_lane_s32(a_.neon_i32, 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      return a_.i32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtsi64_si32(a) simde_mm_cvtsi64_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_empty (void) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    _mm_empty();
+  #else
+    /* noop */
+  #endif
+}
+#define simde_m_empty() simde_mm_empty()
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_empty() simde_mm_empty()
+#  define _m_empty() simde_mm_empty()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_madd_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_madd_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x4_t i1 = vmull_s16(a_.neon_i16, b_.neon_i16);
+      r_.neon_i32 = vpadd_s32(vget_low_s32(i1), vget_high_s32(i1));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i += 2) {
+        r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) + (a_.i16[i + 1] * b_.i16[i + 1]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmaddwd(a, b) simde_mm_madd_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_madd_pi16(a, b) simde_mm_madd_pi16(a, b)
+#  define _m_pmaddwd(a, b) simde_mm_madd_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_mulhi_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_mulhi_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int32x4_t t1 = vmull_s16(a_.neon_i16, b_.neon_i16);
+      const uint32x4_t t2 = vshrq_n_u32(vreinterpretq_u32_s32(t1), 16);
+      const uint16x4_t t3 = vmovn_u32(t2);
+      r_.neon_u16 = t3;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((a_.i16[i] * b_.i16[i]) >> 16));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmulhw(a, b) simde_mm_mulhi_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_mulhi_pi16(a, b) simde_mm_mulhi_pi16(a, b)
+#  define _m_pmulhw(a, b) simde_mm_mulhi_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_mullo_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_mullo_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int32x4_t t1 = vmull_s16(a_.neon_i16, b_.neon_i16);
+      const uint16x4_t t2 = vmovn_u32(vreinterpretq_u32_s32(t1));
+      r_.neon_u16 = t2;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((a_.i16[i] * b_.i16[i]) & 0xffff));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmullw(a, b) simde_mm_mullo_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_mullo_pi16(a, b) simde_mm_mullo_pi16(a, b)
+#  define _m_pmullw(a, b) simde_mm_mullo_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_or_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_or_si64(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vorr_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 | b_.i64;
+    #else
+      r_.i64[0] = a_.i64[0] | b_.i64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_por(a, b) simde_mm_or_si64(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_or_si64(a, b) simde_mm_or_si64(a, b)
+#  define _m_por(a, b) simde_mm_or_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_packs_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_packs_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqmovn_s16(vcombine_s16(a_.neon_i16, b_.neon_i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if (a_.i16[i] < INT8_MIN) {
+          r_.i8[i] = INT8_MIN;
+        } else if (a_.i16[i] > INT8_MAX) {
+          r_.i8[i] = INT8_MAX;
+        } else {
+          r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, a_.i16[i]);
+        }
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if (b_.i16[i] < INT8_MIN) {
+          r_.i8[i + 4] = INT8_MIN;
+        } else if (b_.i16[i] > INT8_MAX) {
+          r_.i8[i + 4] = INT8_MAX;
+        } else {
+          r_.i8[i + 4] = HEDLEY_STATIC_CAST(int8_t, b_.i16[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_packsswb(a, b) simde_mm_packs_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_packs_pi16(a, b) simde_mm_packs_pi16(a, b)
+#  define _m_packsswb(a, b) simde_mm_packs_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_packs_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_packs_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqmovn_s32(vcombine_s32(a_.neon_i32, b_.neon_i32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (8 / sizeof(a_.i32[0])) ; i++) {
+        if (a_.i32[i] < SHRT_MIN) {
+          r_.i16[i] = SHRT_MIN;
+        } else if (a_.i32[i] > INT16_MAX) {
+          r_.i16[i] = INT16_MAX;
+        } else {
+          r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i32[i]);
+        }
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (8 / sizeof(b_.i32[0])) ; i++) {
+        if (b_.i32[i] < SHRT_MIN) {
+          r_.i16[i + 2] = SHRT_MIN;
+        } else if (b_.i32[i] > INT16_MAX) {
+          r_.i16[i + 2] = INT16_MAX;
+        } else {
+          r_.i16[i + 2] = HEDLEY_STATIC_CAST(int16_t, b_.i32[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_packssdw(a, b) simde_mm_packs_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_packs_pi32(a, b) simde_mm_packs_pi32(a, b)
+#  define _m_packssdw(a, b) simde_mm_packs_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_packs_pu16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_packs_pu16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      const int16x8_t t1 = vcombine_s16(a_.neon_i16, b_.neon_i16);
+
+      /* Set elements which are < 0 to 0 */
+      const int16x8_t t2 = vandq_s16(t1, vreinterpretq_s16_u16(vcgezq_s16(t1)));
+
+      /* Vector with all s16 elements set to UINT8_MAX */
+      const int16x8_t vmax = vmovq_n_s16(HEDLEY_STATIC_CAST(int16_t, UINT8_MAX));
+
+      /* Elements which are within the acceptable range */
+      const int16x8_t le_max = vandq_s16(t2, vreinterpretq_s16_u16(vcleq_s16(t2, vmax)));
+      const int16x8_t gt_max = vandq_s16(vmax, vreinterpretq_s16_u16(vcgtq_s16(t2, vmax)));
+
+      /* Final values as 16-bit integers */
+      const int16x8_t values = vorrq_s16(le_max, gt_max);
+
+      r_.neon_u8 = vmovn_u16(vreinterpretq_u16_s16(values));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if (a_.i16[i] > UINT8_MAX) {
+          r_.u8[i] = UINT8_MAX;
+        } else if (a_.i16[i] < 0) {
+          r_.u8[i] = 0;
+        } else {
+          r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]);
+        }
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if (b_.i16[i] > UINT8_MAX) {
+          r_.u8[i + 4] = UINT8_MAX;
+        } else if (b_.i16[i] < 0) {
+          r_.u8[i + 4] = 0;
+        } else {
+          r_.u8[i + 4] = HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_packuswb(a, b) simde_mm_packs_pu16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_packs_pu16(a, b) simde_mm_packs_pu16(a, b)
+#  define _m_packuswb(a, b) simde_mm_packs_pu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set_pi8 (int8_t e7, int8_t e6, int8_t e5, int8_t e4, int8_t e3, int8_t e2, int8_t e1, int8_t e0) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set_pi8(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    simde__m64_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int8_t v[sizeof(r_.i8) / sizeof(r_.i8[0])] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+      r_.neon_i8 = vld1_s8(v);
+    #else
+      r_.i8[0] = e0;
+      r_.i8[1] = e1;
+      r_.i8[2] = e2;
+      r_.i8[3] = e3;
+      r_.i8[4] = e4;
+      r_.i8[5] = e5;
+      r_.i8[6] = e6;
+      r_.i8[7] = e7;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_pi8(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_set_pi8(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_set_pu8 (uint8_t e7, uint8_t e6, uint8_t e5, uint8_t e4, uint8_t e3, uint8_t e2, uint8_t e1, uint8_t e0) {
+  simde__m64_private r_;
+
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    r_.n = _mm_set_pi8(
+        HEDLEY_STATIC_CAST(int8_t, e7),
+        HEDLEY_STATIC_CAST(int8_t, e6),
+        HEDLEY_STATIC_CAST(int8_t, e5),
+        HEDLEY_STATIC_CAST(int8_t, e4),
+        HEDLEY_STATIC_CAST(int8_t, e3),
+        HEDLEY_STATIC_CAST(int8_t, e2),
+        HEDLEY_STATIC_CAST(int8_t, e1),
+        HEDLEY_STATIC_CAST(int8_t, e0));
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    const uint8_t v[sizeof(r_.u8) / sizeof(r_.u8[0])] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+    r_.neon_u8 = vld1_u8(v);
+  #else
+    r_.u8[0] = e0;
+    r_.u8[1] = e1;
+    r_.u8[2] = e2;
+    r_.u8[3] = e3;
+    r_.u8[4] = e4;
+    r_.u8[5] = e5;
+    r_.u8[6] = e6;
+    r_.u8[7] = e7;
+  #endif
+
+  return simde__m64_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set_pi16 (int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set_pi16(e3, e2, e1, e0);
+  #else
+    simde__m64_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int16_t v[sizeof(r_.i16) / sizeof(r_.i16[0])] = { e0, e1, e2, e3 };
+      r_.neon_i16 = vld1_s16(v);
+    #else
+      r_.i16[0] = e0;
+      r_.i16[1] = e1;
+      r_.i16[2] = e2;
+      r_.i16[3] = e3;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_pi16(e3, e2, e1, e0) simde_mm_set_pi16(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_set_pu16 (uint16_t e3, uint16_t e2, uint16_t e1, uint16_t e0) {
+  simde__m64_private r_;
+
+#if defined(SIMDE_X86_MMX_NATIVE)
+  r_.n = _mm_set_pi16(
+      HEDLEY_STATIC_CAST(int16_t, e3),
+      HEDLEY_STATIC_CAST(int16_t, e2),
+      HEDLEY_STATIC_CAST(int16_t, e1),
+      HEDLEY_STATIC_CAST(int16_t, e0)
+    );
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  const uint16_t v[sizeof(r_.u16) / sizeof(r_.u16[0])] = { e0, e1, e2, e3 };
+  r_.neon_u16 = vld1_u16(v);
+#else
+  r_.u16[0] = e0;
+  r_.u16[1] = e1;
+  r_.u16[2] = e2;
+  r_.u16[3] = e3;
+#endif
+
+  return simde__m64_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_set_pu32 (uint32_t e1, uint32_t e0) {
+  simde__m64_private r_;
+
+#if defined(SIMDE_X86_MMX_NATIVE)
+  r_.n = _mm_set_pi32(
+      HEDLEY_STATIC_CAST(int32_t, e1),
+      HEDLEY_STATIC_CAST(int32_t, e0));
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  const uint32_t v[sizeof(r_.u32) / sizeof(r_.u32[0])] = { e0, e1 };
+  r_.neon_u32 = vld1_u32(v);
+#else
+  r_.u32[0] = e0;
+  r_.u32[1] = e1;
+#endif
+
+  return simde__m64_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set_pi32 (int32_t e1, int32_t e0) {
+  simde__m64_private r_;
+
+#if defined(SIMDE_X86_MMX_NATIVE)
+  r_.n = _mm_set_pi32(e1, e0);
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  const int32_t v[sizeof(r_.i32) / sizeof(r_.i32[0])] = { e0, e1 };
+  r_.neon_i32 = vld1_s32(v);
+#else
+  r_.i32[0] = e0;
+  r_.i32[1] = e1;
+#endif
+
+  return simde__m64_from_private(r_);
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_pi32(e1, e0) simde_mm_set_pi32(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_set_pi64 (int64_t e0) {
+  simde__m64_private r_;
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  const int64_t v[sizeof(r_.i64) / sizeof(r_.i64[0])] = { e0 };
+  r_.neon_i64 = vld1_s64(v);
+#else
+  r_.i64[0] = e0;
+#endif
+
+  return simde__m64_from_private(r_);
+}
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_set_f32x2 (simde_float32 e1, simde_float32 e0) {
+  simde__m64_private r_;
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  const simde_float32 v[sizeof(r_.f32) / sizeof(r_.f32[0])] = { e0, e1 };
+  r_.neon_f32 = vld1_f32(v);
+#else
+  r_.f32[0] = e0;
+  r_.f32[1] = e1;
+#endif
+
+  return simde__m64_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set1_pi8 (int8_t a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi8(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde__m64_private r_;
+    r_.neon_i8 = vmov_n_s8(a);
+    return simde__m64_from_private(r_);
+  #else
+    return simde_mm_set_pi8(a, a, a, a, a, a, a, a);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set1_pi8(a) simde_mm_set1_pi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set1_pi16 (int16_t a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi16(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde__m64_private r_;
+    r_.neon_i16 = vmov_n_s16(a);
+    return simde__m64_from_private(r_);
+  #else
+    return simde_mm_set_pi16(a, a, a, a);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set1_pi16(a) simde_mm_set1_pi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_set1_pi32 (int32_t a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_pi32(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde__m64_private r_;
+    r_.neon_i32 = vmov_n_s32(a);
+    return simde__m64_from_private(r_);
+  #else
+    return simde_mm_set_pi32(a, a);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_set1_pi32(a) simde_mm_set1_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_setr_pi8 (int8_t e7, int8_t e6, int8_t e5, int8_t e4, int8_t e3, int8_t e2, int8_t e1, int8_t e0) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setr_pi8(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    return simde_mm_set_pi8(e0, e1, e2, e3, e4, e5, e6, e7);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_setr_pi8(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_pi8(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_setr_pi16 (int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setr_pi16(e3, e2, e1, e0);
+  #else
+    return simde_mm_set_pi16(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_setr_pi16(e3, e2, e1, e0) simde_mm_setr_pi16(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_setr_pi32 (int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setr_pi32(e1, e0);
+  #else
+    return simde_mm_set_pi32(e0, e1);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_setr_pi32(e1, e0) simde_mm_setr_pi32(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_setzero_si64 (void) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setzero_si64();
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    simde__m64_private r_;
+    r_.neon_u32 = vmov_n_u32(0);
+    return simde__m64_from_private(r_);
+  #else
+    return simde_mm_set_pi32(0, 0);
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_setzero_si64() simde_mm_setzero_si64()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_load_si64 (const void* mem_addr) {
+  simde__m64 r;
+  simde_memcpy(&r, SIMDE_ASSUME_ALIGNED_AS(simde__m64, mem_addr), sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_loadu_si64 (const void* mem_addr) {
+  simde__m64 r;
+  simde_memcpy(&r, mem_addr, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_x_mm_store_si64 (void* mem_addr, simde__m64 value) {
+  simde_memcpy(SIMDE_ASSUME_ALIGNED_AS(simde__m64, mem_addr), &value, sizeof(value));
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_x_mm_storeu_si64 (void* mem_addr, simde__m64 value) {
+  simde_memcpy(mem_addr, &value, sizeof(value));
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_x_mm_setone_si64 (void) {
+  return simde_mm_set1_pi32(~INT32_C(0));
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sll_pi16 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sll_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wvector-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+        #pragma clang diagnostic ignored "-Wvector-conversion"
+      #endif
+      r_.neon_i16 = vshl_s16(a_.neon_i16, vmov_n_s16(HEDLEY_STATIC_CAST(int16_t, vget_lane_u64(count_.neon_u64, 0))));
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i16 = a_.i16 << count_.u64[0];
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 15)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, a_.u16[i] << count_.u64[0]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psllw(a, count) simde_mm_sll_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sll_pi16(a, count) simde_mm_sll_pi16(a, count)
+#  define _m_psllw(a, count) simde_mm_sll_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sll_pi32 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sll_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wvector-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+        #pragma clang diagnostic ignored "-Wvector-conversion"
+      #endif
+      r_.neon_i32 = vshl_s32(a_.neon_i32, vmov_n_s32(HEDLEY_STATIC_CAST(int32_t, vget_lane_u64(count_.neon_u64, 0))));
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i32 = a_.i32 << count_.u64[0];
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 31)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] << count_.u64[0];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pslld(a, count) simde_mm_sll_pi32(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sll_pi32(a, count) simde_mm_sll_pi32(a, count)
+#  define _m_pslld(a, count) simde_mm_sll_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_slli_pi16 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_slli_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i16 = a_.i16 << count;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vshl_s16(a_.neon_i16, vmov_n_s16((int16_t) count));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, a_.u16[i] << count);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psllwi(a, count) simde_mm_slli_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_slli_pi16(a, count) simde_mm_slli_pi16(a, count)
+#  define _m_psllwi(a, count) simde_mm_slli_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_slli_pi32 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_slli_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i32 = a_.i32 << count;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vshl_s32(a_.neon_i32, vmov_n_s32((int32_t) count));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] << count;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pslldi(a, b) simde_mm_slli_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_slli_pi32(a, count) simde_mm_slli_pi32(a, count)
+#  define _m_pslldi(a, count) simde_mm_slli_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_slli_si64 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_slli_si64(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i64 = a_.i64 << count;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vshl_s64(a_.neon_i64, vmov_n_s64((int64_t) count));
+    #else
+      r_.u64[0] = a_.u64[0] << count;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psllqi(a, count) simde_mm_slli_si64(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_slli_si64(a, count) simde_mm_slli_si64(a, count)
+#  define _m_psllqi(a, count) simde_mm_slli_si64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sll_si64 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sll_si64(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vshl_s64(a_.neon_i64, count_.neon_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 << count_.i64;
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 63)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      r_.u64[0] = a_.u64[0] << count_.u64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psllq(a, count) simde_mm_sll_si64(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sll_si64(a, count) simde_mm_sll_si64(a, count)
+#  define _m_psllq(a, count) simde_mm_sll_si64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srl_pi16 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_srl_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u16 = a_.u16 >> count_.u64[0];
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshl_u16(a_.neon_u16, vmov_n_s16(-((int16_t) vget_lane_u64(count_.neon_u64, 0))));
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 15)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < sizeof(r_.u16) / sizeof(r_.u16[0]) ; i++) {
+        r_.u16[i] = a_.u16[i] >> count_.u64[0];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrlw(a, count) simde_mm_srl_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srl_pi16(a, count) simde_mm_srl_pi16(a, count)
+#  define _m_psrlw(a, count) simde_mm_srl_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srl_pi32 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_srl_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u32 = a_.u32 >> count_.u64[0];
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshl_u32(a_.neon_u32, vmov_n_s32(-((int32_t) vget_lane_u64(count_.neon_u64, 0))));
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 31)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < sizeof(r_.u32) / sizeof(r_.u32[0]) ; i++) {
+        r_.u32[i] = a_.u32[i] >> count_.u64[0];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrld(a, count) simde_mm_srl_pi32(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srl_pi32(a, count) simde_mm_srl_pi32(a, count)
+#  define _m_psrld(a, count) simde_mm_srl_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srli_pi16 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_srli_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u16 = a_.u16 >> count;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshl_u16(a_.neon_u16, vmov_n_s16(-((int16_t) count)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] >> count;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrlwi(a, count) simde_mm_srli_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srli_pi16(a, count) simde_mm_srli_pi16(a, count)
+#  define _m_psrlwi(a, count) simde_mm_srli_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srli_pi32 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_srli_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u32 = a_.u32 >> count;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshl_u32(a_.neon_u32, vmov_n_s32(-((int32_t) count)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] >> count;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrldi(a, count) simde_mm_srli_pi32(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srli_pi32(a, count) simde_mm_srli_pi32(a, count)
+#  define _m_psrldi(a, count) simde_mm_srli_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srli_si64 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_srli_si64(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vshl_u64(a_.neon_u64, vmov_n_s64(-count));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u64 = a_.u64 >> count;
+    #else
+      r_.u64[0] = a_.u64[0] >> count;
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrlqi(a, count) simde_mm_srli_si64(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srli_si64(a, count) simde_mm_srli_si64(a, count)
+#  define _m_psrlqi(a, count) simde_mm_srli_si64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srl_si64 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_srl_si64(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vshl_u64(a_.neon_u64, vneg_s64(count_.neon_i64));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 >> count_.u64;
+    #else
+      if (HEDLEY_UNLIKELY(count_.u64[0] > 63)) {
+        simde_memset(&r_, 0, sizeof(r_));
+        return simde__m64_from_private(r_);
+      }
+
+      r_.u64[0] = a_.u64[0] >> count_.u64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrlq(a, count) simde_mm_srl_si64(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srl_si64(a, count) simde_mm_srl_si64(a, count)
+#  define _m_psrlq(a, count) simde_mm_srl_si64(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srai_pi16 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_srai_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i16 = a_.i16 >> (count & 0xff);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vshl_s16(a_.neon_i16, vmov_n_s16(-HEDLEY_STATIC_CAST(int16_t, count));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] >> (count & 0xff);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrawi(a, count) simde_mm_srai_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srai_pi16(a, count) simde_mm_srai_pi16(a, count)
+#  define _m_psrawi(a, count) simde_mm_srai_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_srai_pi32 (simde__m64 a, int count) {
+  #if defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_srai_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i32 = a_.i32 >> (count & 0xff);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vshl_s32(a_.neon_i32, vmov_n_s32(-HEDLEY_STATIC_CAST(int32_t, count)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] >> (count & 0xff);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psradi(a, count) simde_mm_srai_pi32(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_srai_pi32(a, count) simde_mm_srai_pi32(a, count)
+#  define _m_psradi(a, count) simde_mm_srai_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sra_pi16 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sra_pi16(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i16 = a_.i16 >> cnt;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vshl_s16(a_.neon_i16, vmov_n_s16(-HEDLEY_STATIC_CAST(int16_t, vget_lane_u64(count_.neon_u64, 0))));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] >> cnt;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psraw(a, count) simde_mm_sra_pi16(a, count)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sra_pi16(a, count) simde_mm_sra_pi16(a, count)
+#  define _m_psraw(a, count) simde_mm_sra_pi16(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sra_pi32 (simde__m64 a, simde__m64 count) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sra_pi32(a, count);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private count_ = simde__m64_to_private(count);
+    const int32_t cnt = (count_.u64[0] > 31) ? 31 : HEDLEY_STATIC_CAST(int32_t, count_.u64[0]);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.i32 = a_.i32 >> cnt;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vshl_s32(a_.neon_i32, vmov_n_s32(-HEDLEY_STATIC_CAST(int32_t, vget_lane_u64(count_.neon_u64, 0))));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] >> cnt;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psrad(a, b) simde_mm_sra_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sra_pi32(a, count) simde_mm_sra_pi32(a, count)
+#  define _m_psrad(a, count) simde_mm_sra_pi32(a, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sub_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vsub_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 - b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] - b_.i8[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubb(a, b) simde_mm_sub_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sub_pi8(a, b) simde_mm_sub_pi8(a, b)
+#  define _m_psubb(a, b) simde_mm_sub_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sub_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vsub_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 - b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] - b_.i16[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubw(a, b) simde_mm_sub_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sub_pi16(a, b) simde_mm_sub_pi16(a, b)
+#  define _m_psubw(a, b) simde_mm_sub_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sub_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vsub_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 - b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] - b_.i32[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubd(a, b) simde_mm_sub_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_sub_pi32(a, b) simde_mm_sub_pi32(a, b)
+#  define _m_psubd(a, b) simde_mm_sub_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_subs_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_subs_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqsub_s8(a_.neon_i8, b_.neon_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        if (((b_.i8[i]) > 0 && (a_.i8[i]) < INT8_MIN + (b_.i8[i]))) {
+          r_.i8[i] = INT8_MIN;
+        } else if ((b_.i8[i]) < 0 && (a_.i8[i]) > INT8_MAX + (b_.i8[i])) {
+          r_.i8[i] = INT8_MAX;
+        } else {
+          r_.i8[i] = (a_.i8[i]) - (b_.i8[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubsb(a, b) simde_mm_subs_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_subs_pi8(a, b) simde_mm_subs_pi8(a, b)
+#  define _m_psubsb(a, b) simde_mm_subs_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_subs_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_subs_pu8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqsub_u8(a_.neon_u8, b_.neon_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        const int32_t x = a_.u8[i] - b_.u8[i];
+        if (x < 0) {
+          r_.u8[i] = 0;
+        } else if (x > UINT8_MAX) {
+          r_.u8[i] = UINT8_MAX;
+        } else {
+          r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, x);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubusb(a, b) simde_mm_subs_pu8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_subs_pu8(a, b) simde_mm_subs_pu8(a, b)
+#  define _m_psubusb(a, b) simde_mm_subs_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_subs_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_subs_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqsub_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        if (((b_.i16[i]) > 0 && (a_.i16[i]) < SHRT_MIN + (b_.i16[i]))) {
+          r_.i16[i] = SHRT_MIN;
+        } else if ((b_.i16[i]) < 0 && (a_.i16[i]) > INT16_MAX + (b_.i16[i])) {
+          r_.i16[i] = INT16_MAX;
+        } else {
+          r_.i16[i] = (a_.i16[i]) - (b_.i16[i]);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubsw(a, b) simde_mm_subs_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_subs_pi16(a, b) simde_mm_subs_pi16(a, b)
+#  define _m_psubsw(a, b) simde_mm_subs_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_subs_pu16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_subs_pu16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqsub_u16(a_.neon_u16, b_.neon_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        const int x = a_.u16[i] - b_.u16[i];
+        if (x < 0) {
+          r_.u16[i] = 0;
+        } else if (x > UINT16_MAX) {
+          r_.u16[i] = UINT16_MAX;
+        } else {
+          r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, x);
+        }
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psubusw(a, b) simde_mm_subs_pu16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_subs_pu16(a, b) simde_mm_subs_pu16(a, b)
+#  define _m_psubusw(a, b) simde_mm_subs_pu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpackhi_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpackhi_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip2_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.i8, b_.i8, 4, 12, 5, 13, 6, 14, 7, 15);
+    #else
+      r_.i8[0] = a_.i8[4];
+      r_.i8[1] = b_.i8[4];
+      r_.i8[2] = a_.i8[5];
+      r_.i8[3] = b_.i8[5];
+      r_.i8[4] = a_.i8[6];
+      r_.i8[5] = b_.i8[6];
+      r_.i8[6] = a_.i8[7];
+      r_.i8[7] = b_.i8[7];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpckhbw(a, b) simde_mm_unpackhi_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpackhi_pi8(a, b) simde_mm_unpackhi_pi8(a, b)
+#  define _m_punpckhbw(a, b) simde_mm_unpackhi_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpackhi_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpackhi_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip2_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 2, 6, 3, 7);
+    #else
+      r_.i16[0] = a_.i16[2];
+      r_.i16[1] = b_.i16[2];
+      r_.i16[2] = a_.i16[3];
+      r_.i16[3] = b_.i16[3];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpckhwd(a, b) simde_mm_unpackhi_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpackhi_pi16(a, b) simde_mm_unpackhi_pi16(a, b)
+#  define _m_punpckhwd(a, b) simde_mm_unpackhi_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpackhi_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpackhi_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip2_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 1, 3);
+    #else
+      r_.i32[0] = a_.i32[1];
+      r_.i32[1] = b_.i32[1];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpckhdq(a, b) simde_mm_unpackhi_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpackhi_pi32(a, b) simde_mm_unpackhi_pi32(a, b)
+#  define _m_punpckhdq(a, b) simde_mm_unpackhi_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpacklo_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpacklo_pi8(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip1_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 8, a_.i8, b_.i8, 0, 8, 1, 9, 2, 10, 3, 11);
+    #else
+      r_.i8[0] = a_.i8[0];
+      r_.i8[1] = b_.i8[0];
+      r_.i8[2] = a_.i8[1];
+      r_.i8[3] = b_.i8[1];
+      r_.i8[4] = a_.i8[2];
+      r_.i8[5] = b_.i8[2];
+      r_.i8[6] = a_.i8[3];
+      r_.i8[7] = b_.i8[3];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpcklbw(a, b) simde_mm_unpacklo_pi8(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpacklo_pi8(a, b) simde_mm_unpacklo_pi8(a, b)
+#  define _m_punpcklbw(a, b) simde_mm_unpacklo_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpacklo_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpacklo_pi16(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip1_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 0, 4, 1, 5);
+    #else
+      r_.i16[0] = a_.i16[0];
+      r_.i16[1] = b_.i16[0];
+      r_.i16[2] = a_.i16[1];
+      r_.i16[3] = b_.i16[1];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpcklwd(a, b) simde_mm_unpacklo_pi16(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpacklo_pi16(a, b) simde_mm_unpacklo_pi16(a, b)
+#  define _m_punpcklwd(a, b) simde_mm_unpacklo_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_unpacklo_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_unpacklo_pi32(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip1_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 0, 2);
+    #else
+      r_.i32[0] = a_.i32[0];
+      r_.i32[1] = b_.i32[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_punpckldq(a, b) simde_mm_unpacklo_pi32(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpacklo_pi32(a, b) simde_mm_unpacklo_pi32(a, b)
+#  define _m_punpckldq(a, b) simde_mm_unpacklo_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_xor_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_xor_si64(a, b);
+  #else
+    simde__m64_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = veor_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      r_.u64[0] = a_.u64[0] ^ b_.u64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pxor(a, b) simde_mm_xor_si64(a, b)
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _mm_xor_si64(a, b) simde_mm_xor_si64(a, b)
+#  define _m_pxor(a, b) simde_mm_xor_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_m_to_int (simde__m64 a) {
+  #if defined(SIMDE_X86_MMX_NATIVE)
+    return _m_to_int(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wvector-conversion") && SIMDE_DETECT_CLANG_VERSION_NOT(10,0,0)
+        #pragma clang diagnostic ignored "-Wvector-conversion"
+      #endif
+      return vget_lane_s32(a_.neon_i32, 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      return a_.i32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_MMX_ENABLE_NATIVE_ALIASES)
+#  define _m_to_int(a) simde_m_to_int(a)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_MMX_H) */

--- a/2.0/simde/x86/sse.h
+++ b/2.0/simde/x86/sse.h
@@ -1,0 +1,4305 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ *   2015-2017 John W. Ratcliff <jratcliffscarab@gmail.com>
+ *   2015      Brandon Rowlett <browlett@nvidia.com>
+ *   2015      Ken Fast <kfast@gdeb.com>
+ */
+
+#if !defined(SIMDE_X86_SSE_H)
+#define SIMDE_X86_SSE_H
+
+#include "mmx.h"
+
+#if defined(_WIN32)
+  #include <windows.h>
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(16) int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(16) simde_int128  i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN(16) simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(16) int8_t         i8[16];
+    SIMDE_ALIGN(16) int16_t        i16[8];
+    SIMDE_ALIGN(16) int32_t        i32[4];
+    SIMDE_ALIGN(16) int64_t        i64[2];
+    SIMDE_ALIGN(16) uint8_t        u8[16];
+    SIMDE_ALIGN(16) uint16_t       u16[8];
+    SIMDE_ALIGN(16) uint32_t       u32[4];
+    SIMDE_ALIGN(16) uint64_t       u64[2];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(16) simde_int128  i128[1];
+    SIMDE_ALIGN(16) simde_uint128 u128[1];
+    #endif
+    SIMDE_ALIGN(16) simde_float32  f32[4];
+    SIMDE_ALIGN(16) int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(16) uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+  #endif
+
+    SIMDE_ALIGN(16) simde__m64_private m64_private[2];
+    SIMDE_ALIGN(16) simde__m64         m64[2];
+
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    SIMDE_ALIGN(16) __m128         n;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_ALIGN(16) int8x16_t      neon_i8;
+    SIMDE_ALIGN(16) int16x8_t      neon_i16;
+    SIMDE_ALIGN(16) int32x4_t      neon_i32;
+    SIMDE_ALIGN(16) int64x2_t      neon_i64;
+    SIMDE_ALIGN(16) uint8x16_t     neon_u8;
+    SIMDE_ALIGN(16) uint16x8_t     neon_u16;
+    SIMDE_ALIGN(16) uint32x4_t     neon_u32;
+    SIMDE_ALIGN(16) uint64x2_t     neon_u64;
+    SIMDE_ALIGN(16) float32x4_t    neon_f32;
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      SIMDE_ALIGN(16) float64x2_t    neon_f64;
+    #endif
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_ALIGN(16) v128_t         wasm_v128;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)      altivec_u8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)     altivec_u16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)       altivec_u32;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)        altivec_i8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)       altivec_i16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)         altivec_i32;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)              altivec_f32;
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
+    #endif
+  #endif
+} simde__m128_private;
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  typedef __m128 simde__m128;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+   typedef float32x4_t simde__m128;
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+   typedef v128_t simde__m128;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+   typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128;
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+  typedef simde_float32 simde__m128 SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#else
+  typedef simde__m128_private simde__m128;
+#endif
+
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+  typedef simde__m128 __m128;
+#endif
+
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128), "simde__m128 size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128_private), "simde__m128_private size incorrect");
+#if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128) == 16, "simde__m128 is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128_private) == 16, "simde__m128_private is not 16-byte aligned");
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde__m128_from_private(simde__m128_private v) {
+  simde__m128 r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128_private
+simde__m128_to_private(simde__m128 v) {
+  simde__m128_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, int8x16_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, int16x8_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, int32x4_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, int64x2_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, uint8x16_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, uint16x8_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, uint32x4_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, uint64x2_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, float32x4_t, neon, f32)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, float64x2_t, neon, f64)
+  #endif
+#endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
+
+#if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+
+  #if defined(SIMDE_BUG_GCC_95782)
+    SIMDE_FUNCTION_ATTRIBUTES
+    SIMDE_POWER_ALTIVEC_VECTOR(float)
+    simde__m128_to_altivec_f32(simde__m128 value) {
+      simde__m128_private r_ = simde__m128_to_private(value);
+      return r_.altivec_f32;
+    }
+
+    SIMDE_FUNCTION_ATTRIBUTES
+    simde__m128
+    simde__m128_from_altivec_f32(SIMDE_POWER_ALTIVEC_VECTOR(float) value) {
+      simde__m128_private r_;
+      r_.altivec_f32 = value;
+      return simde__m128_from_private(r_);
+    }
+  #else
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(float), altivec, f32)
+  #endif
+
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+  #endif
+#endif /* defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) */
+
+enum {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    SIMDE_MM_ROUND_NEAREST     = _MM_ROUND_NEAREST,
+    SIMDE_MM_ROUND_DOWN        = _MM_ROUND_DOWN,
+    SIMDE_MM_ROUND_UP          = _MM_ROUND_UP,
+    SIMDE_MM_ROUND_TOWARD_ZERO = _MM_ROUND_TOWARD_ZERO
+  #else
+    SIMDE_MM_ROUND_NEAREST     = 0x0000,
+    SIMDE_MM_ROUND_DOWN        = 0x2000,
+    SIMDE_MM_ROUND_UP          = 0x4000,
+    SIMDE_MM_ROUND_TOWARD_ZERO = 0x6000
+  #endif
+};
+
+#if defined(_MM_FROUND_TO_NEAREST_INT)
+#  define SIMDE_MM_FROUND_TO_NEAREST_INT _MM_FROUND_TO_NEAREST_INT
+#  define SIMDE_MM_FROUND_TO_NEG_INF     _MM_FROUND_TO_NEG_INF
+#  define SIMDE_MM_FROUND_TO_POS_INF     _MM_FROUND_TO_POS_INF
+#  define SIMDE_MM_FROUND_TO_ZERO        _MM_FROUND_TO_ZERO
+#  define SIMDE_MM_FROUND_CUR_DIRECTION  _MM_FROUND_CUR_DIRECTION
+
+#  define SIMDE_MM_FROUND_RAISE_EXC      _MM_FROUND_RAISE_EXC
+#  define SIMDE_MM_FROUND_NO_EXC         _MM_FROUND_NO_EXC
+#else
+#  define SIMDE_MM_FROUND_TO_NEAREST_INT 0x00
+#  define SIMDE_MM_FROUND_TO_NEG_INF     0x01
+#  define SIMDE_MM_FROUND_TO_POS_INF     0x02
+#  define SIMDE_MM_FROUND_TO_ZERO        0x03
+#  define SIMDE_MM_FROUND_CUR_DIRECTION  0x04
+
+#  define SIMDE_MM_FROUND_RAISE_EXC      0x00
+#  define SIMDE_MM_FROUND_NO_EXC         0x08
+#endif
+
+#define SIMDE_MM_FROUND_NINT \
+  (SIMDE_MM_FROUND_TO_NEAREST_INT | SIMDE_MM_FROUND_RAISE_EXC)
+#define SIMDE_MM_FROUND_FLOOR \
+  (SIMDE_MM_FROUND_TO_NEG_INF | SIMDE_MM_FROUND_RAISE_EXC)
+#define SIMDE_MM_FROUND_CEIL \
+  (SIMDE_MM_FROUND_TO_POS_INF | SIMDE_MM_FROUND_RAISE_EXC)
+#define SIMDE_MM_FROUND_TRUNC \
+  (SIMDE_MM_FROUND_TO_ZERO | SIMDE_MM_FROUND_RAISE_EXC)
+#define SIMDE_MM_FROUND_RINT \
+  (SIMDE_MM_FROUND_CUR_DIRECTION | SIMDE_MM_FROUND_RAISE_EXC)
+#define SIMDE_MM_FROUND_NEARBYINT \
+  (SIMDE_MM_FROUND_CUR_DIRECTION | SIMDE_MM_FROUND_NO_EXC)
+
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES) && !defined(_MM_FROUND_TO_NEAREST_INT)
+#  define _MM_FROUND_TO_NEAREST_INT SIMDE_MM_FROUND_TO_NEAREST_INT
+#  define _MM_FROUND_TO_NEG_INF SIMDE_MM_FROUND_TO_NEG_INF
+#  define _MM_FROUND_TO_POS_INF SIMDE_MM_FROUND_TO_POS_INF
+#  define _MM_FROUND_TO_ZERO SIMDE_MM_FROUND_TO_ZERO
+#  define _MM_FROUND_CUR_DIRECTION SIMDE_MM_FROUND_CUR_DIRECTION
+#  define _MM_FROUND_RAISE_EXC SIMDE_MM_FROUND_RAISE_EXC
+#  define _MM_FROUND_NINT SIMDE_MM_FROUND_NINT
+#  define _MM_FROUND_FLOOR SIMDE_MM_FROUND_FLOOR
+#  define _MM_FROUND_CEIL SIMDE_MM_FROUND_CEIL
+#  define _MM_FROUND_TRUNC SIMDE_MM_FROUND_TRUNC
+#  define _MM_FROUND_RINT SIMDE_MM_FROUND_RINT
+#  define _MM_FROUND_NEARBYINT SIMDE_MM_FROUND_NEARBYINT
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+unsigned int
+SIMDE_MM_GET_ROUNDING_MODE(void) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _MM_GET_ROUNDING_MODE();
+  #elif defined(SIMDE_HAVE_FENV_H)
+    unsigned int vfe_mode;
+
+    switch (fegetround()) {
+      #if defined(FE_TONEAREST)
+        case FE_TONEAREST:
+          vfe_mode = SIMDE_MM_ROUND_NEAREST;
+          break;
+      #endif
+
+      #if defined(FE_TOWARDZERO)
+        case FE_TOWARDZERO:
+          vfe_mode = SIMDE_MM_ROUND_DOWN;
+          break;
+      #endif
+
+      #if defined(FE_UPWARD)
+        case FE_UPWARD:
+          vfe_mode = SIMDE_MM_ROUND_UP;
+          break;
+      #endif
+
+      #if defined(FE_DOWNWARD)
+        case FE_DOWNWARD:
+          vfe_mode = SIMDE_MM_ROUND_TOWARD_ZERO;
+          break;
+      #endif
+
+      default:
+        vfe_mode = SIMDE_MM_ROUND_NEAREST;
+        break;
+    }
+
+    return vfe_mode;
+  #else
+    return SIMDE_MM_ROUND_NEAREST;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+  #define _MM_GET_ROUNDING_MODE() SIMDE_MM_GET_ROUNDING_MODE()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+SIMDE_MM_SET_ROUNDING_MODE(unsigned int a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _MM_SET_ROUNDING_MODE(a);
+  #elif defined(SIMDE_HAVE_FENV_H)
+    int fe_mode = FE_TONEAREST;
+
+    switch (a) {
+      #if defined(FE_TONEAREST)
+        case SIMDE_MM_ROUND_NEAREST:
+          fe_mode = FE_TONEAREST;
+          break;
+      #endif
+
+      #if defined(FE_TOWARDZERO)
+        case SIMDE_MM_ROUND_TOWARD_ZERO:
+          fe_mode = FE_TOWARDZERO;
+          break;
+      #endif
+
+      #if defined(FE_DOWNWARD)
+        case SIMDE_MM_ROUND_DOWN:
+          fe_mode = FE_DOWNWARD;
+          break;
+      #endif
+
+      #if defined(FE_UPWARD)
+        case SIMDE_MM_ROUND_UP:
+          fe_mode = FE_UPWARD;
+          break;
+      #endif
+
+      default:
+        return;
+    }
+
+    fesetround(fe_mode);
+  #else
+    (void) a;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+  #define _MM_SET_ROUNDING_MODE(a) SIMDE_MM_SET_ROUNDING_MODE(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_mm_getcsr (void) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_getcsr();
+  #else
+    return SIMDE_MM_GET_ROUNDING_MODE();
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+  #define _mm_getcsr() simde_mm_getcsr()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_setcsr (uint32_t a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_setcsr(a);
+  #else
+    SIMDE_MM_SET_ROUNDING_MODE(HEDLEY_STATIC_CAST(unsigned int, a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+  #define _mm_setcsr(a) simde_mm_setcsr(a)
+#endif
+
+#if !defined(__x86_64__) || !defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_round_ps (simde__m128 a, int rounding)
+    SIMDE_REQUIRE_CONSTANT_RANGE(rounding, 0, 15) {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a);
+
+  /* For architectures which lack a current direction SIMD instruction.
+   *
+   * Note that NEON actually has a current rounding mode instruction,
+   * but in ARMv8+ the rounding mode is ignored and nearest is always
+   * used, so we treat ARMv7 as having a rounding mode but ARMv8 as
+   * not. */
+  #if \
+      defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) || \
+      defined(SIMDE_ARM_NEON_A32V8)
+    if ((rounding & 7) == SIMDE_MM_FROUND_CUR_DIRECTION)
+      rounding = HEDLEY_STATIC_CAST(int, SIMDE_MM_GET_ROUNDING_MODE()) << 13;
+  #endif
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    case SIMDE_MM_FROUND_CUR_DIRECTION:
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+        r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_round(a_.altivec_f32));
+      #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
+        r_.neon_f32 = vrndiq_f32(a_.neon_f32);
+      #elif defined(simde_math_nearbyintf)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_nearbyintf(a_.f32[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_NEAREST_INT:
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+        r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_round(a_.altivec_f32));
+      #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
+        r_.neon_f32 = vrndaq_f32(a_.neon_f32);
+      #elif defined(simde_math_roundf)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_roundf(a_.f32[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_NEG_INF:
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+        r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_floor(a_.altivec_f32));
+      #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
+        r_.neon_f32 = vrndmq_f32(a_.neon_f32);
+      #elif defined(simde_math_floorf)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_floorf(a_.f32[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_POS_INF:
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+        r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_ceil(a_.altivec_f32));
+      #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
+        r_.neon_f32 = vrndpq_f32(a_.neon_f32);
+      #elif defined(simde_math_ceilf)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_ceilf(a_.f32[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_ZERO:
+      #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+        r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_trunc(a_.altivec_f32));
+      #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && 0
+        r_.neon_f32 = vrndq_f32(a_.neon_f32);
+      #elif defined(simde_math_truncf)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+          r_.f32[i] = simde_math_truncf(a_.f32[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+  }
+
+  return simde__m128_from_private(r_);
+}
+#endif
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+  #define simde_mm_round_ps(a, rounding) _mm_round_ps(a, rounding)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #define _mm_round_ps(a, rounding) simde_mm_round_ps(a, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_set_ps (simde_float32 e3, simde_float32 e2, simde_float32 e1, simde_float32 e0) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_set_ps(e3, e2, e1, e0);
+  #else
+    simde__m128_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN(16) simde_float32 data[4] = { e0, e1, e2, e3 };
+      r_.neon_f32 = vld1q_f32(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_make(e0, e1, e2, e3);
+    #else
+      r_.f32[0] = e0;
+      r_.f32[1] = e1;
+      r_.f32[2] = e2;
+      r_.f32[3] = e3;
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_ps(e3, e2, e1, e0) simde_mm_set_ps(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_set_ps1 (simde_float32 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_set_ps1(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_f32(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    (void) a;
+    return vec_splats(a);
+  #else
+    return simde_mm_set_ps(a, a, a, a);
+  #endif
+}
+#define simde_mm_set1_ps(a) simde_mm_set_ps1(a)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_ps1(a) simde_mm_set_ps1(a)
+#  define _mm_set1_ps(a) simde_mm_set1_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_move_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_move_ss(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(vgetq_lane_f32(b_.neon_f32, 0), a_.neon_f32, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) m = {
+        16, 17, 18, 19,
+        4,  5,  6,  7,
+        8,  9, 10, 11,
+        12, 13, 14, 15
+      };
+      r_.altivec_f32 = vec_perm(a_.altivec_f32, b_.altivec_f32, m);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v8x16_shuffle(b_.wasm_v128, a_.wasm_v128, 0, 1, 2, 3, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 4, 1, 2, 3);
+    #else
+      r_.f32[0] = b_.f32[0];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_move_ss(a, b) simde_mm_move_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_add_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_add_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vaddq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_add(a_.altivec_f32, b_.altivec_f32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 + b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] + b_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_add_ps(a, b) simde_mm_add_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_add_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_add_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_add_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t b0 = vgetq_lane_f32(b_.neon_f32, 0);
+      float32x4_t value = vsetq_lane_f32(b0, vdupq_n_f32(0), 0);
+      // the upper values in the result must be the remnants of <a>.
+      r_.neon_f32 = vaddq_f32(a_.neon_f32, value);
+    #else
+      r_.f32[0] = a_.f32[0] + b_.f32[0];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_add_ss(a, b) simde_mm_add_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_and_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_and_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 & b_.i32;
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_and(a_.altivec_f32, b_.altivec_f32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] & b_.i32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_and_ps(a, b) simde_mm_and_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_andnot_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_andnot_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_andc(b_.altivec_f32, a_.altivec_f32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = ~a_.i32 & b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ~(a_.i32[i]) & b_.i32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_andnot_ps(a, b) simde_mm_andnot_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_xor_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_xor_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] ^ b_.u32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_xor_ps(a, b) simde_mm_xor_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_or_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_or_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] | b_.u32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_or_ps(a, b) simde_mm_or_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_not_ps(simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    /* Note: we use ints instead of floats because we don't want cmpeq
+     * to return false for (NaN, NaN) */
+    __m128i ai = _mm_castps_si128(a);
+    return _mm_castsi128_ps(_mm_andnot_si128(ai, _mm_cmpeq_epi32(ai, ai)));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = ~a_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = ~(a_.i32[i]);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_select_ps(simde__m128 a, simde__m128 b, simde__m128 mask) {
+  /* This function is for when you want to blend two elements together
+   * according to a mask.  It is similar to _mm_blendv_ps, except that
+   * it is undefined whether the blend is based on the highest bit in
+   * each lane (like blendv) or just bitwise operations.  This allows
+   * us to implement the function efficiently everywhere.
+   *
+   * Basically, you promise that all the lanes in mask are either 0 or
+   * ~0. */
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_ps(a, b, mask);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b),
+      mask_ = simde__m128_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbslq_s32(mask_.neon_u32, b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_bitselect(b_.wasm_v128, a_.wasm_v128, mask_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_sel(a_.altivec_i32, b_.altivec_i32, mask_.altivec_u32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 ^ ((a_.i32 ^ b_.i32) & mask_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] ^ ((a_.i32[i] ^ b_.i32[i]) & mask_.i32[i]);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_avg_pu16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_avg_pu16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vrhadd_u16(b_.neon_u16, a_.neon_u16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint32_t wa SIMDE_VECTOR(16);
+      uint32_t wb SIMDE_VECTOR(16);
+      uint32_t wr SIMDE_VECTOR(16);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u16);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u16);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u16, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pavgw(a, b) simde_mm_avg_pu16(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_avg_pu16(a, b) simde_mm_avg_pu16(a, b)
+#  define _m_pavgw(a, b) simde_mm_avg_pu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_avg_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_avg_pu8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vrhadd_u8(b_.neon_u8, a_.neon_u8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint16_t wa SIMDE_VECTOR(16);
+      uint16_t wb SIMDE_VECTOR(16);
+      uint16_t wr SIMDE_VECTOR(16);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u8);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u8);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u8, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pavgb(a, b) simde_mm_avg_pu8(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_avg_pu8(a, b) simde_mm_avg_pu8(a, b)
+#  define _m_pavgb(a, b) simde_mm_avg_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_abs_ps(simde__m128 a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,1,0))
+    return _mm512_castps512_ps128(_mm512_abs_ps(_mm512_castps128_ps512(a)));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vabsq_f32(a_.neon_f32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_abs(a_.altivec_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_abs(a_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_fabsf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpeq_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpeq_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vceqq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpeq(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.f32 == b_.f32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] == b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpeq_ps(a, b) simde_mm_cmpeq_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpeq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpeq_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpeq_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] == b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpeq_ss(a, b) simde_mm_cmpeq_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpge_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpge_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcgeq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_ge(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpge(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 >= b_.f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] >= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpge_ps(a, b) simde_mm_cmpge_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpge_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
+    return _mm_cmpge_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpge_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] >= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpge_ss(a, b) simde_mm_cmpge_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpgt_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpgt_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcgtq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpgt(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 > b_.f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] > b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpgt_ps(a, b) simde_mm_cmpgt_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpgt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
+    return _mm_cmpgt_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpgt_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] > b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpgt_ss(a, b) simde_mm_cmpgt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmple_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmple_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcleq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_le(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmple(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 <= b_.f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] <= b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmple_ps(a, b) simde_mm_cmple_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmple_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmple_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmple_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] <= b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmple_ss(a, b) simde_mm_cmple_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmplt_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmplt_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcltq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmplt(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 < b_.f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] < b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmplt_ps(a, b) simde_mm_cmplt_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmplt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmplt_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmplt_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] < b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmplt_ss(a, b) simde_mm_cmplt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpneq_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpneq_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vmvnq_u32(vceqq_f32(a_.neon_f32, b_.neon_f32));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_ne(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE) && SIMDE_ARCH_POWER_CHECK(900) && !defined(HEDLEY_IBM_VERSION)
+      /* vec_cmpne(SIMDE_POWER_ALTIVEC_VECTOR(float), SIMDE_POWER_ALTIVEC_VECTOR(float))
+        is missing from XL C/C++ v16.1.1,
+        though the documentation (table 89 on page 432 of the IBM XL C/C++ for
+        Linux Compiler Reference, Version 16.1.1) shows that it should be
+        present.  Both GCC and clang support it. */
+      r_.altivec_f32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), vec_cmpne(a_.altivec_f32, b_.altivec_f32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.f32 != b_.f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (a_.f32[i] != b_.f32[i]) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpneq_ps(a, b) simde_mm_cmpneq_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpneq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpneq_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpneq_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.u32[0] = (a_.f32[0] != b_.f32[0]) ? ~UINT32_C(0) : UINT32_C(0);
+    SIMDE_VECTORIZE
+    for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpneq_ss(a, b) simde_mm_cmpneq_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnge_ps (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmplt_ps(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnge_ps(a, b) simde_mm_cmpnge_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnge_ss (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmplt_ss(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnge_ss(a, b) simde_mm_cmpnge_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpngt_ps (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmple_ps(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpngt_ps(a, b) simde_mm_cmpngt_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpngt_ss (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmple_ss(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpngt_ss(a, b) simde_mm_cmpngt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnle_ps (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmpgt_ps(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnle_ps(a, b) simde_mm_cmpnle_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnle_ss (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmpgt_ss(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnle_ss(a, b) simde_mm_cmpnle_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnlt_ps (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmpge_ps(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnlt_ps(a, b) simde_mm_cmpnlt_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpnlt_ss (simde__m128 a, simde__m128 b) {
+  return simde_mm_cmpge_ss(a, b);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpnlt_ss(a, b) simde_mm_cmpnlt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpord_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpord_ps(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_and(wasm_f32x4_eq(a, a), wasm_f32x4_eq(b, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* Note: NEON does not have ordered compare builtin
+        Need to compare a eq a and b eq b to check for NaN
+        Do AND of results to get final */
+      uint32x4_t ceqaa = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t ceqbb = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      r_.neon_u32 = vandq_u32(ceqaa, ceqbb);
+    #elif defined(simde_math_isnanf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? UINT32_C(0) : ~UINT32_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpord_ps(a, b) simde_mm_cmpord_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpunord_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpunord_ps(a, b);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_v128_or(wasm_f32x4_ne(a, a), wasm_f32x4_ne(b, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t ceqaa = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t ceqbb = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      r_.neon_u32 = vmvnq_u32(vandq_u32(ceqaa, ceqbb));
+    #elif defined(simde_math_isnanf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = (simde_math_isnanf(a_.f32[i]) || simde_math_isnanf(b_.f32[i])) ? ~UINT32_C(0) : UINT32_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpunord_ps(a, b) simde_mm_cmpunord_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpunord_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
+    return _mm_cmpunord_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpunord_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(simde_math_isnanf)
+      r_.u32[0] = (simde_math_isnanf(a_.f32[0]) || simde_math_isnanf(b_.f32[0])) ? ~UINT32_C(0) : UINT32_C(0);
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i];
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpunord_ss(a, b) simde_mm_cmpunord_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comieq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comieq_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_eq_b = vceqq_f32(a_.neon_f32, b_.neon_f32);
+      return !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_eq_b), 0) != 0);
+    #else
+      return a_.f32[0] == b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comieq_ss(a, b) simde_mm_comieq_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comige_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comige_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_ge_b = vcgeq_f32(a_.neon_f32, b_.neon_f32);
+      return !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_ge_b), 0) != 0);
+    #else
+      return a_.f32[0] >= b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comige_ss(a, b) simde_mm_comige_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comigt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comigt_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_gt_b = vcgtq_f32(a_.neon_f32, b_.neon_f32);
+      return !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_gt_b), 0) != 0);
+    #else
+      return a_.f32[0] > b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comigt_ss(a, b) simde_mm_comigt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comile_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comile_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_le_b = vcleq_f32(a_.neon_f32, b_.neon_f32);
+      return !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_le_b), 0) != 0);
+    #else
+      return a_.f32[0] <= b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comile_ss(a, b) simde_mm_comile_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comilt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comilt_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_lt_b = vcltq_f32(a_.neon_f32, b_.neon_f32);
+      return !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_lt_b), 0) != 0);
+    #else
+      return a_.f32[0] < b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comilt_ss(a, b) simde_mm_comilt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comineq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_comineq_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_neq_b = vmvnq_u32(vceqq_f32(a_.neon_f32, b_.neon_f32));
+      return !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_neq_b), 0) != 0);
+    #else
+      return a_.f32[0] != b_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_comineq_ss(a, b) simde_mm_comineq_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_copysign_ps(simde__m128 dest, simde__m128 src) {
+  simde__m128_private
+    r_,
+    dest_ = simde__m128_to_private(dest),
+    src_ = simde__m128_to_private(src);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    const uint32x4_t sign_pos = vreinterpretq_u32_f32(vdupq_n_f32(-SIMDE_FLOAT32_C(0.0)));
+    r_.neon_u32 = vbslq_u32(sign_pos, src_.neon_u32, dest_.neon_u32);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    const v128_t sign_pos = wasm_f32x4_splat(-0.0f);
+    r_.wasm_v128 = wasm_v128_bitselect(src_.wasm_v128, dest_.wasm_v128, sign_pos);
+  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+    #if !defined(HEDLEY_IBM_VERSION)
+      r_.altivec_f32 = vec_cpsgn(dest_.altivec_f32, src_.altivec_f32);
+    #else
+      r_.altivec_f32 = vec_cpsgn(src_.altivec_f32, dest_.altivec_f32);
+    #endif
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) sign_pos = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), vec_splats(-0.0f));
+    r_.altivec_f32 = vec_sel(dest_.altivec_f32, src_.altivec_f32, sign_pos);
+  #elif defined(SIMDE_IEEE754_STORAGE)
+    (void) src_;
+    (void) dest_;
+    simde__m128 sign_pos = simde_mm_set1_ps(-0.0f);
+    r_ = simde__m128_to_private(simde_mm_xor_ps(dest, simde_mm_and_ps(simde_mm_xor_ps(dest, src), sign_pos)));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_copysignf(dest_.f32[i], src_.f32[i]);
+    }
+  #endif
+
+  return simde__m128_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_xorsign_ps(simde__m128 dest, simde__m128 src) {
+  return simde_mm_xor_ps(simde_mm_and_ps(simde_mm_set1_ps(-0.0f), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvt_pi2ps (simde__m128 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvt_pi2ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcombine_f32(vcvt_f32_s32(b_.neon_i32), vget_high_f32(a_.neon_f32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.m64_private[0].f32, b_.i32);
+      r_.m64_private[1] = a_.m64_private[1];
+
+    #else
+      r_.f32[0] = (simde_float32) b_.i32[0];
+      r_.f32[1] = (simde_float32) b_.i32[1];
+      r_.i32[2] = a_.i32[2];
+      r_.i32[3] = a_.i32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvt_pi2ps(a, b) simde_mm_cvt_pi2ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvt_ps2pi (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvt_ps2pi(a);
+  #else
+    simde__m64_private r_;
+    simde__m128_private a_;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    a_ = simde__m128_to_private(simde_mm_round_ps(a, SIMDE_MM_FROUND_CUR_DIRECTION));
+    r_.neon_i32 = vcvt_s32_f32(vget_low_f32(a_.neon_f32));
+  #elif defined(SIMDE_CONVERT_VECTOR_) && !defined(__clang__) && 0
+    SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].f32);
+  #else
+    a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, simde_math_nearbyintf(a_.f32[i]));
+    }
+  #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvt_ps2pi(a) simde_mm_cvt_ps2pi((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvt_si2ss (simde__m128 a, int32_t b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cvt_si2ss(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(HEDLEY_STATIC_CAST(float, b), a_.neon_f32, 0);
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b);
+      r_.i32[1] = a_.i32[1];
+      r_.i32[2] = a_.i32[2];
+      r_.i32[3] = a_.i32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvt_si2ss(a, b) simde_mm_cvt_si2ss((a), b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvt_ss2si (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cvt_ss2si(a);
+  #elif defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_GCC_95399)
+    return vgetq_lane_s32(vcvtnq_s32_f32(simde__m128_to_neon_f32(a)), 0);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(simde_mm_round_ps(a, SIMDE_MM_FROUND_CUR_DIRECTION));
+    return SIMDE_CONVERT_FTOI(int32_t, a_.f32[0]);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvt_ss2si(a) simde_mm_cvt_ss2si((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpi16_ps (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi16_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && 0 /* TODO */
+      r_.neon_f32 = vmovl_s16(vget_low_s16(vuzp1q_s16(a_.neon_i16, vmovq_n_s16(0))));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f32, a_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        simde_float32 v = a_.i16[i];
+        r_.f32[i] = v;
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpi16_ps(a) simde_mm_cvtpi16_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpi32_ps (simde__m128 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi32_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+    simde__m64_private b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcombine_f32(vcvt_f32_s32(b_.neon_i32), vget_high_f32(a_.neon_f32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.m64_private[0].f32, b_.i32);
+      r_.m64_private[1] = a_.m64_private[1];
+    #else
+      r_.f32[0] = (simde_float32) b_.i32[0];
+      r_.f32[1] = (simde_float32) b_.i32[1];
+      r_.i32[2] = a_.i32[2];
+      r_.i32[3] = a_.i32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpi32_ps(a, b) simde_mm_cvtpi32_ps((a), b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpi32x2_ps (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi32x2_ps(a, b);
+  #else
+    simde__m128_private r_;
+    simde__m64_private
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_s32(vcombine_s32(a_.neon_i32, b_.neon_i32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.m64_private[0].f32, a_.i32);
+      SIMDE_CONVERT_VECTOR_(r_.m64_private[1].f32, b_.i32);
+    #else
+      r_.f32[0] = (simde_float32) a_.i32[0];
+      r_.f32[1] = (simde_float32) a_.i32[1];
+      r_.f32[2] = (simde_float32) b_.i32[0];
+      r_.f32[3] = (simde_float32) b_.i32[1];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpi32x2_ps(a, b) simde_mm_cvtpi32x2_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpi8_ps (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi8_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_s32(vmovl_s16(vget_low_s16(vmovl_s8(a_.neon_i8))));
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, a_.i8[0]);
+      r_.f32[1] = HEDLEY_STATIC_CAST(simde_float32, a_.i8[1]);
+      r_.f32[2] = HEDLEY_STATIC_CAST(simde_float32, a_.i8[2]);
+      r_.f32[3] = HEDLEY_STATIC_CAST(simde_float32, a_.i8[3]);
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpi8_ps(a) simde_mm_cvtpi8_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtps_pi16 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtps_pi16(a);
+  #else
+    simde__m64_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_GCC_95399)
+      r_.neon_i16 = vmovn_s32(vcvtq_s32_f32(vrndiq_f32(a_.neon_f32)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = SIMDE_CONVERT_FTOI(int16_t, simde_math_roundf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtps_pi16(a) simde_mm_cvtps_pi16((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtps_pi32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtps_pi32(a);
+  #else
+    simde__m64_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_GCC_95399)
+      r_.neon_i32 = vcvt_s32_f32(vget_low_f32(vrndiq_f32(a_.neon_f32)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_roundf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtps_pi32(a) simde_mm_cvtps_pi32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtps_pi8 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtps_pi8(a);
+  #else
+    simde__m64_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE) && !defined(SIMDE_BUG_GCC_95471)
+      /* Clamp the input to [INT8_MIN, INT8_MAX], round, convert to i32, narrow to
+      * i16, combine with an all-zero vector of i16 (which will become the upper
+      * half), narrow to i8. */
+      float32x4_t max = vdupq_n_f32(HEDLEY_STATIC_CAST(simde_float32, INT8_MAX));
+      float32x4_t min = vdupq_n_f32(HEDLEY_STATIC_CAST(simde_float32, INT8_MIN));
+      float32x4_t values = vrndnq_f32(vmaxq_f32(vminq_f32(max, a_.neon_f32), min));
+      r_.neon_i8 = vmovn_s16(vcombine_s16(vmovn_s32(vcvtq_s32_f32(values)), vdup_n_s16(0)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f32) / sizeof(a_.f32[0])) ; i++) {
+        if (a_.f32[i] > HEDLEY_STATIC_CAST(simde_float32, INT8_MAX))
+          r_.i8[i] = INT8_MAX;
+        else if (a_.f32[i] <  HEDLEY_STATIC_CAST(simde_float32, INT8_MIN))
+          r_.i8[i] = INT8_MIN;
+        else
+          r_.i8[i] = SIMDE_CONVERT_FTOI(int8_t, simde_math_roundf(a_.f32[i]));
+      }
+      /* Note: the upper half is undefined */
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtps_pi8(a) simde_mm_cvtps_pi8((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpu16_ps (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpu16_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_u32(vmovl_u16(a_.neon_u16));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f32, a_.u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (simde_float32) a_.u16[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpu16_ps(a) simde_mm_cvtpu16_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpu8_ps (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpu8_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_u32(vmovl_u16(vget_low_u16(vmovl_u8(a_.neon_u8))));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = HEDLEY_STATIC_CAST(simde_float32, a_.u8[i]);
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtpu8_ps(a) simde_mm_cvtpu8_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtsi32_ss (simde__m128 a, int32_t b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cvtsi32_ss(a, b);
+  #else
+    simde__m128_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(HEDLEY_STATIC_CAST(float32_t, b), a_.neon_f32, 0);
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b);
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtsi32_ss(a, b) simde_mm_cvtsi32_ss((a), b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtsi64_ss (simde__m128 a, int64_t b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtsi64_ss(a, b);
+    #else
+      return _mm_cvtsi64x_ss(a, b);
+    #endif
+  #else
+    simde__m128_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(HEDLEY_STATIC_CAST(float32_t, b), a_.neon_f32, 0);
+    #else
+      r_ = a_;
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b);
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtsi64_ss(a, b) simde_mm_cvtsi64_ss((a), b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float32
+simde_mm_cvtss_f32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cvtss_f32(a);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return vgetq_lane_f32(a_.neon_f32, 0);
+    #else
+      return a_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtss_f32(a) simde_mm_cvtss_f32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtss_si32 (simde__m128 a) {
+  return simde_mm_cvt_ss2si(a);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtss_si32(a) simde_mm_cvtss_si32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtss_si64 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtss_si64(a);
+    #else
+      return _mm_cvtss_si64x(a);
+    #endif
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return SIMDE_CONVERT_FTOI(int64_t, simde_math_roundf(vgetq_lane_f32(a_.neon_f32, 0)));
+    #else
+      return SIMDE_CONVERT_FTOI(int64_t, simde_math_roundf(a_.f32[0]));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtss_si64(a) simde_mm_cvtss_si64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtt_ps2pi (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtt_ps2pi(a);
+  #else
+    simde__m64_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vcvt_s32_f32(vget_low_f32(a_.neon_f32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].f32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, a_.f32[i]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_mm_cvttps_pi32(a) simde_mm_cvtt_ps2pi(a)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtt_ps2pi(a) simde_mm_cvtt_ps2pi((a))
+#  define _mm_cvttps_pi32(a) simde_mm_cvttps_pi32((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtt_ss2si (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cvtt_ss2si(a);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return SIMDE_CONVERT_FTOI(int32_t, vgetq_lane_f32(a_.neon_f32, 0));
+    #else
+      return SIMDE_CONVERT_FTOI(int32_t, a_.f32[0]);
+    #endif
+  #endif
+}
+#define simde_mm_cvttss_si32(a) simde_mm_cvtt_ss2si((a))
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvtt_ss2si(a) simde_mm_cvtt_ss2si((a))
+#  define _mm_cvttss_si32(a) simde_mm_cvtt_ss2si((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvttss_si64 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(_MSC_VER)
+    #if defined(__PGI)
+      return _mm_cvttss_si64x(a);
+    #else
+      return _mm_cvttss_si64(a);
+    #endif
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return SIMDE_CONVERT_FTOI(int64_t, vgetq_lane_f32(a_.neon_f32, 0));
+    #else
+      return SIMDE_CONVERT_FTOI(int64_t, a_.f32[0]);
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cvttss_si64(a) simde_mm_cvttss_si64((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cmpord_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cmpord_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_cmpord_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(simde_math_isnanf)
+      r_.u32[0] = (simde_math_isnanf(simde_mm_cvtss_f32(a)) || simde_math_isnanf(simde_mm_cvtss_f32(b))) ? UINT32_C(0) : ~UINT32_C(0);
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i];
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_cmpord_ss(a, b) simde_mm_cmpord_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_div_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_div_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vdivq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x4_t recip0 = vrecpeq_f32(b_.neon_f32);
+      float32x4_t recip1 = vmulq_f32(recip0, vrecpsq_f32(recip0, b_.neon_f32));
+      r_.neon_f32 = vmulq_f32(a_.neon_f32, recip1);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+        r_.wasm_v128 =  wasm_f32x4_div(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 / b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] / b_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_div_ps(a, b) simde_mm_div_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_div_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_div_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_div_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t value =
+              vgetq_lane_f32(simde__m128_to_private(simde_mm_div_ps(a, b)).neon_f32, 0);
+      r_.neon_f32 = vsetq_lane_f32(value, a_.neon_f32, 0);
+    #else
+      r_.f32[0] = a_.f32[0] / b_.f32[0];
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_div_ss(a, b) simde_mm_div_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int16_t
+simde_mm_extract_pi16 (simde__m64 a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m64_private a_ = simde__m64_to_private(a);
+  return a_.i16[imm8];
+}
+#if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(HEDLEY_PGI_VERSION)
+#  if HEDLEY_HAS_WARNING("-Wvector-conversion")
+     /* https://bugs.llvm.org/show_bug.cgi?id=44589 */
+#    define simde_mm_extract_pi16(a, imm8) ( \
+         HEDLEY_DIAGNOSTIC_PUSH \
+         _Pragma("clang diagnostic ignored \"-Wvector-conversion\"") \
+         HEDLEY_STATIC_CAST(int16_t, _mm_extract_pi16((a), (imm8))) \
+         HEDLEY_DIAGNOSTIC_POP \
+       )
+#  else
+#    define simde_mm_extract_pi16(a, imm8) HEDLEY_STATIC_CAST(int16_t, _mm_extract_pi16(a, imm8))
+#  endif
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_extract_pi16(a, imm8) vget_lane_s16(simde__m64_to_private(a).neon_i16, imm8)
+#endif
+#define simde_m_pextrw(a, imm8) simde_mm_extract_pi16(a, imm8)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_extract_pi16(a, imm8) simde_mm_extract_pi16((a), (imm8))
+#  define _m_pextrw(a, imm8) simde_mm_extract_pi16((a), (imm8))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_insert_pi16 (simde__m64 a, int16_t i, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 3) {
+  simde__m64_private
+    r_,
+    a_ = simde__m64_to_private(a);
+
+  r_.i64[0] = a_.i64[0];
+  r_.i16[imm8] = i;
+
+  return simde__m64_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+#  if HEDLEY_HAS_WARNING("-Wvector-conversion")
+     /* https://bugs.llvm.org/show_bug.cgi?id=44589 */
+#    define ssimde_mm_insert_pi16(a, i, imm8) ( \
+         HEDLEY_DIAGNOSTIC_PUSH \
+         _Pragma("clang diagnostic ignored \"-Wvector-conversion\"") \
+        (_mm_insert_pi16((a), (i), (imm8))) \
+         HEDLEY_DIAGNOSTIC_POP \
+       )
+#  else
+#    define simde_mm_insert_pi16(a, i, imm8) _mm_insert_pi16(a, i, imm8)
+#  endif
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_insert_pi16(a, i, imm8) simde__m64_from_neon_i16(vset_lane_s16((i), simde__m64_to_neon_i16(a), (imm8)))
+#endif
+#define simde_m_pinsrw(a, i, imm8) (simde_mm_insert_pi16(a, i, imm8))
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_insert_pi16(a, i, imm8) simde_mm_insert_pi16(a, i, imm8)
+#  define _m_pinsrw(a, i, imm8) simde_mm_insert_pi16(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_load_ps (simde_float32 const mem_addr[HEDLEY_ARRAY_PARAM(4)]) {
+  simde_assert_aligned(16, mem_addr);
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  return _mm_load_ps(mem_addr);
+#else
+  simde__m128_private r_;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_f32 = vld1q_f32(mem_addr);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    r_.altivec_f32 = vec_vsx_ld(0, mem_addr);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    r_.altivec_f32 = vec_ld(0, mem_addr);
+  #else
+    r_ = *SIMDE_ALIGN_CAST(simde__m128_private const*, mem_addr);
+  #endif
+
+  return simde__m128_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_load_ps(mem_addr) simde_mm_load_ps(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_load_ps1 (simde_float32 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_load_ps1(mem_addr);
+  #else
+    simde__m128_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vld1q_dup_f32(mem_addr);
+    #else
+      r_ = simde__m128_to_private(simde_mm_set1_ps(*mem_addr));
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#define simde_mm_load1_ps(mem_addr) simde_mm_load_ps1(mem_addr)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_load_ps1(mem_addr) simde_mm_load_ps1(mem_addr)
+#  define _mm_load1_ps(mem_addr) simde_mm_load_ps1(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_load_ss (simde_float32 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_load_ss(mem_addr);
+  #else
+    simde__m128_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(*mem_addr, vdupq_n_f32(0), 0);
+    #else
+      r_.f32[0] = *mem_addr;
+      r_.i32[1] = 0;
+      r_.i32[2] = 0;
+      r_.i32[3] = 0;
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_load_ss(mem_addr) simde_mm_load_ss(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_loadh_pi (simde__m128 a, simde__m64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_loadh_pi(a, HEDLEY_REINTERPRET_CAST(__m64 const*, mem_addr));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_f32 = vcombine_f32(vget_low_f32(a_.neon_f32), vld1_f32(HEDLEY_REINTERPRET_CAST(const float32_t*, mem_addr)));
+  #else
+    simde__m64_private b_ = *HEDLEY_REINTERPRET_CAST(simde__m64_private const*, mem_addr);
+    r_.f32[0] = a_.f32[0];
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = b_.f32[0];
+    r_.f32[3] = b_.f32[1];
+  #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_loadh_pi(a, mem_addr) simde_mm_loadh_pi((a), (simde__m64 const*) (mem_addr))
+#endif
+
+/* The SSE documentation says that there are no alignment requirements
+   for mem_addr.  Unfortunately they used the __m64 type for the argument
+   which is supposed to be 8-byte aligned, so some compilers (like clang
+   with -Wcast-align) will generate a warning if you try to cast, say,
+   a simde_float32* to a simde__m64* for this function.
+
+   I think the choice of argument type is unfortunate, but I do think we
+   need to stick to it here.  If there is demand I can always add something
+   like simde_x_mm_loadl_f32(simde__m128, simde_float32 mem_addr[2]) */
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_loadl_pi (simde__m128 a, simde__m64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_loadl_pi(a, HEDLEY_REINTERPRET_CAST(__m64 const*, mem_addr));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcombine_f32(vld1_f32(
+        HEDLEY_REINTERPRET_CAST(const float32_t*, mem_addr)), vget_high_f32(a_.neon_f32));
+    #else
+      simde__m64_private b_;
+      simde_memcpy(&b_, mem_addr, sizeof(b_));
+      r_.i32[0] = b_.i32[0];
+      r_.i32[1] = b_.i32[1];
+      r_.i32[2] = a_.i32[2];
+      r_.i32[3] = a_.i32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_loadl_pi(a, mem_addr) simde_mm_loadl_pi((a), (simde__m64 const*) (mem_addr))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_loadr_ps (simde_float32 const mem_addr[HEDLEY_ARRAY_PARAM(4)]) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_loadr_ps(mem_addr);
+  #else
+    simde__m128_private
+      r_,
+      v_ = simde__m128_to_private(simde_mm_load_ps(mem_addr));
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_f32 = vrev64q_f32(v_.neon_f32);
+    r_.neon_f32 = vextq_f32(r_.neon_f32, r_.neon_f32, 2);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && 0
+    /* TODO: XLC documentation has it, but it doesn't seem to work.
+    * More investigation is necessary. */
+    r_.altivec_f32 = vec_reve(a_.altivec_f32);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, v_.f32, v_.f32, 3, 2, 1, 0);
+  #else
+    r_.f32[0] = v_.f32[3];
+    r_.f32[1] = v_.f32[2];
+    r_.f32[2] = v_.f32[1];
+    r_.f32[3] = v_.f32[0];
+  #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_loadr_ps(mem_addr) simde_mm_loadr_ps(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_loadu_ps (simde_float32 const mem_addr[HEDLEY_ARRAY_PARAM(4)]) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_loadu_ps(mem_addr);
+  #else
+    simde__m128_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vld1q_f32(HEDLEY_REINTERPRET_CAST(const float32_t*, mem_addr));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_load(mem_addr);
+    #else
+      r_.f32[0] = mem_addr[0];
+      r_.f32[1] = mem_addr[1];
+      r_.f32[2] = mem_addr[2];
+      r_.f32[3] = mem_addr[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_loadu_ps(mem_addr) simde_mm_loadu_ps(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskmove_si64 (simde__m64 a, simde__m64 mask, int8_t* mem_addr) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    _mm_maskmove_si64(a, mask, HEDLEY_REINTERPRET_CAST(char*, mem_addr));
+  #else
+    simde__m64_private
+      a_ = simde__m64_to_private(a),
+      mask_ = simde__m64_to_private(mask);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++)
+      if (mask_.i8[i] < 0)
+        mem_addr[i] = a_.i8[i];
+  #endif
+}
+#define simde_m_maskmovq(a, mask, mem_addr) simde_mm_maskmove_si64(a, mask, mem_addr)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_maskmove_si64(a, mask, mem_addr) simde_mm_maskmove_si64((a), (mask), SIMDE_CHECKED_REINTERPRET_CAST(int8_t*, char*, (mem_addr)))
+#  define _m_maskmovq(a, mask, mem_addr) simde_mm_maskmove_si64((a), (mask), SIMDE_CHECKED_REINTERPRET_CAST(int8_t*, char*, (mem_addr)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_max_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_max_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmax_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmaxsw(a, b) simde_mm_max_pi16(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_max_pi16(a, b) simde_mm_max_pi16(a, b)
+#  define _m_pmaxsw(a, b) simde_mm_max_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_max_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_max_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vmaxq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_max(a_.altivec_f32, b_.altivec_f32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (a_.f32[i] > b_.f32[i]) ? a_.f32[i] : b_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_max_ps(a, b) simde_mm_max_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_max_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_max_pu8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vmax_u8(a_.neon_u8, b_.neon_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmaxub(a, b) simde_mm_max_pu8(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_max_pu8(a, b) simde_mm_max_pu8(a, b)
+#  define _m_pmaxub(a, b) simde_mm_max_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_max_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_max_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_max_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t value = vgetq_lane_f32(maxq_f32(a_.neon_f32, b_.neon_f32), 0);
+      r_.neon_f32 = vsetq_lane_f32(value, a_.neon_f32, 0);
+    #else
+      r_.f32[0] = (a_.f32[0] > b_.f32[0]) ? a_.f32[0] : b_.f32[0];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_max_ss(a, b) simde_mm_max_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_min_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_min_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmin_s16(a_.neon_i16, b_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pminsw(a, b) simde_mm_min_pi16(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_min_pi16(a, b) simde_mm_min_pi16(a, b)
+#  define _m_pminsw(a, b) simde_mm_min_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_min_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_min_ps(a, b);
+  #elif defined(SIMDE_FAST_NANS) && defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde__m128_from_neon_f32(vminq_f32(simde__m128_to_neon_f32(a), simde__m128_to_neon_f32(b)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    #if defined(SIMDE_FAST_NANS)
+      r_.wasm_v128 = wasm_f32x4_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      r_.wasm_v128 = wasm_v128_bitselect(a_.wasm_v128, b_.wasm_v128, wasm_f32x4_lt(a_.wasm_v128, b_.wasm_v128));
+    #endif
+    return simde__m128_from_private(r_);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_FAST_NANS)
+      r_.altivec_f32 = vec_min(a_.altivec_f32, b_.altivec_f32);
+    #else
+      r_.altivec_f32 = vec_sel(b_.altivec_f32, a_.altivec_f32, vec_cmpgt(b_.altivec_f32, a_.altivec_f32));
+    #endif
+
+    return simde__m128_from_private(r_);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m128 mask = simde_mm_cmplt_ps(a, b);
+    return simde_mm_or_ps(simde_mm_and_ps(mask, a), simde_mm_andnot_ps(mask, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = (a_.f32[i] < b_.f32[i]) ? a_.f32[i] : b_.f32[i];
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_min_ps(a, b) simde_mm_min_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_min_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_min_pu8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vmin_u8(a_.neon_u8, b_.neon_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pminub(a, b) simde_mm_min_pu8(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_min_pu8(a, b) simde_mm_min_pu8(a, b)
+#  define _m_pminub(a, b) simde_mm_min_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_min_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_min_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_min_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t value = vgetq_lane_f32(vminq_f32(a_.neon_f32, b_.neon_f32), 0);
+      r_.neon_f32 = vsetq_lane_f32(value, a_.neon_f32, 0);
+    #else
+      r_.f32[0] = (a_.f32[0] < b_.f32[0]) ? a_.f32[0] : b_.f32[0];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_min_ss(a, b) simde_mm_min_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_movehl_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_movehl_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x2_t a32 = vget_high_f32(a_.neon_f32);
+      float32x2_t b32 = vget_high_f32(b_.neon_f32);
+      r_.neon_f32 = vcombine_f32(b32, a32);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 6, 7, 2, 3);
+    #else
+      r_.f32[0] = b_.f32[2];
+      r_.f32[1] = b_.f32[3];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_movehl_ps(a, b) simde_mm_movehl_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_movelh_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_movelh_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x2_t a10 = vget_low_f32(a_.neon_f32);
+      float32x2_t b10 = vget_low_f32(b_.neon_f32);
+      r_.neon_f32 = vcombine_f32(a10, b10);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 0, 1, 4, 5);
+    #else
+      r_.f32[0] = a_.f32[0];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = b_.f32[0];
+      r_.f32[3] = b_.f32[1];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_movelh_ps(a, b) simde_mm_movelh_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_movemask_pi8 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movemask_pi8(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+    int r = 0;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x8_t input = a_.neon_u8;
+      const int8_t xr[8] = {-7, -6, -5, -4, -3, -2, -1, 0};
+      const uint8x8_t mask_and = vdup_n_u8(0x80);
+      const int8x8_t mask_shift = vld1_s8(xr);
+      const uint8x8_t mask_result = vshl_u8(vand_u8(input, mask_and), mask_shift);
+      uint8x8_t lo = mask_result;
+      r = vaddv_u8(lo);
+    #else
+      const size_t nmemb = sizeof(a_.i8) / sizeof(a_.i8[0]);
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < nmemb ; i++) {
+        r |= (a_.u8[nmemb - 1 - i] >> 7) << (nmemb - 1 - i);
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#define simde_m_pmovmskb(a) simde_mm_movemask_pi8(a)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_movemask_pi8(a) simde_mm_movemask_pi8(a)
+#  define _m_pmovmskb(a) simde_mm_movemask_pi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_movemask_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movemask_ps(a);
+  #else
+    int r = 0;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      static const int32_t shift_amount[] = { 0, 1, 2, 3 };
+      const int32x4_t shift = vld1q_s32(shift_amount);
+      uint32x4_t tmp = vshrq_n_u32(a_.neon_u32, 31);
+      return HEDLEY_STATIC_CAST(int, vaddvq_u32(vshlq_u32(tmp, shift)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Shift out everything but the sign bits with a 32-bit unsigned shift right.
+      uint64x2_t high_bits = vreinterpretq_u64_u32(vshrq_n_u32(a_.neon_u32, 31));
+      // Merge the two pairs together with a 64-bit unsigned shift right + add.
+      uint8x16_t paired = vreinterpretq_u8_u64(vsraq_n_u64(high_bits, high_bits, 31));
+      // Extract the result.
+      return vgetq_lane_u8(paired, 0) | (vgetq_lane_u8(paired, 8) << 2);
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < sizeof(a_.u32) / sizeof(a_.u32[0]) ; i++) {
+        r |= (a_.u32[i] >> ((sizeof(a_.u32[i]) * CHAR_BIT) - 1)) << i;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_movemask_ps(a) simde_mm_movemask_ps((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mul_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_mul_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vmulq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_mul(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 * b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] * b_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_mul_ps(a, b) simde_mm_mul_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_mul_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_mul_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_mul_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.f32[0] = a_.f32[0] * b_.f32[0];
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = a_.f32[2];
+    r_.f32[3] = a_.f32[3];
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_mul_ss(a, b) simde_mm_mul_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_mulhi_pu16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_mulhi_pu16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const uint32x4_t t1 = vmull_u16(a_.neon_u16, b_.neon_u16);
+      const uint32x4_t t2 = vshrq_n_u32(t1, 16);
+      const uint16x4_t t3 = vmovn_u32(t2);
+      r_.neon_u16 = t3;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, ((HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i])) >> UINT32_C(16)));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_pmulhuw(a, b) simde_mm_mulhi_pu16(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_mulhi_pu16(a, b) simde_mm_mulhi_pu16(a, b)
+#  define _m_pmulhuw(a, b) simde_mm_mulhi_pu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_prefetch (char const* p, int i) {
+  #if defined(HEDLEY_GCC_VERSION)
+    __builtin_prefetch(p);
+  #else
+    (void) p;
+  #endif
+
+  (void) i;
+}
+#if defined(SIMDE_X86_SSE_NATIVE)
+#  define simde_mm_prefetch(p, i) _mm_prefetch(p, i)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_prefetch(p, i) simde_mm_prefetch(p, i)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_negate_ps(simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return simde_mm_xor_ps(a, _mm_set1_ps(SIMDE_FLOAT32_C(-0.0)));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+      r_.altivec_f32 = vec_neg(a_.altivec_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vnegq_f32(a_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_neg(a_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_NEGATE)
+      r_.f32 = -a_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = -a_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_rcp_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_rcp_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x4_t recip = vrecpeq_f32(a_.neon_f32);
+
+      #if SIMDE_ACCURACY_PREFERENCE > 0
+        for (int i = 0; i < SIMDE_ACCURACY_PREFERENCE ; ++i) {
+          recip = vmulq_f32(recip, vrecpsq_f32(recip, a_.neon_f32));
+        }
+      #endif
+
+      r_.neon_f32 = recip;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_div(simde_mm_set1_ps(1.0f), a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f32 = vec_re(a_.altivec_f32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.f32 = 1.0f / a_.f32;
+    #elif defined(SIMDE_IEEE754_STORAGE)
+      /* https://stackoverflow.com/questions/12227126/division-as-multiply-and-lut-fast-float-division-reciprocal/12228234#12228234 */
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        int32_t ix;
+        simde_float32 fx = a_.f32[i];
+        simde_memcpy(&ix, &fx, sizeof(ix));
+        int32_t x = INT32_C(0x7EF311C3) - ix;
+        simde_float32 temp;
+        simde_memcpy(&temp, &x, sizeof(temp));
+        r_.f32[i] = temp * (SIMDE_FLOAT32_C(2.0) - temp * fx);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = 1.0f / a_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_rcp_ps(a) simde_mm_rcp_ps((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_rcp_ss (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_rcp_ss(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_rcp_ps(a));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    r_.f32[0] = 1.0f / a_.f32[0];
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = a_.f32[2];
+    r_.f32[3] = a_.f32[3];
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_rcp_ss(a) simde_mm_rcp_ss((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_rsqrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_rsqrt_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vrsqrteq_f32(a_.neon_f32);
+    #elif defined(SIMDE_IEEE754_STORAGE)
+      /* https://basesandframes.files.wordpress.com/2020/04/even_faster_math_functions_green_2020.pdf
+        Pages 100 - 103 */
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        #if SIMDE_ACCURACY_PREFERENCE <= 0
+          r_.i32[i] = INT32_C(0x5F37624F) - (a_.i32[i] >> 1);
+        #else
+          simde_float32 x = a_.f32[i];
+          simde_float32 xhalf = SIMDE_FLOAT32_C(0.5) * x;
+          int32_t ix;
+
+          simde_memcpy(&ix, &x, sizeof(ix));
+
+          #if SIMDE_ACCURACY_PREFERENCE == 1
+            ix = INT32_C(0x5F375A82) - (ix >> 1);
+          #else
+            ix = INT32_C(0x5F37599E) - (ix >> 1);
+          #endif
+
+          simde_memcpy(&x, &ix, sizeof(x));
+
+          #if SIMDE_ACCURACY_PREFERENCE >= 2
+            x = x * (SIMDE_FLOAT32_C(1.5008909) - xhalf * x * x);
+          #endif
+          x = x * (SIMDE_FLOAT32_C(1.5008909) - xhalf * x * x);
+
+          r_.f32[i] = x;
+        #endif
+      }
+    #elif defined(simde_math_sqrtf)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = 1.0f / simde_math_sqrtf(a_.f32[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_rsqrt_ps(a) simde_mm_rsqrt_ps((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_rsqrt_ss (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_rsqrt_ss(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_rsqrt_ps(a));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(vgetq_lane_f32(simde_mm_rsqrt_ps(a).neon_f32, 0), a_.neon_f32, 0);
+  #elif defined(SIMDE_IEEE754_STORAGE)
+    {
+      #if SIMDE_ACCURACY_PREFERENCE <= 0
+        r_.i32[0] = INT32_C(0x5F37624F) - (a_.i32[0] >> 1);
+      #else
+        simde_float32 x = a_.f32[0];
+        simde_float32 xhalf = SIMDE_FLOAT32_C(0.5) * x;
+        int32_t ix;
+
+        simde_memcpy(&ix, &x, sizeof(ix));
+
+        #if SIMDE_ACCURACY_PREFERENCE == 1
+          ix = INT32_C(0x5F375A82) - (ix >> 1);
+        #else
+          ix = INT32_C(0x5F37599E) - (ix >> 1);
+        #endif
+
+        simde_memcpy(&x, &ix, sizeof(x));
+
+        #if SIMDE_ACCURACY_PREFERENCE >= 2
+          x = x * (SIMDE_FLOAT32_C(1.5008909) - xhalf * x * x);
+        #endif
+        x = x * (SIMDE_FLOAT32_C(1.5008909) - xhalf * x * x);
+
+        r_.f32[0] = x;
+      #endif
+    }
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = a_.f32[2];
+    r_.f32[3] = a_.f32[3];
+  #elif defined(simde_math_sqrtf)
+    r_.f32[0] = 1.0f / simde_math_sqrtf(a_.f32[0]);
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = a_.f32[2];
+    r_.f32[3] = a_.f32[3];
+  #else
+    HEDLEY_UNREACHABLE();
+  #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_rsqrt_ss(a) simde_mm_rsqrt_ss((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sad_pu8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sad_pu8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x4_t t = vpaddl_u8(vabd_u8(a_.neon_u8, b_.neon_u8));
+      uint16_t r0 = t[0] + t[1] + t[2] + t[3];
+      r_.neon_u16 = vset_lane_u16(r0, vdup_n_u16(0), 0);
+    #else
+      uint16_t sum = 0;
+
+      #if defined(SIMDE_HAVE_STDLIB_H)
+        SIMDE_VECTORIZE_REDUCTION(+:sum)
+        for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+          sum += HEDLEY_STATIC_CAST(uint8_t, abs(a_.u8[i] - b_.u8[i]));
+        }
+
+        r_.i16[0] = HEDLEY_STATIC_CAST(int16_t, sum);
+        r_.i16[1] = 0;
+        r_.i16[2] = 0;
+        r_.i16[3] = 0;
+      #else
+        HEDLEY_UNREACHABLE();
+      #endif
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#define simde_m_psadbw(a, b) simde_mm_sad_pu8(a, b)
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sad_pu8(a, b) simde_mm_sad_pu8(a, b)
+#  define _m_psadbw(a, b) simde_mm_sad_pu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_set_ss (simde_float32 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_set_ss(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vsetq_lane_f32(a, vdupq_n_f32(SIMDE_FLOAT32_C(0.0)), 0);
+  #else
+    return simde_mm_set_ps(SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(0.0), SIMDE_FLOAT32_C(0.0), a);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_set_ss(a) simde_mm_set_ss(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_setr_ps (simde_float32 e3, simde_float32 e2, simde_float32 e1, simde_float32 e0) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_setr_ps(e3, e2, e1, e0);
+  #else
+    return simde_mm_set_ps(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_setr_ps(e3, e2, e1, e0) simde_mm_setr_ps(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_setzero_ps (void) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_setzero_ps();
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vdupq_n_f32(SIMDE_FLOAT32_C(0.0));
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return vec_splats(SIMDE_FLOAT32_C(0.0));
+  #else
+    simde__m128 r;
+    simde_memset(&r, 0, sizeof(r));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_setzero_ps() simde_mm_setzero_ps()
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_undefined_ps (void) {
+  simde__m128_private r_;
+
+  #if defined(SIMDE_HAVE_UNDEFINED128)
+    r_.n = _mm_undefined_ps();
+  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+    r_ = simde__m128_to_private(simde_mm_setzero_ps());
+  #endif
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_undefined_ps() simde_mm_undefined_ps()
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_POP
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_setone_ps (void) {
+  simde__m128 t = simde_mm_setzero_ps();
+  return simde_mm_cmpeq_ps(t, t);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_sfence (void) {
+    /* TODO: Use Hedley. */
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_sfence();
+  #elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7))
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  #elif !defined(__INTEL_COMPILER) && defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
+    #if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 9)
+      __atomic_thread_fence(__ATOMIC_SEQ_CST);
+    #else
+      atomic_thread_fence(memory_order_seq_cst);
+    #endif
+  #elif defined(_MSC_VER)
+    MemoryBarrier();
+  #elif HEDLEY_HAS_EXTENSION(c_atomic)
+    __c11_atomic_thread_fence(__ATOMIC_SEQ_CST);
+  #elif defined(__GNUC__) && ((__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1))
+    __sync_synchronize();
+  #elif defined(_OPENMP)
+    #pragma omp critical(simde_mm_sfence_)
+    { }
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sfence() simde_mm_sfence()
+#endif
+
+#define SIMDE_MM_SHUFFLE(z, y, x, w) (((z) << 6) | ((y) << 4) | ((x) << 2) | (w))
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _MM_SHUFFLE(z, y, x, w) SIMDE_MM_SHUFFLE(z, y, x, w)
+#endif
+
+#if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+#  define simde_mm_shuffle_pi16(a, imm8) _mm_shuffle_pi16(a, imm8)
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#  define simde_mm_shuffle_pi16(a, imm8) (__extension__ ({ \
+      const simde__m64_private simde__tmp_a_ = simde__m64_to_private(a); \
+      simde__m64_from_private((simde__m64_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 8, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          (((imm8)     ) & 3), \
+          (((imm8) >> 2) & 3), \
+          (((imm8) >> 4) & 3), \
+          (((imm8) >> 6) & 3)) }); }))
+#else
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_shuffle_pi16 (simde__m64 a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  simde__m64_private r_;
+  simde__m64_private a_ = simde__m64_to_private(a);
+
+  for (size_t i = 0 ; i < sizeof(r_.i16) / sizeof(r_.i16[0]) ; i++) {
+    r_.i16[i] = a_.i16[(imm8 >> (i * 2)) & 3];
+  }
+
+HEDLEY_DIAGNOSTIC_PUSH
+#if HEDLEY_HAS_WARNING("-Wconditional-uninitialized")
+#  pragma clang diagnostic ignored "-Wconditional-uninitialized"
+#endif
+  return simde__m64_from_private(r_);
+HEDLEY_DIAGNOSTIC_POP
+}
+#endif
+#if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+#  define simde_m_pshufw(a, imm8) _m_pshufw(a, imm8)
+#else
+#  define simde_m_pshufw(a, imm8) simde_mm_shuffle_pi16(a, imm8)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_shuffle_pi16(a, imm8) simde_mm_shuffle_pi16(a, imm8)
+#  define _m_pshufw(a, imm8) simde_mm_shuffle_pi16(a, imm8)
+#endif
+
+#if defined(SIMDE_X86_SSE_NATIVE) && !defined(__PGI)
+#  define simde_mm_shuffle_ps(a, b, imm8) _mm_shuffle_ps(a, b, imm8)
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+#  define simde_mm_shuffle_ps(a, b, imm8) (__extension__ ({ \
+      simde__m128_from_private((simde__m128_private) { .f32 = \
+        SIMDE_SHUFFLE_VECTOR_(32, 16, \
+          simde__m128_to_private(a).f32, \
+          simde__m128_to_private(b).f32, \
+          (((imm8)     ) & 3), \
+          (((imm8) >> 2) & 3), \
+          (((imm8) >> 4) & 3) + 4, \
+          (((imm8) >> 6) & 3) + 4) }); }))
+#else
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_shuffle_ps (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  r_.f32[0] = a_.f32[(imm8 >> 0) & 3];
+  r_.f32[1] = a_.f32[(imm8 >> 2) & 3];
+  r_.f32[2] = b_.f32[(imm8 >> 4) & 3];
+  r_.f32[3] = b_.f32[(imm8 >> 6) & 3];
+
+  return simde__m128_from_private(r_);
+}
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_shuffle_ps(a, b, imm8) simde_mm_shuffle_ps((a), (b), imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sqrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sqrt_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vsqrtq_f32(a_.neon_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x4_t est = vrsqrteq_f32(a_.neon_f32);
+      for (int i = 0 ; i <= SIMDE_ACCURACY_PREFERENCE ; i++) {
+        est = vmulq_f32(vrsqrtsq_f32(vmulq_f32(a_.neon_f32, est), est), est);
+      }
+      r_.neon_f32 = vmulq_f32(a_.neon_f32, est);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_sqrt(a_.wasm_v128);
+    #elif defined(simde_math_sqrt)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < sizeof(r_.f32) / sizeof(r_.f32[0]) ; i++) {
+        r_.f32[i] = simde_math_sqrtf(a_.f32[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sqrt_ps(a) simde_mm_sqrt_ps((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sqrt_ss (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sqrt_ss(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_sqrt_ps(a));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t value =
+            vgetq_lane_f32(simde__m128_to_private(simde_mm_sqrt_ps(a)).neon_f32, 0);
+      r_.neon_f32 = vsetq_lane_f32(value, a_.neon_f32, 0);
+    #elif defined(simde_math_sqrtf)
+      r_.f32[0] = simde_math_sqrtf(a_.f32[0]);
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[3];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sqrt_ss(a) simde_mm_sqrt_ss((a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_ps (simde_float32 mem_addr[4], simde__m128 a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_store_ps(mem_addr, a);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_f32(mem_addr, a_.neon_f32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      vec_vsx_st(a_.altivec_f32, 0, mem_addr);
+    #elif defined(SIMDE_POWER_ALTIVEC_P5_NATIVE)
+      vec_st(a_.altivec_f32, 0, mem_addr);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      wasm_v128_store(mem_addr, a_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE_ALIGNED(mem_addr:16)
+      for (size_t i = 0 ; i < sizeof(a_.f32) / sizeof(a_.f32[0]) ; i++) {
+        mem_addr[i] = a_.f32[i];
+      }
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_store_ps(mem_addr, a) simde_mm_store_ps(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_ps1 (simde_float32 mem_addr[4], simde__m128 a) {
+  simde_assert_aligned(16, mem_addr);
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  _mm_store_ps1(mem_addr, a);
+#else
+  simde__m128_private a_ = simde__m128_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    mem_addr[0] = vgetq_lane_f32(a_.neon_f32, 0);
+    mem_addr[1] = vgetq_lane_f32(a_.neon_f32, 0);
+    mem_addr[2] = vgetq_lane_f32(a_.neon_f32, 0);
+    mem_addr[3] = vgetq_lane_f32(a_.neon_f32, 0);
+  #else
+    SIMDE_VECTORIZE_ALIGNED(mem_addr:16)
+    for (size_t i = 0 ; i < sizeof(a_.f32) / sizeof(a_.f32[0]) ; i++) {
+      mem_addr[i] = a_.f32[0];
+    }
+  #endif
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_store_ps1(mem_addr, a) simde_mm_store_ps1(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_ss (simde_float32* mem_addr, simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_store_ss(mem_addr, a);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_lane_f32(mem_addr, a_.neon_f32, 0);
+    #else
+      *mem_addr = a_.f32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_store_ss(mem_addr, a) simde_mm_store_ss(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store1_ps (simde_float32 mem_addr[4], simde__m128 a) {
+  simde_assert_aligned(16, mem_addr);
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  _mm_store1_ps(mem_addr, a);
+#else
+  simde_mm_store_ps1(mem_addr, a);
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_store1_ps(mem_addr, a) simde_mm_store1_ps(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storeh_pi (simde__m64* mem_addr, simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_storeh_pi(HEDLEY_REINTERPRET_CAST(__m64*, mem_addr), a);
+  #else
+    simde__m64_private* dest_ = HEDLEY_REINTERPRET_CAST(simde__m64_private*, mem_addr);
+    simde__m128_private a_ = simde__m128_to_private(a);
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      dest_->f32[0] = vgetq_lane_f32(a_.neon_f32, 2);
+      dest_->f32[1] = vgetq_lane_f32(a_.neon_f32, 3);
+    #else
+      dest_->f32[0] = a_.f32[2];
+      dest_->f32[1] = a_.f32[3];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_storeh_pi(mem_addr, a) simde_mm_storeh_pi(mem_addr, (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storel_pi (simde__m64* mem_addr, simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_storel_pi(HEDLEY_REINTERPRET_CAST(__m64*, mem_addr), a);
+  #else
+    simde__m64_private* dest_ = HEDLEY_REINTERPRET_CAST(simde__m64_private*, mem_addr);
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      dest_->neon_f32 = vget_low_f32(a_.neon_f32);
+    #else
+      dest_->f32[0] = a_.f32[0];
+      dest_->f32[1] = a_.f32[1];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_storel_pi(mem_addr, a) simde_mm_storel_pi(mem_addr, (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storer_ps (simde_float32 mem_addr[4], simde__m128 a) {
+  simde_assert_aligned(16, mem_addr);
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  _mm_storer_ps(mem_addr, a);
+#else
+  simde__m128_private a_ = simde__m128_to_private(a);
+
+  #if defined(SIMDE_SHUFFLE_VECTOR_)
+    a_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, a_.f32, 3, 2, 1, 0);
+    simde_mm_store_ps(mem_addr, simde__m128_from_private(a_));
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    mem_addr[0] = vgetq_lane_f32(a_.neon_f32, 3);
+    mem_addr[1] = vgetq_lane_f32(a_.neon_f32, 2);
+    mem_addr[2] = vgetq_lane_f32(a_.neon_f32, 1);
+    mem_addr[3] = vgetq_lane_f32(a_.neon_f32, 0);
+  #else
+    SIMDE_VECTORIZE_ALIGNED(mem_addr:16)
+    for (size_t i = 0 ; i < sizeof(a_.f32) / sizeof(a_.f32[0]) ; i++) {
+      mem_addr[i] = a_.f32[((sizeof(a_.f32) / sizeof(a_.f32[0])) - 1) - i];
+    }
+  #endif
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_storer_ps(mem_addr, a) simde_mm_storer_ps(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storeu_ps (simde_float32 mem_addr[4], simde__m128 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    _mm_storeu_ps(mem_addr, a);
+  #else
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_f32(mem_addr, a_.neon_f32);
+    #else
+      simde_memcpy(mem_addr, &a_, sizeof(a_));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_storeu_ps(mem_addr, a) simde_mm_storeu_ps(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sub_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sub_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vsubq_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_sub(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f32 = a_.f32 - b_.f32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i] - b_.f32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sub_ps(a, b) simde_mm_sub_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sub_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sub_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_sub_ps(a, b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    r_.f32[0] = a_.f32[0] - b_.f32[0];
+    r_.f32[1] = a_.f32[1];
+    r_.f32[2] = a_.f32[2];
+    r_.f32[3] = a_.f32[3];
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_sub_ss(a, b) simde_mm_sub_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomieq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomieq_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_eq_b = vceqq_f32(a_.neon_f32, b_.neon_f32);
+      r = !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_eq_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] == b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] == b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomieq_ss(a, b) simde_mm_ucomieq_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomige_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomige_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_ge_b = vcgeq_f32(a_.neon_f32, b_.neon_f32);
+      r = !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_ge_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] >= b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] >= b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomige_ss(a, b) simde_mm_ucomige_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomigt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomigt_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_gt_b = vcgtq_f32(a_.neon_f32, b_.neon_f32);
+      r = !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_gt_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] > b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] > b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomigt_ss(a, b) simde_mm_ucomigt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomile_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomile_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_le_b = vcleq_f32(a_.neon_f32, b_.neon_f32);
+      r = !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_le_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] <= b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] <= b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomile_ss(a, b) simde_mm_ucomile_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomilt_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomilt_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_or_b_nan = vmvnq_u32(vandq_u32(a_not_nan, b_not_nan));
+      uint32x4_t a_lt_b = vcltq_f32(a_.neon_f32, b_.neon_f32);
+      r = !!(vgetq_lane_u32(vorrq_u32(a_or_b_nan, a_lt_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] < b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] < b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomilt_ss(a, b) simde_mm_ucomilt_ss((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomineq_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_ucomineq_ss(a, b);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t a_not_nan = vceqq_f32(a_.neon_f32, a_.neon_f32);
+      uint32x4_t b_not_nan = vceqq_f32(b_.neon_f32, b_.neon_f32);
+      uint32x4_t a_and_b_not_nan = vandq_u32(a_not_nan, b_not_nan);
+      uint32x4_t a_neq_b = vmvnq_u32(vceqq_f32(a_.neon_f32, b_.neon_f32));
+      r = !!(vgetq_lane_u32(vandq_u32(a_and_b_not_nan, a_neq_b), 0) != 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f32[0] != b_.f32[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f32[0] != b_.f32[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_ucomineq_ss(a, b) simde_mm_ucomineq_ss((a), (b))
+#endif
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+#  if defined(__has_builtin)
+#    if __has_builtin(__builtin_ia32_undef128)
+#      define SIMDE_HAVE_UNDEFINED128
+#    endif
+#  elif !defined(__PGI) && !defined(SIMDE_BUG_GCC_REV_208793) && !defined(_MSC_VER)
+#    define SIMDE_HAVE_UNDEFINED128
+#  endif
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_unpackhi_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_unpackhi_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vzip2q_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x2_t a1 = vget_high_f32(a_.neon_f32);
+      float32x2_t b1 = vget_high_f32(b_.neon_f32);
+      float32x2x2_t result = vzip_f32(a1, b1);
+      r_.neon_f32 = vcombine_f32(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 2, 6, 3, 7);
+    #else
+      r_.f32[0] = a_.f32[2];
+      r_.f32[1] = b_.f32[2];
+      r_.f32[2] = a_.f32[3];
+      r_.f32[3] = b_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpackhi_ps(a, b) simde_mm_unpackhi_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_unpacklo_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_unpacklo_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vzip1q_f32(a_.neon_f32, b_.neon_f32);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 0, 4, 1, 5);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x2_t a1 = vget_low_f32(a_.neon_f32);
+      float32x2_t b1 = vget_low_f32(b_.neon_f32);
+      float32x2x2_t result = vzip_f32(a1, b1);
+      r_.neon_f32 = vcombine_f32(result.val[0], result.val[1]);
+    #else
+      r_.f32[0] = a_.f32[0];
+      r_.f32[1] = b_.f32[0];
+      r_.f32[2] = a_.f32[1];
+      r_.f32[3] = b_.f32[1];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_unpacklo_ps(a, b) simde_mm_unpacklo_ps((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_pi (simde__m64* mem_addr, simde__m64 a) {
+  #if defined(SIMDE_X86_SSE_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    _mm_stream_pi(HEDLEY_REINTERPRET_CAST(__m64*, mem_addr), a);
+  #else
+    simde__m64_private*
+      dest = HEDLEY_REINTERPRET_CAST(simde__m64_private*, mem_addr),
+      a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      dest->i64[0] = vget_lane_s64(a_.neon_i64, 0);
+    #else
+      dest->i64[0] = a_.i64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_stream_pi(mem_addr, a) simde_mm_stream_pi(mem_addr, (a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_ps (simde_float32 mem_addr[4], simde__m128 a) {
+  simde_assert_aligned(16, mem_addr);
+
+#if defined(SIMDE_X86_SSE_NATIVE)
+  _mm_stream_ps(mem_addr, a);
+#else
+  simde__m128_private a_ = simde__m128_to_private(a);
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  vst1q_f32(SIMDE_ASSUME_ALIGNED(16, mem_addr), a_.neon_f32);
+#else
+  simde_memcpy(SIMDE_ASSUME_ALIGNED(16, mem_addr), &a_, sizeof(a_));
+#endif
+#endif
+}
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _mm_stream_ps(mem_addr, a) simde_mm_stream_ps(SIMDE_CHECKED_REINTERPRET_CAST(float*, simde_float32*, mem_addr), (a))
+#endif
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
+  do {                                                  \
+        float32x4x2_t ROW01 = vtrnq_f32(row0, row1);      \
+        float32x4x2_t ROW23 = vtrnq_f32(row2, row3);      \
+        row0 = vcombine_f32(vget_low_f32(ROW01.val[0]),   \
+                            vget_low_f32(ROW23.val[0]));  \
+        row1 = vcombine_f32(vget_low_f32(ROW01.val[1]),   \
+                            vget_low_f32(ROW23.val[1]));  \
+        row2 = vcombine_f32(vget_high_f32(ROW01.val[0]),  \
+                            vget_high_f32(ROW23.val[0])); \
+        row3 = vcombine_f32(vget_high_f32(ROW01.val[1]),  \
+                            vget_high_f32(ROW23.val[1])); \
+    } while (0)
+#else
+#define SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
+  do { \
+    simde__m128 tmp3, tmp2, tmp1, tmp0; \
+    tmp0 = simde_mm_unpacklo_ps((row0), (row1)); \
+    tmp2 = simde_mm_unpacklo_ps((row2), (row3)); \
+    tmp1 = simde_mm_unpackhi_ps((row0), (row1)); \
+    tmp3 = simde_mm_unpackhi_ps((row2), (row3)); \
+    row0 = simde_mm_movelh_ps(tmp0, tmp2); \
+    row1 = simde_mm_movehl_ps(tmp2, tmp0); \
+    row2 = simde_mm_movelh_ps(tmp1, tmp3); \
+    row3 = simde_mm_movehl_ps(tmp3, tmp1); \
+  } while (0)
+#endif
+#if defined(SIMDE_X86_SSE_ENABLE_NATIVE_ALIASES)
+#  define _MM_TRANSPOSE4_PS(row0, row1, row2, row3) SIMDE_MM_TRANSPOSE4_PS(row0, row1, row2, row3)
+#endif
+
+#if defined(_MM_EXCEPT_INVALID)
+#  define SIMDE_MM_EXCEPT_INVALID _MM_EXCEPT_INVALID
+#else
+#  define SIMDE_MM_EXCEPT_INVALID (0x0001)
+#endif
+#if defined(_MM_EXCEPT_DENORM)
+#  define SIMDE_MM_EXCEPT_DENORM _MM_EXCEPT_DENORM
+#else
+#  define SIMDE_MM_EXCEPT_DENORM (0x0002)
+#endif
+#if defined(_MM_EXCEPT_DIV_ZERO)
+#  define SIMDE_MM_EXCEPT_DIV_ZERO _MM_EXCEPT_DIV_ZERO
+#else
+#  define SIMDE_MM_EXCEPT_DIV_ZERO (0x0004)
+#endif
+#if defined(_MM_EXCEPT_OVERFLOW)
+#  define SIMDE_MM_EXCEPT_OVERFLOW _MM_EXCEPT_OVERFLOW
+#else
+#  define SIMDE_MM_EXCEPT_OVERFLOW (0x0008)
+#endif
+#if defined(_MM_EXCEPT_UNDERFLOW)
+#  define SIMDE_MM_EXCEPT_UNDERFLOW _MM_EXCEPT_UNDERFLOW
+#else
+#  define SIMDE_MM_EXCEPT_UNDERFLOW (0x0010)
+#endif
+#if defined(_MM_EXCEPT_INEXACT)
+#  define SIMDE_MM_EXCEPT_INEXACT _MM_EXCEPT_INEXACT
+#else
+#  define SIMDE_MM_EXCEPT_INEXACT (0x0020)
+#endif
+#if defined(_MM_EXCEPT_MASK)
+#  define SIMDE_MM_EXCEPT_MASK _MM_EXCEPT_MASK
+#else
+#  define SIMDE_MM_EXCEPT_MASK \
+     (SIMDE_MM_EXCEPT_INVALID | SIMDE_MM_EXCEPT_DENORM | \
+      SIMDE_MM_EXCEPT_DIV_ZERO | SIMDE_MM_EXCEPT_OVERFLOW | \
+      SIMDE_MM_EXCEPT_UNDERFLOW | SIMDE_MM_EXCEPT_INEXACT)
+#endif
+
+#if defined(_MM_MASK_INVALID)
+#  define SIMDE_MM_MASK_INVALID _MM_MASK_INVALID
+#else
+#  define SIMDE_MM_MASK_INVALID (0x0080)
+#endif
+#if defined(_MM_MASK_DENORM)
+#  define SIMDE_MM_MASK_DENORM _MM_MASK_DENORM
+#else
+#  define SIMDE_MM_MASK_DENORM (0x0100)
+#endif
+#if defined(_MM_MASK_DIV_ZERO)
+#  define SIMDE_MM_MASK_DIV_ZERO _MM_MASK_DIV_ZERO
+#else
+#  define SIMDE_MM_MASK_DIV_ZERO (0x0200)
+#endif
+#if defined(_MM_MASK_OVERFLOW)
+#  define SIMDE_MM_MASK_OVERFLOW _MM_MASK_OVERFLOW
+#else
+#  define SIMDE_MM_MASK_OVERFLOW (0x0400)
+#endif
+#if defined(_MM_MASK_UNDERFLOW)
+#  define SIMDE_MM_MASK_UNDERFLOW _MM_MASK_UNDERFLOW
+#else
+#  define SIMDE_MM_MASK_UNDERFLOW (0x0800)
+#endif
+#if defined(_MM_MASK_INEXACT)
+#  define SIMDE_MM_MASK_INEXACT _MM_MASK_INEXACT
+#else
+#  define SIMDE_MM_MASK_INEXACT (0x1000)
+#endif
+#if defined(_MM_MASK_MASK)
+#  define SIMDE_MM_MASK_MASK _MM_MASK_MASK
+#else
+#  define SIMDE_MM_MASK_MASK \
+     (SIMDE_MM_MASK_INVALID | SIMDE_MM_MASK_DENORM | \
+      SIMDE_MM_MASK_DIV_ZERO | SIMDE_MM_MASK_OVERFLOW | \
+      SIMDE_MM_MASK_UNDERFLOW | SIMDE_MM_MASK_INEXACT)
+#endif
+
+#if defined(_MM_FLUSH_ZERO_MASK)
+#  define SIMDE_MM_FLUSH_ZERO_MASK _MM_FLUSH_ZERO_MASK
+#else
+#  define SIMDE_MM_FLUSH_ZERO_MASK (0x8000)
+#endif
+#if defined(_MM_FLUSH_ZERO_ON)
+#  define SIMDE_MM_FLUSH_ZERO_ON _MM_FLUSH_ZERO_ON
+#else
+#  define SIMDE_MM_FLUSH_ZERO_ON (0x8000)
+#endif
+#if defined(_MM_FLUSH_ZERO_OFF)
+#  define SIMDE_MM_FLUSH_ZERO_OFF _MM_FLUSH_ZERO_OFF
+#else
+#  define SIMDE_MM_FLUSH_ZERO_OFF (0x0000)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE_H) */

--- a/2.0/simde/x86/sse2.h
+++ b/2.0/simde/x86/sse2.h
@@ -1,0 +1,7089 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ *   2015-2017 John W. Ratcliff <jratcliffscarab@gmail.com>
+ *   2015      Brandon Rowlett <browlett@nvidia.com>
+ *   2015      Ken Fast <kfast@gdeb.com>
+ *   2017      Hasindu Gamaarachchi <hasindu@unsw.edu.au>
+ *   2018      Jeff Daily <jeff.daily@amd.com>
+ */
+
+#if !defined(SIMDE_X86_SSE2_H)
+#define SIMDE_X86_SSE2_H
+
+#include "sse.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(16) int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(16) simde_int128  i128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) simde_uint128 u128 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    #endif
+    SIMDE_ALIGN(16) simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+
+    SIMDE_ALIGN(16) int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(16) int8_t         i8[16];
+    SIMDE_ALIGN(16) int16_t        i16[8];
+    SIMDE_ALIGN(16) int32_t        i32[4];
+    SIMDE_ALIGN(16) int64_t        i64[2];
+    SIMDE_ALIGN(16) uint8_t        u8[16];
+    SIMDE_ALIGN(16) uint16_t       u16[8];
+    SIMDE_ALIGN(16) uint32_t       u32[4];
+    SIMDE_ALIGN(16) uint64_t       u64[2];
+    #if defined(SIMDE_HAVE_INT128_)
+    SIMDE_ALIGN(16) simde_int128  i128[1];
+    SIMDE_ALIGN(16) simde_uint128 u128[1];
+    #endif
+    SIMDE_ALIGN(16) simde_float32  f32[4];
+    SIMDE_ALIGN(16) simde_float64  f64[2];
+
+    SIMDE_ALIGN(16) int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(16) uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+  #endif
+
+    SIMDE_ALIGN(16) simde__m64_private m64_private[2];
+    SIMDE_ALIGN(16) simde__m64         m64[2];
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    SIMDE_ALIGN(16) __m128i        n;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_ALIGN(16) int8x16_t      neon_i8;
+    SIMDE_ALIGN(16) int16x8_t      neon_i16;
+    SIMDE_ALIGN(16) int32x4_t      neon_i32;
+    SIMDE_ALIGN(16) int64x2_t      neon_i64;
+    SIMDE_ALIGN(16) uint8x16_t     neon_u8;
+    SIMDE_ALIGN(16) uint16x8_t     neon_u16;
+    SIMDE_ALIGN(16) uint32x4_t     neon_u32;
+    SIMDE_ALIGN(16) uint64x2_t     neon_u64;
+    SIMDE_ALIGN(16) float32x4_t    neon_f32;
+    #if defined(SIMDE_ARCH_AARCH64)
+    SIMDE_ALIGN(16) float64x2_t    neon_f64;
+    #endif
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_ALIGN(16) v128_t         wasm_v128;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
+    #if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
+    #else
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
+    #endif
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
+    #if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+    #else
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
+    #endif
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
+    #endif
+  #endif
+} simde__m128i_private;
+
+typedef union {
+  #if defined(SIMDE_VECTOR_SUBSCRIPT)
+    SIMDE_ALIGN(16) int8_t          i8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int16_t        i16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int32_t        i32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int64_t        i64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint8_t         u8 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint16_t       u16 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint32_t       u32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint64_t       u64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) simde_float32  f32 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) simde_float64  f64 SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) int_fast32_t  i32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+    SIMDE_ALIGN(16) uint_fast32_t u32f SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  #else
+    SIMDE_ALIGN(16) int8_t         i8[16];
+    SIMDE_ALIGN(16) int16_t        i16[8];
+    SIMDE_ALIGN(16) int32_t        i32[4];
+    SIMDE_ALIGN(16) int64_t        i64[2];
+    SIMDE_ALIGN(16) uint8_t        u8[16];
+    SIMDE_ALIGN(16) uint16_t       u16[8];
+    SIMDE_ALIGN(16) uint32_t       u32[4];
+    SIMDE_ALIGN(16) uint64_t       u64[2];
+    SIMDE_ALIGN(16) simde_float32  f32[4];
+    SIMDE_ALIGN(16) simde_float64  f64[2];
+    SIMDE_ALIGN(16) int_fast32_t  i32f[16 / sizeof(int_fast32_t)];
+    SIMDE_ALIGN(16) uint_fast32_t u32f[16 / sizeof(uint_fast32_t)];
+  #endif
+
+    SIMDE_ALIGN(16) simde__m64_private m64_private[2];
+    SIMDE_ALIGN(16) simde__m64         m64[2];
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    SIMDE_ALIGN(16) __m128d        n;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    SIMDE_ALIGN(16) int8x16_t      neon_i8;
+    SIMDE_ALIGN(16) int16x8_t      neon_i16;
+    SIMDE_ALIGN(16) int32x4_t      neon_i32;
+    SIMDE_ALIGN(16) int64x2_t      neon_i64;
+    SIMDE_ALIGN(16) uint8x16_t     neon_u8;
+    SIMDE_ALIGN(16) uint16x8_t     neon_u16;
+    SIMDE_ALIGN(16) uint32x4_t     neon_u32;
+    SIMDE_ALIGN(16) uint64x2_t     neon_u64;
+    SIMDE_ALIGN(16) float32x4_t    neon_f32;
+    #if defined(SIMDE_ARCH_AARCH64)
+    SIMDE_ALIGN(16) float64x2_t    neon_f64;
+    #endif
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    SIMDE_ALIGN(16) v128_t         wasm_v128;
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed char)          altivec_i8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed short)         altivec_i16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32;
+    #if defined(__INT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__INT_FAST32_TYPE__)  altivec_i32f;
+    #else
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed int)           altivec_i32f;
+    #endif
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned char)        altivec_u8;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned short)       altivec_u16;
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32;
+    #if defined(__UINT_FAST32_TYPE__) && defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(__UINT_FAST32_TYPE__) altivec_u32f;
+    #else
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned int)         altivec_u32f;
+    #endif
+    SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(float)                altivec_f32;
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(signed long long)   altivec_i64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) altivec_u64;
+      SIMDE_ALIGN(16) SIMDE_POWER_ALTIVEC_VECTOR(double)             altivec_f64;
+    #endif
+  #endif
+} simde__m128d_private;
+
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  typedef __m128i simde__m128i;
+  typedef __m128d simde__m128d;
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+   typedef int64x2_t simde__m128i;
+#  if defined(SIMDE_ARCH_AARCH64)
+     typedef float64x2_t simde__m128d;
+#  elif defined(SIMDE_VECTOR_SUBSCRIPT)
+     typedef simde_float64 simde__m128d SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#  else
+     typedef simde__m128d_private simde__m128d;
+#  endif
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+   typedef v128_t simde__m128i;
+   typedef v128_t simde__m128d;
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  typedef SIMDE_POWER_ALTIVEC_VECTOR(float) simde__m128i;
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+     typedef SIMDE_POWER_ALTIVEC_VECTOR(double) simde__m128d;
+  #else
+     typedef simde__m128d_private simde__m128d;
+  #endif
+#elif defined(SIMDE_VECTOR_SUBSCRIPT)
+  typedef int64_t simde__m128i SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+  typedef simde_float64 simde__m128d SIMDE_ALIGN(16) SIMDE_VECTOR(16) SIMDE_MAY_ALIAS;
+#else
+  typedef simde__m128i_private simde__m128i;
+  typedef simde__m128d_private simde__m128d;
+#endif
+
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  typedef simde__m128i __m128i;
+  typedef simde__m128d __m128d;
+#endif
+
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i), "simde__m128i size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128i_private), "simde__m128i_private size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d), "simde__m128d size incorrect");
+HEDLEY_STATIC_ASSERT(16 == sizeof(simde__m128d_private), "simde__m128d_private size incorrect");
+#if defined(SIMDE_CHECK_ALIGNMENT) && defined(SIMDE_ALIGN_OF)
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i) == 16, "simde__m128i is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128i_private) == 16, "simde__m128i_private is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d) == 16, "simde__m128d is not 16-byte aligned");
+HEDLEY_STATIC_ASSERT(SIMDE_ALIGN_OF(simde__m128d_private) == 16, "simde__m128d_private is not 16-byte aligned");
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde__m128i_from_private(simde__m128i_private v) {
+  simde__m128i r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i_private
+simde__m128i_to_private(simde__m128i v) {
+  simde__m128i_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde__m128d_from_private(simde__m128d_private v) {
+  simde__m128d r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d_private
+simde__m128d_to_private(simde__m128d v) {
+  simde__m128d_private r;
+  simde_memcpy(&r, &v, sizeof(r));
+  return r;
+}
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int8x16_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int16x8_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int32x4_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, int64x2_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint8x16_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint16x8_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint32x4_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, uint64x2_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float32x4_t, neon, f32)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, float64x2_t, neon, f64)
+  #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128i, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+  #endif
+#endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
+
+#if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int8x16_t, neon, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int16x8_t, neon, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int32x4_t, neon, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, int64x2_t, neon, i64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint8x16_t, neon, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint16x8_t, neon, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint32x4_t, neon, u32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, uint64x2_t, neon, u64)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float32x4_t, neon, f32)
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, float64x2_t, neon, f64)
+  #endif
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed char), altivec, i8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed short), altivec, i16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed int), altivec, i32)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), altivec, u8)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned short), altivec, u16)
+  SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), altivec, u32)
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), altivec, u64)
+    SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(signed long long), altivec, i64)
+    #if defined(SIMDE_BUG_GCC_95782)
+      SIMDE_FUNCTION_ATTRIBUTES
+      SIMDE_POWER_ALTIVEC_VECTOR(double)
+      simde__m128d_to_altivec_f64(simde__m128d value) {
+        simde__m128d_private r_ = simde__m128d_to_private(value);
+        return r_.altivec_f64;
+      }
+
+      SIMDE_FUNCTION_ATTRIBUTES
+      simde__m128d
+      simde__m128d_from_altivec_f64(SIMDE_POWER_ALTIVEC_VECTOR(double) value) {
+        simde__m128d_private r_;
+        r_.altivec_f64 = value;
+        return simde__m128d_from_private(r_);
+      }
+    #else
+      SIMDE_X86_GENERATE_CONVERSION_FUNCTION(m128d, SIMDE_POWER_ALTIVEC_VECTOR(double), altivec, f64)
+    #endif
+  #endif
+#endif /* defined(SIMDE_ARM_NEON_A32V7_NATIVE) */
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_set_pd (simde_float64 e1, simde_float64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_pd(e1, e0);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_make(e0, e1);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      SIMDE_ALIGN(16) simde_float64 data[2] = { e0, e1 };
+      r_.neon_f64 = vld1q_f64(data);
+    #else
+      r_.f64[0] = e0;
+      r_.f64[1] = e1;
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_pd(e1, e0) simde_mm_set_pd(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_set1_pd (simde_float64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_pd(a);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_splat(a);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vdupq_n_f64(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_f64 = vec_splats(HEDLEY_STATIC_CAST(double, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.f64[i] = a;
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#define simde_mm_set_pd1(a) simde_mm_set1_pd(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_pd(a) simde_mm_set1_pd(a)
+  #define _mm_set_pd1(a) simde_mm_set1_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_abs_pd(simde__m128d a) {
+  #if defined(SIMDE_X86_AVX512F_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(7,4,0))
+    return _mm512_castpd512_pd128(_mm512_abs_pd(_mm512_castpd128_pd512(a)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V8_NATIVE)
+      r_.neon_f32 = vabsq_f32(a_.neon_f32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f32 = vec_abs(a_.altivec_f32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_fabs(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_not_pd(simde__m128d a) {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+  #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    r_.altivec_f64 = vec_nor(a_.altivec_f64, a_.altivec_f64);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i32f = ~a_.i32f;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+      r_.i32f[i] = ~(a_.i32f[i]);
+    }
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_select_pd(simde__m128d a, simde__m128d b, simde__m128d mask) {
+  /* This function is for when you want to blend two elements together
+   * according to a mask.  It is similar to _mm_blendv_pd, except that
+   * it is undefined whether the blend is based on the highest bit in
+   * each lane (like blendv) or just bitwise operations.  This allows
+   * us to implement the function efficiently everywhere.
+   *
+   * Basically, you promise that all the lanes in mask are either 0 or
+   * ~0. */
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_pd(a, b, mask);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b),
+      mask_ = simde__m128d_to_private(mask);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 ^ ((a_.i64 ^ b_.i64) & mask_.i64);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] ^ ((a_.i64[i] ^ b_.i64[i]) & mask_.i64[i]);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_add_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vaddq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_add(a_.altivec_i8, b_.altivec_i8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 + b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] + b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_epi8(a, b) simde_mm_add_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_add_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vaddq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_add(a_.altivec_i16, b_.altivec_i16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 + b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] + b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_epi16(a, b) simde_mm_add_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_add_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vaddq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_add(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 + b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] + b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_epi32(a, b) simde_mm_add_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_add_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vaddq_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i64 = vec_add(a_.altivec_i64, b_.altivec_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 + b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] + b_.i64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_epi64(a, b) simde_mm_add_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_add_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vaddq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_add(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_add(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 + b_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] + b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_pd(a, b) simde_mm_add_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_move_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_move_sd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane_f64(b_.neon_f64, 0), a_.neon_f64, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) m = {
+        16, 17, 18, 19, 20, 21, 22, 23,
+         8,  9, 10, 11, 12, 13, 14, 15
+      };
+      r_.altivec_f64 = vec_perm(a_.altivec_f64, b_.altivec_f64, m);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 2, 1);
+    #else
+      r_.f64[0] = b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_move_sd(a, b) simde_mm_move_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_add_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_add_sd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.f64[0] = a_.f64[0] + b_.f64[0];
+    r_.f64[1] = a_.f64[1];
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0)
+      return simde_mm_move_sd(a, simde_mm_add_pd(a, b));
+    #else
+        r_.f64[0] = a_.f64[0] + b_.f64[0];
+        r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_sd(a, b) simde_mm_add_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_add_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_add_si64(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vadd_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0] + b_.i64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_add_si64(a, b) simde_mm_add_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_adds_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqaddq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_add_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_adds(a_.altivec_i8, b_.altivec_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        const int_fast16_t tmp =
+          HEDLEY_STATIC_CAST(int_fast16_t, a_.i8[i]) +
+          HEDLEY_STATIC_CAST(int_fast16_t, b_.i8[i]);
+        r_.i8[i] = HEDLEY_STATIC_CAST(int8_t, ((tmp < INT8_MAX) ? ((tmp > INT8_MIN) ? tmp : INT8_MIN) : INT8_MAX));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_adds_epi8(a, b) simde_mm_adds_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_adds_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqaddq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_add_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_adds(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int_fast32_t tmp =
+          HEDLEY_STATIC_CAST(int_fast32_t, a_.i16[i]) +
+          HEDLEY_STATIC_CAST(int_fast32_t, b_.i16[i]);
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, ((tmp < INT16_MAX) ? ((tmp > INT16_MIN) ? tmp : INT16_MIN) : INT16_MAX));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_adds_epi16(a, b) simde_mm_adds_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_adds_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqaddq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_add_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_adds(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = ((UINT8_MAX - a_.u8[i]) > b_.u8[i]) ? (a_.u8[i] + b_.u8[i]) : UINT8_MAX;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_adds_epu8(a, b) simde_mm_adds_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_adds_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_adds_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqaddq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_add_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_adds(a_.altivec_u16, b_.altivec_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = ((UINT16_MAX - a_.u16[i]) > b_.u16[i]) ? (a_.u16[i] + b_.u16[i]) : UINT16_MAX;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_adds_epu16(a, b) simde_mm_adds_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_and_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_and(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_and(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_and_pd(a, b) simde_mm_and_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_and_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_and_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vandq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u32f = vec_and(a_.altivec_u32f, b_.altivec_u32f);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_and_si128(a, b) simde_mm_and_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_andnot_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_andnot(b_.wasm_v128, a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_andc(b_.altivec_f64, a_.altivec_f64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32f = vec_andc(b_.altivec_i32f, a_.altivec_i32f);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = ~a_.u64[i] & b_.u64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_andnot_pd(a, b) simde_mm_andnot_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_andnot_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_andnot_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vbicq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_andc(b_.altivec_i32, a_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = ~a_.i32f & b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = ~(a_.i32f[i]) & b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_andnot_si128(a, b) simde_mm_andnot_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_xor_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_xor(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = veorq_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_xor_pd(a, b) simde_mm_xor_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_avg_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_avg_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vrhaddq_u8(b_.neon_u8, a_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_avgr(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_avg(a_.altivec_u8, b_.altivec_u8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint16_t wa SIMDE_VECTOR(32);
+      uint16_t wb SIMDE_VECTOR(32);
+      uint16_t wr SIMDE_VECTOR(32);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u8);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u8);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u8, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] + b_.u8[i] + 1) >> 1;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_avg_epu8(a, b) simde_mm_avg_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_avg_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_avg_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vrhaddq_u16(b_.neon_u16, a_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_avgr(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_avg(a_.altivec_u16, b_.altivec_u16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && defined(SIMDE_CONVERT_VECTOR_)
+      uint32_t wa SIMDE_VECTOR(32);
+      uint32_t wb SIMDE_VECTOR(32);
+      uint32_t wr SIMDE_VECTOR(32);
+      SIMDE_CONVERT_VECTOR_(wa, a_.u16);
+      SIMDE_CONVERT_VECTOR_(wb, b_.u16);
+      wr = (wa + wb + 1) >> 1;
+      SIMDE_CONVERT_VECTOR_(r_.u16, wr);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = (a_.u16[i] + b_.u16[i] + 1) >> 1;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_avg_epu16(a, b) simde_mm_avg_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setzero_si128 (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setzero_si128();
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vdupq_n_s32(0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, 0));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT)
+      r_.i32 = __extension__ (__typeof__(r_.i32)) { 0, 0, 0, 0 };
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = 0;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setzero_si128() (simde_mm_setzero_si128())
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_bslli_si128 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+    return simde_mm_setzero_si128();
+  }
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+    r_.altivec_i8 =
+    #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      vec_slo
+    #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+      vec_sro
+    #endif
+        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+  #elif defined(SIMDE_HAVE_INT128_) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE) && 0
+    r_.u128[0] = a_.u128[0] << s;
+  #else
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+    for (int i = imm8 ; i < HEDLEY_STATIC_CAST(int, sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      r_.i8[i] = a_.i8[i - imm8];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+  #define simde_mm_bslli_si128(a, imm8) _mm_slli_si128(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_mm_bslli_si128(a, imm8) \
+  simde__m128i_from_neon_i8(((imm8) <= 0) ? simde__m128i_to_neon_i8(a) : (((imm8) > 15) ? (vdupq_n_s8(0)) : (vextq_s8(vdupq_n_s8(0), simde__m128i_to_neon_i8(a), 16 - (imm8)))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_bslli_si128(a, imm8) (__extension__ ({ \
+    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    simde__m128i_private simde__tmp_r_; \
+    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
+      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    } else { \
+      simde__tmp_r_.i8 = \
+        SIMDE_SHUFFLE_VECTOR_(8, 16, \
+          simde__tmp_z_.i8, \
+          (simde__tmp_a_).i8, \
+          HEDLEY_STATIC_CAST(int8_t, (16 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (17 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (18 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (19 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (20 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (21 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (22 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (23 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (24 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (25 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (26 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (27 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (28 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (29 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (30 - imm8) & 31), \
+          HEDLEY_STATIC_CAST(int8_t, (31 - imm8) & 31)); \
+    } \
+    simde__m128i_from_private(simde__tmp_r_); }))
+#endif
+#define simde_mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_bslli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+  #define _mm_slli_si128(a, imm8) simde_mm_bslli_si128(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_bsrli_si128 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  if (HEDLEY_UNLIKELY((imm8 & ~15))) {
+    return simde_mm_setzero_si128();
+  }
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE) && defined(SIMDE_ENDIAN_ORDER)
+    r_.altivec_i8 =
+    #if (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      vec_sro
+    #else /* SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG */
+      vec_slo
+    #endif
+        (a_.altivec_i8, vec_splats(HEDLEY_STATIC_CAST(unsigned char, imm8 * 8)));
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+      const int e = HEDLEY_STATIC_CAST(int, i) + imm8;
+      r_.i8[i] = (e < 16) ? a_.i8[e] : 0;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+  #define simde_mm_bsrli_si128(a, imm8) _mm_srli_si128(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) && !defined(__clang__)
+  #define simde_mm_bsrli_si128(a, imm8) \
+  simde__m128i_from_neon_i8(((imm8 < 0) || (imm8 > 15)) ? vdupq_n_s8(0) : (vextq_s8(simde__m128i_to_private(a).neon_i8, vdupq_n_s8(0), ((imm8 & 15) != 0) ? imm8 : (imm8 & 15))))
+#elif defined(SIMDE_SHUFFLE_VECTOR_) && !defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+  #define simde_mm_bsrli_si128(a, imm8) (__extension__ ({ \
+    const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+    const simde__m128i_private simde__tmp_z_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    simde__m128i_private simde__tmp_r_ = simde__m128i_to_private(a); \
+    if (HEDLEY_UNLIKELY(imm8 > 15)) { \
+      simde__tmp_r_ = simde__m128i_to_private(simde_mm_setzero_si128()); \
+    } else { \
+      simde__tmp_r_.i8 = \
+      SIMDE_SHUFFLE_VECTOR_(8, 16, \
+        simde__tmp_z_.i8, \
+        (simde__tmp_a_).i8, \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 16) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 17) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 18) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 19) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 20) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 21) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 22) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 23) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 24) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 25) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 26) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 27) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 28) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 29) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 30) & 31), \
+        HEDLEY_STATIC_CAST(int8_t, (imm8 + 31) & 31)); \
+    } \
+    simde__m128i_from_private(simde__tmp_r_); }))
+#endif
+#define simde_mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_bsrli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+  #define _mm_srli_si128(a, imm8) simde_mm_bsrli_si128((a), (imm8))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_clflush (void const* p) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_clflush(p);
+  #else
+    (void) p;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_clflush(a, b) simde_mm_clflush()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comieq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comieq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] == b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comieq_sd(a, b) simde_mm_comieq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comige_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comige_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcgeq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] >= b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comige_sd(a, b) simde_mm_comige_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comigt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comigt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcgtq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] > b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comigt_sd(a, b) simde_mm_comigt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comile_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comile_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcleq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] <= b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comile_sd(a, b) simde_mm_comile_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comilt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comilt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !!vgetq_lane_u64(vcltq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] < b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comilt_sd(a, b) simde_mm_comilt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_comineq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_comineq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return !vgetq_lane_u64(vceqq_f64(a_.neon_f64, b_.neon_f64), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #else
+      return a_.f64[0] != b_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_comineq_sd(a, b) simde_mm_comineq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_copysign_pd(simde__m128d dest, simde__m128d src) {
+  simde__m128d_private
+    r_,
+    dest_ = simde__m128d_to_private(dest),
+    src_ = simde__m128d_to_private(src);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t sign_pos = vreinterpretq_u64_f64(vdupq_n_f64(-SIMDE_FLOAT64_C(0.0)));
+    #else
+      simde_float64 dbl_nz = -SIMDE_FLOAT64_C(0.0);
+      uint64_t u64_nz;
+      simde_memcpy(&u64_nz, &dbl_nz, sizeof(u64_nz));
+      uint64x2_t sign_pos = vdupq_n_u64(u64_nz);
+    #endif
+    r_.neon_u64 = vbslq_u64(sign_pos, src_.neon_u64, dest_.neon_u64);
+  #elif defined(SIMDE_POWER_ALTIVEC_P9_NATIVE)
+    #if !defined(HEDLEY_IBM_VERSION)
+      r_.altivec_f64 = vec_cpsgn(dest_.altivec_f64, src_.altivec_f64);
+    #else
+      r_.altivec_f64 = vec_cpsgn(src_.altivec_f64, dest_.altivec_f64);
+    #endif
+  #elif defined(simde_math_copysign)
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_copysign(dest_.f64[i], src_.f64[i]);
+    }
+  #else
+    simde__m128d sgnbit = simde_mm_set1_pd(-SIMDE_FLOAT64_C(0.0));
+    return simde_mm_xor_pd(simde_mm_and_pd(sgnbit, src), simde_mm_andnot_pd(sgnbit, dest));
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_xorsign_pd(simde__m128d dest, simde__m128d src) {
+  return simde_mm_xor_pd(simde_mm_and_pd(simde_mm_set1_pd(-0.0), src), dest);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_castpd_ps (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_ps(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f32_f64(a);
+  #else
+    simde__m128 r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castpd_ps(a) simde_mm_castpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_castpd_si128 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castpd_si128(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_s64_f64(a);
+  #else
+    simde__m128i r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castpd_si128(a) simde_mm_castpd_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_castps_pd (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_pd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_f32(a);
+  #else
+    simde__m128d r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castps_pd(a) simde_mm_castps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_castps_si128 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castps_si128(a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde__m128i_from_neon_i32(simde__m128_to_private(a).neon_i32);
+  #else
+    simde__m128i r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castps_si128(a) simde_mm_castps_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_castsi128_pd (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castsi128_pd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vreinterpretq_f64_s64(a);
+  #else
+    simde__m128d r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castsi128_pd(a) simde_mm_castsi128_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_castsi128_ps (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_castsi128_ps(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    return HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(float), a);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return simde__m128_from_neon_i32(simde__m128i_to_private(a).neon_i32);
+  #else
+    simde__m128 r;
+    simde_memcpy(&r, &a, sizeof(a));
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_castsi128_ps(a) simde_mm_castsi128_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vceqq_s8(b_.neon_i8, a_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpeq(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 == b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] == b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi8(a, b) simde_mm_cmpeq_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vceqq_s16(b_.neon_i16, a_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpeq(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = (a_.i16 == b_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] == b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi16(a, b) simde_mm_cmpeq_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vceqq_s32(b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpeq(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), a_.i32 == b_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] == b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_epi32(a, b) simde_mm_cmpeq_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpeq_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vceqq_s64(b_.neon_i64, a_.neon_i64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_eq(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpeq(a_.altivec_f64, b_.altivec_f64));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 == b_.f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] == b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_pd(a, b) simde_mm_cmpeq_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpeq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpeq_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpeq_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.u64[0] == b_.u64[0]) ? ~UINT64_C(0) : 0;
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpeq_sd(a, b) simde_mm_cmpeq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpneq_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpneq_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vmvnq_u16(vceqq_s16(b_.neon_i16, a_.neon_i16));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_ne(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 != b_.f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] != b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpneq_pd(a, b) simde_mm_cmpneq_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpneq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpneq_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpneq_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] != b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpneq_sd(a, b) simde_mm_cmpneq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcltq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char),vec_cmplt(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 < b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] < b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi8(a, b) simde_mm_cmplt_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vcltq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmplt(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 < b_.i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi16(a, b) simde_mm_cmplt_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmplt_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcltq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmplt(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_lt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 < b_.i32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] < b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_epi32(a, b) simde_mm_cmplt_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmplt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 < b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcltq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_lt(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] < b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_pd(a, b) simde_mm_cmplt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmplt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmplt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmplt_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] < b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmplt_sd(a, b) simde_mm_cmplt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmple_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmple_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 <= b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcleq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_le(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmple(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] <= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmple_pd(a, b) simde_mm_cmple_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmple_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmple_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmple_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] <= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmple_sd(a, b) simde_mm_cmple_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcgtq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmpgt(a_.altivec_i8, b_.altivec_i8));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = HEDLEY_STATIC_CAST(__typeof__(r_.i8), (a_.i8 > b_.i8));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (a_.i8[i] > b_.i8[i]) ? ~INT8_C(0) : INT8_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi8(a, b) simde_mm_cmpgt_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vcgtq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed short), vec_cmpgt(a_.altivec_i16, b_.altivec_i16));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = HEDLEY_STATIC_CAST(__typeof__(r_.i16), (a_.i16 > b_.i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? ~INT16_C(0) : INT16_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi16(a, b) simde_mm_cmpgt_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vcgtq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed int), vec_cmpgt(a_.altivec_i32, b_.altivec_i32));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = HEDLEY_STATIC_CAST(__typeof__(r_.i32), (a_.i32 > b_.i32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (a_.i32[i] > b_.i32[i]) ? ~INT32_C(0) : INT32_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_epi32(a, b) simde_mm_cmpgt_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpgt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpgt_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 > b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_gt(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpgt(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] > b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_pd(a, b) simde_mm_cmpgt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpgt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpgt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpgt_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] > b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpgt_sd(a, b) simde_mm_cmpgt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpge_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpge_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), (a_.f64 >= b_.f64));
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_ge(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_f64 = HEDLEY_STATIC_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_cmpge(a_.altivec_f64, b_.altivec_f64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (a_.f64[i] >= b_.f64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpge_pd(a, b) simde_mm_cmpge_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpge_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpge_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpge_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.u64[0] = (a_.f64[0] >= b_.f64[0]) ? ~UINT64_C(0) : UINT64_C(0);
+    r_.u64[1] = a_.u64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpge_sd(a, b) simde_mm_cmpge_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnge_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnge_pd(a, b);
+  #else
+    return simde_mm_cmplt_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnge_pd(a, b) simde_mm_cmpnge_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnge_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cmpnge_sd(a, b);
+  #else
+    return simde_mm_cmplt_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnge_sd(a, b) simde_mm_cmpnge_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnlt_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnlt_pd(a, b);
+  #else
+    return simde_mm_cmpge_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnlt_pd(a, b) simde_mm_cmpnlt_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnlt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnlt_sd(a, b);
+  #else
+    return simde_mm_cmpge_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnlt_sd(a, b) simde_mm_cmpnlt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnle_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnle_pd(a, b);
+  #else
+    return simde_mm_cmpgt_pd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnle_pd(a, b) simde_mm_cmpnle_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpnle_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpnle_sd(a, b);
+  #else
+    return simde_mm_cmpgt_sd(a, b);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpnle_sd(a, b) simde_mm_cmpnle_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpord_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpord_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      /* Note: NEON does not have ordered compare builtin
+        Need to compare a eq a and b eq b to check for NaN
+        Do AND of results to get final */
+      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      r_.neon_u64 = vandq_u64(ceqaa, ceqbb);
+    #elif defined(simde_math_isnan)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (!simde_math_isnan(a_.f64[i]) && !simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpord_pd(a, b) simde_mm_cmpord_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde_float64
+simde_mm_cvtsd_f64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_cvtsd_f64(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return a_.f64[0];
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_f64(a) simde_mm_cvtsd_f64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpord_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpord_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpord_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_isnan)
+      r_.u64[0] = (!simde_math_isnan(a_.f64[0]) && !simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+      r_.u64[1] = a_.u64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpord_sd(a, b) simde_mm_cmpord_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpunord_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpunord_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t ceqaa = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t ceqbb = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      r_.neon_u64 = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(ceqaa, ceqbb))));
+    #elif defined(simde_math_isnan)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.u64[i] = (simde_math_isnan(a_.f64[i]) || simde_math_isnan(b_.f64[i])) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpunord_pd(a, b) simde_mm_cmpunord_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cmpunord_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cmpunord_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_cmpunord_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_isnan)
+      r_.u64[0] = (simde_math_isnan(a_.f64[0]) || simde_math_isnan(b_.f64[0])) ? ~UINT64_C(0) : UINT64_C(0);
+      r_.u64[1] = a_.u64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cmpunord_sd(a, b) simde_mm_cmpunord_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtepi32_pd (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtepi32_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (simde_float64) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtepi32_pd(a) simde_mm_cvtepi32_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtepi32_ps (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtepi32_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vcvtq_f32_s32(a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f32x4_convert_i32x4(a_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      #if HEDLEY_HAS_WARNING("-Wc11-extensions")
+        #pragma clang diagnostic ignored "-Wc11-extensions"
+      #endif
+      r_.altivec_f32 = vec_ctf(a_.altivec_i32, 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f32, a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = (simde_float32) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtepi32_ps(a) simde_mm_cvtepi32_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtpd_epi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+      r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, simde_math_nearbyint(a_.f64[i]));
+    }
+    simde_memset(&(r_.m64_private[1]), 0, sizeof(r_.m64_private[1]));
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_epi32(a) simde_mm_cvtpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvtpd_pi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpd_pi32(a);
+  #else
+    simde__m64_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, simde_math_nearbyint(a_.f64[i]));
+    }
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_pi32(a) simde_mm_cvtpd_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtpd_ps (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtpd_ps(a);
+  #else
+    simde__m128_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.m64_private[0].f32, a_.f64);
+      r_.m64_private[1] = simde__m64_to_private(simde_mm_setzero_si64());
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vreinterpretq_f32_f64(vcombine_f64(vreinterpret_f64_f32(vcvtx_f32_f64(a_.neon_f64)), vdup_n_f64(0)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+        r_.f32[i] = (simde_float32) a_.f64[i];
+      }
+      simde_memset(&(r_.m64_private[1]), 0, sizeof(r_.m64_private[1]));
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpd_ps(a) simde_mm_cvtpd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtpi32_pd (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvtpi32_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (simde_float64) a_.i32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtpi32_pd(a) simde_mm_cvtpi32_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtps_epi32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtps_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* The default rounding mode on SSE is 'round to even', which ArmV7
+        does not support!  It is supported on ARMv8 however. */
+      #if defined(SIMDE_ARCH_AARCH64)
+        r_.neon_i32 = vcvtnq_s32_f32(a_.neon_f32);
+      #else
+        uint32x4_t signmask = vdupq_n_u32(0x80000000);
+        float32x4_t half = vbslq_f32(signmask, a_.neon_f32, vdupq_n_f32(0.5f)); /* +/- 0.5 */
+        int32x4_t r_normal = vcvtq_s32_f32(vaddq_f32(a_.neon_f32, half)); /* round to integer: [a + 0.5]*/
+        int32x4_t r_trunc = vcvtq_s32_f32(a_.neon_f32); /* truncate to integer: [a] */
+        int32x4_t plusone = vshrq_n_s32(vnegq_s32(r_trunc), 31); /* 1 or 0 */
+        int32x4_t r_even = vbicq_s32(vaddq_s32(r_trunc, plusone), vdupq_n_s32(1)); /* ([a] + {0,1}) & ~1 */
+        float32x4_t delta = vsubq_f32(a_.neon_f32, vcvtq_f32_s32(r_trunc)); /* compute delta: delta = (a - [a]) */
+        uint32x4_t is_delta_half = vceqq_f32(delta, half); /* delta == +/- 0.5 */
+        r_.neon_i32 = vbslq_s32(is_delta_half, r_even, r_normal);
+      #endif
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_C11_EXTENSIONS_
+      SIMDE_DIAGNOSTIC_DISABLE_VECTOR_CONVERSION_
+      r_.altivec_i32 = vec_cts(vec_round(a_.altivec_f32), 0);
+      HEDLEY_DIAGNOSTIC_POP
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = HEDLEY_STATIC_CAST(int32_t, simde_math_roundf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtps_epi32(a) simde_mm_cvtps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtps_pd (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtps_pd(a);
+  #else
+    simde__m128d_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.f64, a_.m64_private[0].f32);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcvt_f64_f32(vget_low_f32(a_.neon_f32));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f32[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtps_pd(a) simde_mm_cvtps_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtsd_si32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsd_si32(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int32_t, simde_math_round(a_.f64[0]));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_si32(a) simde_mm_cvtsd_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtsd_si64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if defined(__PGI)
+      return _mm_cvtsd_si64x(a);
+    #else
+      return _mm_cvtsd_si64(a);
+    #endif
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int64_t, simde_math_round(a_.f64[0]));
+  #endif
+}
+#define simde_mm_cvtsd_si64x(a) simde_mm_cvtsd_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_si64(a) simde_mm_cvtsd_si64(a)
+  #define _mm_cvtsd_si64x(a) simde_mm_cvtsd_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cvtsd_ss (simde__m128 a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsd_ss(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+    simde__m128d_private b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f32 = vsetq_lane_f32(vcvtxd_f32_f64(vgetq_lane_f64(b_.neon_f64, 0)), a_.neon_f32, 0);
+    #else
+      r_.f32[0] = HEDLEY_STATIC_CAST(simde_float32, b_.f64[0]);
+
+      SIMDE_VECTORIZE
+      for (size_t i = 1 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i];
+      }
+    #endif
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsd_ss(a, b) simde_mm_cvtsd_ss(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvtsi128_si32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi128_si32(a);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return vgetq_lane_s32(a_.neon_i32, 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_i32x4_extract_lane(a_.wasm_v128, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      #if defined(SIMDE_BUG_GCC_95227)
+        (void) a_;
+      #endif
+      return vec_extract(a_.altivec_i32, 0);
+    #else
+      return a_.i32[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi128_si32(a) simde_mm_cvtsi128_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvtsi128_si64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if defined(__PGI)
+      return _mm_cvtsi128_si64x(a);
+    #else
+      return _mm_cvtsi128_si64(a);
+    #endif
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && !defined(HEDLEY_IBM_VERSION)
+    return vec_extract(HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), a_.i64), 0);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vgetq_lane_s64(a_.neon_i64, 0);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    return wasm_i64x2_extract_lane(a_.wasm_v128, 0);
+  #endif
+    return a_.i64[0];
+  #endif
+}
+#define simde_mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi128_si64(a) simde_mm_cvtsi128_si64(a)
+  #define _mm_cvtsi128_si64x(a) simde_mm_cvtsi128_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtsi32_sd (simde__m128d a, int32_t b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi32_sd(a, b);
+  #else
+    simde__m128d_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE) && defined(SIMDE_ARCH_AMD64)
+      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
+    #else
+      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+      r_.i64[1] = a_.i64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi32_sd(a, b) simde_mm_cvtsi32_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsi32_si128 (int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtsi32_si128(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vsetq_lane_s32(a, vdupq_n_s32(0), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_make(a, 0, 0, 0);
+    #else
+      r_.i32[0] = a;
+      r_.i32[1] = 0;
+      r_.i32[2] = 0;
+      r_.i32[3] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi32_si128(a) simde_mm_cvtsi32_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtsi64_sd (simde__m128d a, int64_t b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtsi64_sd(a, b);
+    #else
+      return _mm_cvtsi64x_sd(a, b);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(HEDLEY_STATIC_CAST(float64_t, b), a_.neon_f64, 0);
+    #else
+      r_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b);
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#define simde_mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64_sd(a, b)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi64_sd(a, b) simde_mm_cvtsi64_sd(a, b)
+  #define _mm_cvtsi64x_sd(a, b) simde_mm_cvtsi64x_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtsi64_si128 (int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvtsi64_si128(a);
+    #else
+      return _mm_cvtsi64x_si128(a);
+    #endif
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsetq_lane_s64(a, vdupq_n_s64(0), 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_make(a, 0);
+    #else
+      r_.i64[0] = a;
+      r_.i64[1] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_cvtsi64x_si128(a) simde_mm_cvtsi64_si128(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtsi64_si128(a) simde_mm_cvtsi64_si128(a)
+  #define _mm_cvtsi64x_si128(a) simde_mm_cvtsi64x_si128(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cvtss_sd (simde__m128d a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvtss_sd(a, b);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    float64x2_t temp = vcvt_f64_f32(vset_lane_f32(vgetq_lane_f32(simde__m128_to_private(b).neon_f32, 0), vdup_n_f32(0), 0));
+    return vsetq_lane_f64(vgetq_lane_f64(simde__m128d_to_private(a).neon_f64, 1), temp, 1);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a);
+    simde__m128_private b_ = simde__m128_to_private(b);
+
+    a_.f64[0] = HEDLEY_STATIC_CAST(simde_float64, b_.f32[0]);
+
+    return simde__m128d_from_private(a_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvtss_sd(a, b) simde_mm_cvtss_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvttpd_epi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttpd_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    for (size_t i = 0 ; i < (sizeof(a_.f64) / sizeof(a_.f64[0])) ; i++) {
+      r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, a_.f64[i]);
+    }
+    simde_memset(&(r_.m64_private[1]), 0, sizeof(r_.m64_private[1]));
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttpd_epi32(a) simde_mm_cvttpd_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_cvttpd_pi32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_cvttpd_pi32(a);
+  #else
+    simde__m64_private r_;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f64);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, a_.f64[i]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttpd_pi32(a) simde_mm_cvttpd_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvttps_epi32 (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttps_epi32(a);
+  #else
+    simde__m128i_private r_;
+    simde__m128_private a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vcvtq_s32_f32(a_.neon_f32);
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.f32);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = SIMDE_CONVERT_FTOI(int32_t, a_.f32[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttps_epi32(a) simde_mm_cvttps_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_cvttsd_si32 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_cvttsd_si32(a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int32_t, a_.f64[0]);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttsd_si32(a) simde_mm_cvttsd_si32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_cvttsd_si64 (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    #if !defined(__PGI)
+      return _mm_cvttsd_si64(a);
+    #else
+      return _mm_cvttsd_si64x(a);
+    #endif
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+    return SIMDE_CONVERT_FTOI(int64_t, a_.f64[0]);
+  #endif
+}
+#define simde_mm_cvttsd_si64x(a) simde_mm_cvttsd_si64(a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_cvttsd_si64(a) simde_mm_cvttsd_si64(a)
+  #define _mm_cvttsd_si64x(a) simde_mm_cvttsd_si64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_div_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 / b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vdivq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 =  wasm_f64x2_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] / b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_div_pd(a, b) simde_mm_div_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_div_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_div_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vdivq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = a_.f64[0] / b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_div_sd(a, b) simde_mm_div_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_extract_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7)  {
+  uint16_t r;
+  simde__m128i_private a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+      (void) imm8;
+    #endif
+    r = HEDLEY_STATIC_CAST(uint16_t, vec_extract(a_.altivec_i16, imm8));
+  #else
+    r = a_.u16[imm8 & 7];
+  #endif
+
+  return  HEDLEY_STATIC_CAST(int32_t, r);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(4,6,0))
+  #define simde_mm_extract_epi16(a, imm8) _mm_extract_epi16(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_extract_epi16(a, imm8) (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_s16(simde__m128i_to_private(a).neon_i16, (imm8))) & (INT32_C(0x0000ffff)))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_extract_epi16(a, imm8) simde_mm_extract_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_insert_epi16 (simde__m128i a, int16_t i, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7)  {
+  simde__m128i_private a_ = simde__m128i_to_private(a);
+  a_.i16[imm8 & 7] = i;
+  return simde__m128i_from_private(a_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+  #define simde_mm_insert_epi16(a, i, imm8) _mm_insert_epi16((a), (i), (imm8))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_insert_epi16(a, i, imm8) simde__m128i_from_neon_i16(vsetq_lane_s16((i), simde__m128i_to_neon_i16(a), (imm8)))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_insert_epi16(a, i, imm8) simde_mm_insert_epi16(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_load_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_pd(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vld1q_f64(mem_addr);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vld1q_u32(HEDLEY_REINTERPRET_CAST(uint32_t const*, mem_addr));
+    #else
+      r_ = *SIMDE_ALIGN_CAST(simde__m128d_private const*, mem_addr);
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_pd(mem_addr) simde_mm_load_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_load_pd1 (simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load1_pd(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vld1q_dup_f64(mem_addr);
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.f64[1] = *mem_addr;
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#define simde_mm_load1_pd(mem_addr) simde_mm_load_pd1(mem_addr)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_pd1(mem_addr) simde_mm_load_pd1(mem_addr)
+  #define _mm_load1_pd(mem_addr) simde_mm_load1_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_load_sd (simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_sd(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0);
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.u64[1] = UINT64_C(0);
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_sd(mem_addr) simde_mm_load_sd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_load_si128 (simde__m128i const* mem_addr) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_load_si128(HEDLEY_REINTERPRET_CAST(__m128i const*, mem_addr));
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE) || defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_ld(0, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(int) const*, mem_addr));
+    #else
+      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #else
+    return *mem_addr;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_load_si128(mem_addr) simde_mm_load_si128(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_loadh_pd (simde__m128d a, simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadh_pd(a, mem_addr);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcombine_f64(vget_low_f64(a_.neon_f64), vld1_f64(HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)));
+    #else
+      simde_float64 t;
+
+      simde_memcpy(&t, mem_addr, sizeof(t));
+      r_.f64[0] = a_.f64[0];
+      r_.f64[1] = t;
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadh_pd(a, mem_addr) simde_mm_loadh_pd(a, mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadl_epi64 (simde__m128i const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadl_epi64(mem_addr);
+  #else
+    simde__m128i_private r_;
+
+    int64_t value;
+    simde_memcpy(&value, mem_addr, sizeof(value));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(vld1_s64(HEDLEY_REINTERPRET_CAST(int64_t const *, mem_addr)), vdup_n_s64(0));
+    #else
+      r_.i64[0] = value;
+      r_.i64[1] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadl_epi64(mem_addr) simde_mm_loadl_epi64(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_loadl_pd (simde__m128d a, simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadl_pd(a, mem_addr);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vcombine_f64(vld1_f64(
+        HEDLEY_REINTERPRET_CAST(const float64_t*, mem_addr)), vget_high_f64(a_.neon_f64));
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.u64[1] = a_.u64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadl_pd(a, mem_addr) simde_mm_loadl_pd(a, mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_loadr_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadr_pd(mem_addr);
+  #else
+    simde__m128d_private
+      r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = simde_mm_load_pd(mem_addr);
+      r_.neon_f64 = vcombine_f64(vget_high_f64(temp), vget_low_f64(temp));
+    #else
+      r_.f64[0] = mem_addr[1];
+      r_.f64[1] = mem_addr[0];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadr_pd(mem_addr) simde_mm_loadr_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_loadu_pd (simde_float64 const mem_addr[HEDLEY_ARRAY_PARAM(2)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_pd(mem_addr);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vld1q_f64(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    simde_memcpy(&r_, mem_addr, sizeof(r_));
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadu_pd(mem_addr) simde_mm_loadu_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_loadu_epi8(int8_t const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(simde__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vld1q_s8(HEDLEY_REINTERPRET_CAST(int8_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_loadu_epi16(int16_t const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(simde__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vld1q_s16(HEDLEY_REINTERPRET_CAST(int16_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_loadu_epi32(int32_t const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(simde__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_loadu_epi64(int64_t const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(SIMDE_ALIGN_CAST(simde__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vld1q_s64(HEDLEY_REINTERPRET_CAST(int64_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_loadu_si128 (void const* mem_addr) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_loadu_si128(HEDLEY_STATIC_CAST(__m128i const*, mem_addr));
+  #else
+    simde__m128i_private r_;
+
+    #if HEDLEY_GNUC_HAS_ATTRIBUTE(may_alias,3,3,0)
+      HEDLEY_DIAGNOSTIC_PUSH
+      SIMDE_DIAGNOSTIC_DISABLE_PACKED_
+      struct simde_mm_loadu_si128_s {
+        __typeof__(r_) v;
+      } __attribute__((__packed__, __may_alias__));
+      r_ = HEDLEY_REINTERPRET_CAST(const struct simde_mm_loadu_si128_s *, mem_addr)->v;
+      HEDLEY_DIAGNOSTIC_POP
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* Note that this is a lower priority than the struct above since
+       * clang assumes mem_addr is aligned (since it is a __m128i*). */
+      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_loadu_si128(mem_addr) simde_mm_loadu_si128(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_madd_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_madd_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x4_t pl = vmull_s16(vget_low_s16(a_.neon_i16),  vget_low_s16(b_.neon_i16));
+      int32x4_t ph = vmull_s16(vget_high_s16(a_.neon_i16), vget_high_s16(b_.neon_i16));
+      int32x2_t rl = vpadd_s32(vget_low_s32(pl), vget_high_s32(pl));
+      int32x2_t rh = vpadd_s32(vget_low_s32(ph), vget_high_s32(ph));
+      r_.neon_i32 = vcombine_s32(rl, rh);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i += 2) {
+        r_.i32[i / 2] = (a_.i16[i] * b_.i16[i]) + (a_.i16[i + 1] * b_.i16[i + 1]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_madd_epi16(a, b) simde_mm_madd_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_maskmoveu_si128 (simde__m128i a, simde__m128i mask, int8_t mem_addr[HEDLEY_ARRAY_PARAM(16)]) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_maskmoveu_si128(a, mask, HEDLEY_REINTERPRET_CAST(char*, mem_addr));
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      mask_ = simde__m128i_to_private(mask);
+
+    for (size_t i = 0 ; i < (sizeof(a_.i8) / sizeof(a_.i8[0])) ; i++) {
+      if (mask_.u8[i] & 0x80) {
+        mem_addr[i] = a_.i8[i];
+      }
+    }
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_maskmoveu_si128(a, mask, mem_addr) simde_mm_maskmoveu_si128((a), (mask), SIMDE_CHECKED_REINTERPRET_CAST(int8_t*, char*, (mem_addr)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_movemask_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__INTEL_COMPILER)
+    /* ICC has trouble with _mm_movemask_epi8 at -O2 and above: */
+    return _mm_movemask_epi8(a);
+  #else
+    int32_t r = 0;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint8x16_t input = a_.neon_u8;
+      const int8_t xr[16] = {-7, -6, -5, -4, -3, -2, -1, 0, -7, -6, -5, -4, -3, -2, -1, 0};
+      const uint8x16_t mask_and = vdupq_n_u8(0x80);
+      const int8x16_t mask_shift = vld1q_s8(xr);
+      const uint8x16_t mask_result =
+        vshlq_u8(vandq_u8(input, mask_and), mask_shift);
+      uint8x8_t lo = vget_low_u8(mask_result);
+      uint8x8_t hi = vget_high_u8(mask_result);
+      r = vaddv_u8(lo) + (vaddv_u8(hi) << 8);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Use increasingly wide shifts+adds to collect the sign bits
+      // together.
+      // Since the widening shifts would be rather confusing to follow in little endian, everything
+      // will be illustrated in big endian order instead. This has a different result - the bits
+      // would actually be reversed on a big endian machine.
+
+      // Starting input (only half the elements are shown):
+      // 89 ff 1d c0 00 10 99 33
+      uint8x16_t input = a_.neon_u8;
+
+      // Shift out everything but the sign bits with an unsigned shift right.
+      //
+      // Bytes of the vector::
+      // 89 ff 1d c0 00 10 99 33
+      // \  \  \  \  \  \  \  \    high_bits = (uint16x4_t)(input >> 7)
+      //  |  |  |  |  |  |  |  |
+      // 01 01 00 01 00 00 01 00
+      //
+      // Bits of first important lane(s):
+      // 10001001 (89)
+      // \______
+      //        |
+      // 00000001 (01)
+      uint16x8_t high_bits = vreinterpretq_u16_u8(vshrq_n_u8(input, 7));
+
+      // Merge the even lanes together with a 16-bit unsigned shift right + add.
+      // 'xx' represents garbage data which will be ignored in the final result.
+      // In the important bytes, the add functions like a binary OR.
+      //
+      // 01 01 00 01 00 00 01 00
+      //  \_ |  \_ |  \_ |  \_ |   paired16 = (uint32x4_t)(input + (input >> 7))
+      //    \|    \|    \|    \|
+      // xx 03 xx 01 xx 00 xx 02
+      //
+      // 00000001 00000001 (01 01)
+      //        \_______ |
+      //                \|
+      // xxxxxxxx xxxxxx11 (xx 03)
+      uint32x4_t paired16 = vreinterpretq_u32_u16(vsraq_n_u16(high_bits, high_bits, 7));
+
+      // Repeat with a wider 32-bit shift + add.
+      // xx 03 xx 01 xx 00 xx 02
+      //     \____ |     \____ |  paired32 = (uint64x1_t)(paired16 + (paired16 >> 14))
+      //          \|          \|
+      // xx xx xx 0d xx xx xx 02
+      //
+      // 00000011 00000001 (03 01)
+      //        \\_____ ||
+      //         '----.\||
+      // xxxxxxxx xxxx1101 (xx 0d)
+      uint64x2_t paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
+
+      // Last, an even wider 64-bit shift + add to get our result in the low 8 bit lanes.
+      // xx xx xx 0d xx xx xx 02
+      //            \_________ |   paired64 = (uint8x8_t)(paired32 + (paired32 >> 28))
+      //                      \|
+      // xx xx xx xx xx xx xx d2
+      //
+      // 00001101 00000010 (0d 02)
+      //     \   \___ |  |
+      //      '---.  \|  |
+      // xxxxxxxx 11010010 (xx d2)
+      uint8x16_t paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
+
+      // Extract the low 8 bits from each 64-bit lane with 2 8-bit extracts.
+      // xx xx xx xx xx xx xx d2
+      //                      ||  return paired64[0]
+      //                      d2
+      // Note: Little endian would return the correct value 4b (01001011) instead.
+      r = vgetq_lane_u8(paired64, 0) | (HEDLEY_STATIC_CAST(int32_t, vgetq_lane_u8(paired64, 8)) << 8);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_LITTLE)
+      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 1));
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && !defined(HEDLEY_IBM_VERSION) && (SIMDE_ENDIAN_ORDER == SIMDE_ENDIAN_BIG)
+      static const SIMDE_POWER_ALTIVEC_VECTOR(unsigned char) perm = { 120, 112, 104, 96, 88, 80, 72, 64, 56, 48, 40, 32, 24, 16, 8, 0 };
+      r = HEDLEY_STATIC_CAST(int32_t, vec_extract(vec_vbpermq(a_.altivec_u8, perm), 14));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u8) / sizeof(a_.u8[0])) ; i++) {
+        r |= (a_.u8[15 - i] >> 7) << (15 - i);
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_movemask_epi8(a) simde_mm_movemask_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_movemask_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_movemask_pd(a);
+  #else
+    int32_t r = 0;
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      static const int64_t shift_amount[] = { 0, 1 };
+      const int64x2_t shift = vld1q_s64(shift_amount);
+      uint64x2_t tmp = vshrq_n_u64(a_.neon_u64, 63);
+      return HEDLEY_STATIC_CAST(int32_t, vaddvq_u64(vshlq_u64(tmp, shift)));
+    #else
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        r |= (a_.u64[i] >> 63) << i;
+      }
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_movemask_pd(a) simde_mm_movemask_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_movepi64_pi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movepi64_pi64(a);
+  #else
+    simde__m64_private r_;
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i64 = vget_low_s64(a_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_movepi64_pi64(a) simde_mm_movepi64_pi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_movpi64_epi64 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_movpi64_epi64(a);
+  #else
+    simde__m128i_private r_;
+    simde__m64_private a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(a_.neon_i64, vdup_n_s64(0));
+    #else
+      r_.i64[0] = a_.i64[0];
+      r_.i64[1] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_movpi64_epi64(a) simde_mm_movpi64_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vminq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_min(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_min(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] < b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_min_epi16(a, b) simde_mm_min_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vminq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_min(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_min(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] < b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_min_epu8(a, b) simde_mm_min_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_min_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_f64 = vec_min(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vminq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] < b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_min_pd(a, b) simde_mm_min_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_min_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_min_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_min_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vminq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = (a_.f64[0] < b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_min_sd(a, b) simde_mm_min_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmaxq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_max(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (a_.i16[i] > b_.i16[i]) ? a_.i16[i] : b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_max_epi16(a, b) simde_mm_max_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vmaxq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_max(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = (a_.u8[i] > b_.u8[i]) ? a_.u8[i] : b_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_max_epu8(a, b) simde_mm_max_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_max_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      r_.altivec_f64 = vec_max(a_.altivec_f64, b_.altivec_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = (a_.f64[i] > b_.f64[i]) ? a_.f64[i] : b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_max_pd(a, b) simde_mm_max_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_max_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_max_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_max_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vmaxq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = (a_.f64[0] > b_.f64[0]) ? a_.f64[0] : b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_max_sd(a, b) simde_mm_max_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_move_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_move_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsetq_lane_s64(0, a_.neon_i64, 1);
+    #else
+      r_.i64[0] = a_.i64[0];
+      r_.i64[1] = 0;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_move_epi64(a) simde_mm_move_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mul_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x2_t a_lo = vmovn_u64(a_.neon_u64);
+      uint32x2_t b_lo = vmovn_u64(b_.neon_u64);
+      r_.neon_u64 = vmull_u32(a_lo, b_lo);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[i * 2]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[i * 2]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mul_epu32(a, b) simde_mm_mul_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_mul_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i64 = a_.i64 * b_.i64;
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] * b_.i64[i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_mod_epi64 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i64 = a_.i64 % b_.i64;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] % b_.i64[i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mul_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 * b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmulq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_mul(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] * b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mul_pd(a, b) simde_mm_mul_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_mul_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mul_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_mul_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t temp = vmulq_f64(a_.neon_f64, b_.neon_f64);
+      r_.neon_f64 = vsetq_lane_f64(vgetq_lane(a_.neon_f64, 1), temp, 1);
+    #else
+      r_.f64[0] = a_.f64[0] * b_.f64[0];
+      r_.f64[1] = a_.f64[1];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mul_sd(a, b) simde_mm_mul_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_mul_su32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE) && !defined(__PGI)
+    return _mm_mul_su32(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    r_.u64[0] = HEDLEY_STATIC_CAST(uint64_t, a_.u32[0]) * HEDLEY_STATIC_CAST(uint64_t, b_.u32[0]);
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mul_su32(a, b) simde_mm_mul_su32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mulhi_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mulhi_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a3210 = vget_low_s16(a_.neon_i16);
+      int16x4_t b3210 = vget_low_s16(b_.neon_i16);
+      int32x4_t ab3210 = vmull_s16(a3210, b3210); /* 3333222211110000 */
+      int16x4_t a7654 = vget_high_s16(a_.neon_i16);
+      int16x4_t b7654 = vget_high_s16(b_.neon_i16);
+      int32x4_t ab7654 = vmull_s16(a7654, b7654); /* 7777666655554444 */
+      uint16x8x2_t rv = vuzpq_u16(vreinterpretq_u16_s32(ab3210), vreinterpretq_u16_s32(ab7654));
+      r_.neon_u16 = rv.val[1];
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (HEDLEY_STATIC_CAST(uint32_t, HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) >> 16));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mulhi_epi16(a, b) simde_mm_mulhi_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mulhi_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+    return _mm_mulhi_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x4_t a3210 = vget_low_u16(a_.neon_u16);
+      uint16x4_t b3210 = vget_low_u16(b_.neon_u16);
+      uint32x4_t ab3210 = vmull_u16(a3210, b3210); /* 3333222211110000 */
+      uint16x4_t a7654 = vget_high_u16(a_.neon_u16);
+      uint16x4_t b7654 = vget_high_u16(b_.neon_u16);
+      uint32x4_t ab7654 = vmull_u16(a7654, b7654); /* 7777666655554444 */
+      uint16x8x2_t neon_r =
+              vuzpq_u16(vreinterpretq_u16_u32(ab3210), vreinterpretq_u16_u32(ab7654));
+      r_.neon_u16 = neon_r.val[1];
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]) >> 16);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mulhi_epu16(a, b) simde_mm_mulhi_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mullo_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_mullo_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vmulq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      (void) a_;
+      (void) b_;
+      r_.altivec_i16 = vec_mul(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, HEDLEY_STATIC_CAST(uint32_t, a_.u16[i]) * HEDLEY_STATIC_CAST(uint32_t, b_.u16[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mullo_epi16(a, b) simde_mm_mullo_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_or_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v128_or(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vorrq_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_or_pd(a, b) simde_mm_or_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_or_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_or_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vorrq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_or(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f | b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] | b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_or_si128(a, b) simde_mm_or_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_packs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vcombine_s8(vqmovn_s16(a_.neon_i16), vqmovn_s16(b_.neon_i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i8[i]     = (a_.i16[i] > INT8_MAX) ? INT8_MAX : ((a_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, a_.i16[i]));
+        r_.i8[i + 8] = (b_.i16[i] > INT8_MAX) ? INT8_MAX : ((b_.i16[i] < INT8_MIN) ? INT8_MIN : HEDLEY_STATIC_CAST(int8_t, b_.i16[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_packs_epi16(a, b) simde_mm_packs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_packs_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packs_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vcombine_s16(vqmovn_s32(a_.neon_i32), vqmovn_s32(b_.neon_i32));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_packs(a_.altivec_i32, b_.altivec_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i16[i]     = (a_.i32[i] > INT16_MAX) ? INT16_MAX : ((a_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, a_.i32[i]));
+        r_.i16[i + 4] = (b_.i32[i] > INT16_MAX) ? INT16_MAX : ((b_.i32[i] < INT16_MIN) ? INT16_MIN : HEDLEY_STATIC_CAST(int16_t, b_.i32[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_packs_epi32(a, b) simde_mm_packs_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_packus_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_packus_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vcombine_u8(vqmovun_s16(a_.neon_i16), vqmovun_s16(b_.neon_i16));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_packsu(a_.altivec_i16, b_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u8[i]     = (a_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((a_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, a_.i16[i]));
+        r_.u8[i + 8] = (b_.i16[i] > UINT8_MAX) ? UINT8_MAX : ((b_.i16[i] < 0) ? UINT8_C(0) : HEDLEY_STATIC_CAST(uint8_t, b_.i16[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_packus_epi16(a, b) simde_mm_packus_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_pause (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_pause();
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_pause() (simde_mm_pause())
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sad_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sad_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x8_t t = vpaddlq_u8(vabdq_u8(a_.neon_u8, b_.neon_u8));
+      uint16_t r0 = t[0] + t[1] + t[2] + t[3];
+      uint16_t r4 = t[4] + t[5] + t[6] + t[7];
+      uint16x8_t r = vsetq_lane_u16(r0, vdupq_n_u16(0), 0);
+      r_.neon_u16 = vsetq_lane_u16(r4, r, 4);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        uint16_t tmp = 0;
+        SIMDE_VECTORIZE_REDUCTION(+:tmp)
+        for (size_t j = 0 ; j < ((sizeof(r_.u8) / sizeof(r_.u8[0])) / 2) ; j++) {
+          const size_t e = j + (i * 8);
+          tmp += (a_.u8[e] > b_.u8[e]) ? (a_.u8[e] - b_.u8[e]) : (b_.u8[e] - a_.u8[e]);
+        }
+        r_.i64[i] = tmp;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sad_epu8(a, b) simde_mm_sad_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+       int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+       int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
+       int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi8(
+      e15, e14, e13, e12, e11, e10,  e9,  e8,
+       e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_make(
+         e0,  e1,  e2,  e3,  e4,  e5,  e6,  e7,
+         e8,  e9, e10, e11, e12, e13, e14, e15);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, int8x16_t) int8_t data[16] = {
+        e0,  e1,  e2,  e3,
+        e4,  e5,  e6,  e7,
+        e8,  e9,  e10, e11,
+        e12, e13, e14, e15};
+      r_.neon_i8 = vld1q_s8(data);
+    #else
+      r_.i8[ 0] =  e0;
+      r_.i8[ 1] =  e1;
+      r_.i8[ 2] =  e2;
+      r_.i8[ 3] =  e3;
+      r_.i8[ 4] =  e4;
+      r_.i8[ 5] =  e5;
+      r_.i8[ 6] =  e6;
+      r_.i8[ 7] =  e7;
+      r_.i8[ 8] =  e8;
+      r_.i8[ 9] =  e9;
+      r_.i8[10] = e10;
+      r_.i8[11] = e11;
+      r_.i8[12] = e12;
+      r_.i8[13] = e13;
+      r_.i8[14] = e14;
+      r_.i8[15] = e15;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi8(e15, e14, e13, e12, e11, e10,  e9,  e8,  e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+        int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi16(e7, e6, e5, e4, e3, e2, e1, e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, int16x8_t) int16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+      r_.neon_i16 = vld1q_s16(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_make(e0, e1, e2, e3, e4, e5, e6, e7);
+    #else
+      r_.i16[0] = e0;
+      r_.i16[1] = e1;
+      r_.i16[2] = e2;
+      r_.i16[3] = e3;
+      r_.i16[4] = e4;
+      r_.i16[5] = e5;
+      r_.i16[6] = e6;
+      r_.i16[7] = e7;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0) simde_mm_set_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi32(e3, e2, e1, e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, int32x4_t) int32_t data[4] = { e0, e1, e2, e3 };
+      r_.neon_i32 = vld1q_s32(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_make(e0, e1, e2, e3);
+    #else
+      r_.i32[0] = e0;
+      r_.i32[1] = e1;
+      r_.i32[2] = e2;
+      r_.i32[3] = e3;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_epi32(e3,  e2,  e1,  e0) simde_mm_set_epi32(e3,  e2,  e1,  e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set_epi64 (simde__m64 e1, simde__m64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set_epi64(e1, e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vcombine_s64(simde__m64_to_neon_i64(e0), simde__m64_to_neon_i64(e1));
+    #else
+      r_.m64[0] = e0;
+      r_.m64[1] = e1;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_epi64(e1, e0) (simde_mm_set_epi64((e1), (e0)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set_epi64x (int64_t e1, int64_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set_epi64x(e1, e0);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, int64x2_t) int64_t data[2] = {e0, e1};
+      r_.neon_i64 = vld1q_s64(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_make(e0, e1);
+    #else
+      r_.i64[0] = e0;
+      r_.i64[1] = e1;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_epi64x(e1, e0) simde_mm_set_epi64x(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu8 (uint8_t e15, uint8_t e14, uint8_t e13, uint8_t e12,
+         uint8_t e11, uint8_t e10, uint8_t  e9, uint8_t  e8,
+         uint8_t  e7, uint8_t  e6, uint8_t  e5, uint8_t  e4,
+         uint8_t  e3, uint8_t  e2, uint8_t  e1, uint8_t  e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi8(
+      HEDLEY_STATIC_CAST(char, e15), HEDLEY_STATIC_CAST(char, e14), HEDLEY_STATIC_CAST(char, e13), HEDLEY_STATIC_CAST(char, e12),
+      HEDLEY_STATIC_CAST(char, e11), HEDLEY_STATIC_CAST(char, e10), HEDLEY_STATIC_CAST(char,  e9), HEDLEY_STATIC_CAST(char,  e8),
+      HEDLEY_STATIC_CAST(char,  e7), HEDLEY_STATIC_CAST(char,  e6), HEDLEY_STATIC_CAST(char,  e5), HEDLEY_STATIC_CAST(char,  e4),
+      HEDLEY_STATIC_CAST(char,  e3), HEDLEY_STATIC_CAST(char,  e2), HEDLEY_STATIC_CAST(char,  e1), HEDLEY_STATIC_CAST(char,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, uint8x16_t) uint8_t data[16] = {
+        e0,  e1,  e2,  e3,
+        e4,  e5,  e6,  e7,
+        e8,  e9,  e10, e11,
+        e12, e13, e14, e15};
+      r_.neon_u8 = vld1q_u8(data);
+    #else
+      r_.u8[ 0] =  e0; r_.u8[ 1] =  e1; r_.u8[ 2] =  e2; r_.u8[ 3] =  e3;
+      r_.u8[ 4] =  e4; r_.u8[ 5] =  e5; r_.u8[ 6] =  e6; r_.u8[ 7] =  e7;
+      r_.u8[ 8] =  e8; r_.u8[ 9] =  e9; r_.u8[10] = e10; r_.u8[11] = e11;
+      r_.u8[12] = e12; r_.u8[13] = e13; r_.u8[14] = e14; r_.u8[15] = e15;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu16 (uint16_t e7, uint16_t e6, uint16_t e5, uint16_t e4,
+          uint16_t e3, uint16_t e2, uint16_t e1, uint16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi16(
+      HEDLEY_STATIC_CAST(short,  e7), HEDLEY_STATIC_CAST(short,  e6), HEDLEY_STATIC_CAST(short,  e5), HEDLEY_STATIC_CAST(short,  e4),
+      HEDLEY_STATIC_CAST(short,  e3), HEDLEY_STATIC_CAST(short,  e2), HEDLEY_STATIC_CAST(short,  e1), HEDLEY_STATIC_CAST(short,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, uint16x8_t) uint16_t data[8] = { e0, e1, e2, e3, e4, e5, e6, e7 };
+      r_.neon_u16 = vld1q_u16(data);
+    #else
+      r_.u16[0] = e0; r_.u16[1] = e1; r_.u16[2] = e2; r_.u16[3] = e3;
+      r_.u16[4] = e4; r_.u16[5] = e5; r_.u16[6] = e6; r_.u16[7] = e7;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu32 (uint32_t e3, uint32_t e2, uint32_t e1, uint32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_epi32(
+      HEDLEY_STATIC_CAST(int,  e3), HEDLEY_STATIC_CAST(int,  e2), HEDLEY_STATIC_CAST(int,  e1), HEDLEY_STATIC_CAST(int,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, uint32x4_t) uint32_t data[4] = { e0, e1, e2, e3 };
+      r_.neon_u32 = vld1q_u32(data);
+    #else
+      r_.u32[0] = e0;
+      r_.u32[1] = e1;
+      r_.u32[2] = e2;
+      r_.u32[3] = e3;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set_epu64x (uint64_t e1, uint64_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set_epi64x(HEDLEY_STATIC_CAST(int64_t,  e1), HEDLEY_STATIC_CAST(int64_t,  e0));
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      SIMDE_ALIGN_AS(16, uint64x2_t) uint64_t data[2] = {e0, e1};
+      r_.neon_u64 = vld1q_u64(data);
+    #else
+      r_.u64[0] = e0;
+      r_.u64[1] = e1;
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_set_sd (simde_float64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set_sd(a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vsetq_lane_f64(a, vdupq_n_f64(SIMDE_FLOAT64_C(0.0)), 0);
+  #else
+    return simde_mm_set_pd(SIMDE_FLOAT64_C(0.0), a);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set_sd(a) simde_mm_set_sd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set1_epi8 (int8_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi8(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vdupq_n_s8(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i8 = vec_splats(HEDLEY_STATIC_CAST(signed char, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_epi8(a) simde_mm_set1_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set1_epi16 (int16_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi16(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vdupq_n_s16(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i16 = vec_splats(HEDLEY_STATIC_CAST(signed short, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_epi16(a) simde_mm_set1_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set1_epi32 (int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_set1_epi32(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vdupq_n_s32(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i32 = vec_splats(HEDLEY_STATIC_CAST(signed int, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_epi32(a) simde_mm_set1_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set1_epi64x (int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && (!defined(HEDLEY_MSVC_VERSION) || HEDLEY_MSVC_VERSION_CHECK(19,0,0))
+    return _mm_set1_epi64x(a);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vmovq_n_s64(a);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_splat(a);
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_i64 = vec_splats(HEDLEY_STATIC_CAST(signed long long, a));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_epi64x(a) simde_mm_set1_epi64x(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_set1_epi64 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_set1_epi64(a);
+  #else
+    simde__m64_private a_ = simde__m64_to_private(a);
+    return simde_mm_set1_epi64x(a_.i64[0]);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_set1_epi64(a) simde_mm_set1_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu8 (uint8_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u8(vec_splats(HEDLEY_STATIC_CAST(unsigned char, value)));
+  #else
+    return simde_mm_set1_epi8(HEDLEY_STATIC_CAST(int8_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu16 (uint16_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u16(vec_splats(HEDLEY_STATIC_CAST(unsigned short, value)));
+  #else
+    return simde_mm_set1_epi16(HEDLEY_STATIC_CAST(int16_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu32 (uint32_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u32(vec_splats(HEDLEY_STATIC_CAST(unsigned int, value)));
+  #else
+    return simde_mm_set1_epi32(HEDLEY_STATIC_CAST(int32_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_set1_epu64 (uint64_t value) {
+  #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+    return simde__m128i_from_altivec_u64(vec_splats(HEDLEY_STATIC_CAST(unsigned long long, value)));
+  #else
+    return simde_mm_set1_epi64x(HEDLEY_STATIC_CAST(int64_t, value));
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi8 (int8_t e15, int8_t e14, int8_t e13, int8_t e12,
+        int8_t e11, int8_t e10, int8_t  e9, int8_t  e8,
+        int8_t  e7, int8_t  e6, int8_t  e5, int8_t  e4,
+        int8_t  e3, int8_t  e2, int8_t  e1, int8_t  e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi8(
+      e15, e14, e13, e12, e11, e10,  e9,    e8,
+      e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm_set_epi8(
+      e0, e1, e2, e3, e4, e5, e6, e7,
+      e8, e9, e10, e11, e12, e13, e14, e15);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi8(e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi16 (int16_t e7, int16_t e6, int16_t e5, int16_t e4,
+         int16_t e3, int16_t e2, int16_t e1, int16_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi16(e7,  e6,  e5,  e4,  e3,  e2,  e1,  e0);
+  #else
+    return simde_mm_set_epi16(e0, e1, e2, e3, e4, e5, e6, e7);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0) simde_mm_setr_epi16(e7, e6, e5, e4, e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi32 (int32_t e3, int32_t e2, int32_t e1, int32_t e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_epi32(e3, e2, e1, e0);
+  #else
+    return simde_mm_set_epi32(e0, e1, e2, e3);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi32(e3, e2, e1, e0) simde_mm_setr_epi32(e3, e2, e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_setr_epi64 (simde__m64 e1, simde__m64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_setr_epi64(e1, e0);
+  #else
+    return simde_mm_set_epi64(e0, e1);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_epi64(e1, e0) (simde_mm_setr_epi64((e1), (e0)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_setr_pd (simde_float64 e1, simde_float64 e0) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setr_pd(e1, e0);
+  #else
+    return simde_mm_set_pd(e0, e1);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setr_pd(e1, e0) simde_mm_setr_pd(e1, e0)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_setzero_pd (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_setzero_pd();
+  #else
+    return simde_mm_castsi128_pd(simde_mm_setzero_si128());
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_setzero_pd() simde_mm_setzero_pd()
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_undefined_pd (void) {
+  simde__m128d_private r_;
+
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+    r_.n = _mm_undefined_pd();
+  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+    r_ = simde__m128d_to_private(simde_mm_setzero_pd());
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_undefined_pd() simde_mm_undefined_pd()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_undefined_si128 (void) {
+  simde__m128i_private r_;
+
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE__HAVE_UNDEFINED128)
+    r_.n = _mm_undefined_si128();
+  #elif !defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+    r_ = simde__m128i_to_private(simde_mm_setzero_si128());
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_undefined_si128() (simde_mm_undefined_si128())
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+HEDLEY_DIAGNOSTIC_POP
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_setone_pd (void) {
+  return simde_mm_castps_pd(simde_x_mm_setone_ps());
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_setone_si128 (void) {
+  return simde_mm_castps_si128(simde_x_mm_setone_ps());
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_shuffle_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+    r_.i32[i] = a_.i32[(imm8 >> (i * 2)) & 3];
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_shuffle_epi32(a, imm8) _mm_shuffle_epi32((a), (imm8))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm_shuffle_epi32(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i32 = \
+        SIMDE_SHUFFLE_VECTOR_(32, 16, \
+          (simde__tmp_a_).i32, \
+          (simde__tmp_a_).i32, \
+          ((imm8)     ) & 3, \
+          ((imm8) >> 2) & 3, \
+          ((imm8) >> 4) & 3, \
+          ((imm8) >> 6) & 3) }); }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_shuffle_epi32(a, imm8) simde_mm_shuffle_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_shuffle_pd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3)  {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  r_.f64[0] = ((imm8 & 1) == 0) ? a_.f64[0] : a_.f64[1];
+  r_.f64[1] = ((imm8 & 2) == 0) ? b_.f64[0] : b_.f64[1];
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE) && !defined(__PGI)
+  #define simde_mm_shuffle_pd(a, b, imm8) _mm_shuffle_pd((a), (b), (imm8))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm_shuffle_pd(a, b, imm8) (__extension__ ({ \
+      simde__m128d_from_private((simde__m128d_private) { .f64 = \
+        SIMDE_SHUFFLE_VECTOR_(64, 16, \
+          simde__m128d_to_private(a).f64, \
+          simde__m128d_to_private(b).f64, \
+          (((imm8)     ) & 1), \
+          (((imm8) >> 1) & 1) + 2) }); }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_shuffle_pd(a, b, imm8) simde_mm_shuffle_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_shufflehi_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i++) {
+    r_.i16[i] = a_.i16[i];
+  }
+  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = a_.i16[((imm8 >> ((i - 4) * 2)) & 3) + 4];
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_shufflehi_epi16(a, imm8) _mm_shufflehi_epi16((a), (imm8))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm_shufflehi_epi16(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 16, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          0, 1, 2, 3, \
+          (((imm8)     ) & 3) + 4, \
+          (((imm8) >> 2) & 3) + 4, \
+          (((imm8) >> 4) & 3) + 4, \
+          (((imm8) >> 6) & 3) + 4) }); }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_shufflehi_epi16(a, imm8) simde_mm_shufflehi_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_shufflelo_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  for (size_t i = 0 ; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2) ; i++) {
+    r_.i16[i] = a_.i16[((imm8 >> (i * 2)) & 3)];
+  }
+  SIMDE_VECTORIZE
+  for (size_t i = ((sizeof(a_.i16) / sizeof(a_.i16[0])) / 2) ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+    r_.i16[i] = a_.i16[i];
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_shufflelo_epi16(a, imm8) _mm_shufflelo_epi16((a), (imm8))
+#elif defined(SIMDE_SHUFFLE_VECTOR_)
+  #define simde_mm_shufflelo_epi16(a, imm8) (__extension__ ({ \
+      const simde__m128i_private simde__tmp_a_ = simde__m128i_to_private(a); \
+      simde__m128i_from_private((simde__m128i_private) { .i16 = \
+        SIMDE_SHUFFLE_VECTOR_(16, 16, \
+          (simde__tmp_a_).i16, \
+          (simde__tmp_a_).i16, \
+          (((imm8)     ) & 3), \
+          (((imm8) >> 2) & 3), \
+          (((imm8) >> 4) & 3), \
+          (((imm8) >> 6) & 3), \
+          4, 5, 6, 7) }); }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_shufflelo_epi16(a, imm8) simde_mm_shufflelo_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sll_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 15)
+      return simde_mm_setzero_si128();
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u16 = (a_.u16 << count_.u64[0]);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, count_.u64[0])));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 16) ? wasm_i16x8_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i16x8_const(0,0,0,0,0,0,0,0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.u16[i] << count_.u64[0]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi16(a, count) simde_mm_sll_epi16((a), (count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sll_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 31)
+      return simde_mm_setzero_si128();
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.u32 = (a_.u32 << count_.u64[0]);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, count_.u64[0])));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = ((wasm_i64x2_extract_lane(count_.wasm_v128, 0) < 32) ? wasm_i32x4_shl(a_.wasm_v128, HEDLEY_STATIC_CAST(int32_t, wasm_i64x2_extract_lane(count_.wasm_v128, 0))) : wasm_i32x4_const(0,0,0,0));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t, (a_.u32[i] << count_.u64[0]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi32(a, count) (simde_mm_sll_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sll_epi64 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sll_epi64(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    if (count_.u64[0] > 63)
+      return simde_mm_setzero_si128();
+
+    const int_fast16_t s = HEDLEY_STATIC_CAST(int_fast16_t, count_.u64[0]);
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, s)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = (s < 64) ? wasm_i64x2_shl(a_.wasm_v128, s) : wasm_i64x2_const(0,0);
+    #else
+      #if !defined(SIMDE_BUG_GCC_94488)
+        SIMDE_VECTORIZE
+      #endif
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] << s;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sll_epi64(a, count) (simde_mm_sll_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sqrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sqrt_pd(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsqrtq_f64(a_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_sqrt(a_.wasm_v128);
+    #elif defined(simde_math_sqrt)
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sqrt(a_.f64[i]);
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sqrt_pd(a) simde_mm_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sqrt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sqrt_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_sqrt_pd(b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_sqrt)
+      r_.f64[0] = simde_math_sqrt(b_.f64[0]);
+      r_.f64[1] = a_.f64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sqrt_sd(a, b) simde_mm_sqrt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 16 ? 16 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vshlq_u16(a_.neon_u16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi16(a, count) (simde_mm_srl_epi16(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 32 ? 32 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vshlq_u32(a_.neon_u32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x4_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi32(a, count) (simde_mm_srl_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srl_epi64 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_srl_epi64(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 64 ? 64 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(HEDLEY_STATIC_CAST(int64_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u64x2_shr(a_.wasm_v128, cnt);
+    #else
+      #if !defined(SIMDE_BUG_GCC_94488)
+        SIMDE_VECTORIZE
+      #endif
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srl_epi64(a, count) (simde_mm_srl_epi64(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srai_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  /* MSVC requires a range of (0, 255). */
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  const int cnt = (imm8 & ~15) ? 15 : imm8;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = a_.i16[i] >> cnt;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srai_epi16(a, imm8) _mm_srai_epi16((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srai_epi16(a, imm8) simde_mm_srai_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srai_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 255) {
+  /* MSVC requires a range of (0, 255). */
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  const int cnt = (imm8 & ~31) ? 31 : imm8;
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(-cnt));
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] >> cnt;
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srai_epi32(a, imm8) _mm_srai_epi32((a), (imm8))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srai_epi32(a, imm8) simde_mm_srai_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sra_epi16 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sra_epi16(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = HEDLEY_STATIC_CAST(int, (count_.i64[0] > 15 ? 15 : count_.i64[0]));
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vshlq_s16(a_.neon_i16, vdupq_n_s16(HEDLEY_STATIC_CAST(int16_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sra_epi16(a, count) (simde_mm_sra_epi16(a, count))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sra_epi32 (simde__m128i a, simde__m128i count) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_SRA_EPI32)
+    return _mm_sra_epi32(a, count);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      count_ = simde__m128i_to_private(count);
+
+    const int cnt = count_.u64[0] > 31 ? 31 : HEDLEY_STATIC_CAST(int, count_.u64[0]);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vshlq_s32(a_.neon_i32, vdupq_n_s32(HEDLEY_STATIC_CAST(int32_t, -cnt)));
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_shr(a_.wasm_v128, cnt);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] >> cnt;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sra_epi32(a, count) (simde_mm_sra_epi32(a, (count)))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_slli_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 15))) {
+    return simde_mm_setzero_si128();
+  }
+
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i16 = a_.i16 << (imm8 & 0xff);
+  #else
+    const int s = (imm8 > HEDLEY_STATIC_CAST(int, sizeof(r_.i16[0]) * CHAR_BIT) - 1) ? 0 : imm8;
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, a_.i16[i] << s);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) _mm_slli_epi16(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) \
+     (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 15) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_neon_i16( \
+                vshlq_n_s16(simde__m128i_to_neon_i16(a), ((imm8) & 15))); \
+        } \
+        ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) \
+    ((imm8 < 16) ? wasm_i16x8_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_slli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sl(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_slli_epi16(a, imm8) simde_mm_slli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_slli_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 31))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i32 = a_.i32 << imm8;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.i32[i] = a_.i32[i] << (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) _mm_slli_epi32(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) \
+     (__extension__ ({ \
+       simde__m128i ret; \
+       if ((imm8) <= 0) { \
+         ret = a; \
+       } else if ((imm8) > 31) { \
+         ret = simde_mm_setzero_si128(); \
+       } else { \
+         ret = simde__m128i_from_neon_i32( \
+           vshlq_n_s32(simde__m128i_to_neon_i32(a), ((imm8) & 31))); \
+       } \
+       ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) \
+    ((imm8 < 32) ? wasm_i32x4_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_slli_epi32(a, imm8) \
+     (__extension__ ({ \
+       simde__m128i ret; \
+       if ((imm8) <= 0) { \
+         ret = a; \
+       } else if ((imm8) > 31) { \
+         ret = simde_mm_setzero_si128(); \
+       } else { \
+         ret = simde__m128i_from_altivec_i32( \
+           vec_sl(simde__m128i_to_altivec_i32(a), \
+             vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
+       } \
+       ret; \
+     }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_slli_epi32(a, imm8) simde_mm_slli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_slli_epi64 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 63))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.i64 = a_.i64 << imm8;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      r_.i64[i] = a_.i64[i] << (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_slli_epi64(a, imm8) _mm_slli_epi64(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_slli_epi64(a, imm8) \
+     (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 63) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_neon_i64( \
+                vshlq_n_s64(simde__m128i_to_neon_i64(a), ((imm8) & 63))); \
+        } \
+        ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_slli_epi64(a, imm8) \
+    ((imm8 < 64) ? wasm_i64x2_shl(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_slli_epi64(a, imm8) simde_mm_slli_epi64(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srli_epi16 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 15))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u16 = a_.u16 >> imm8;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+      r_.u16[i] = a_.u16[i] >> (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) _mm_srli_epi16(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) \
+     (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 15) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_neon_u16( \
+                vshrq_n_u16(simde__m128i_to_neon_u16(a), (((imm8) & 15) | (((imm8) & 15) == 0)))); \
+        } \
+        ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) \
+    ((imm8 < 16) ? wasm_u16x8_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i16x8_const(0,0,0,0,0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_srli_epi16(a, imm8) \
+    ((imm8 & ~15) ? simde_mm_setzero_si128() : simde__m128i_from_altivec_i16(vec_sr(simde__m128i_to_altivec_i16(a), vec_splat_u16(HEDLEY_STATIC_CAST(unsigned short, imm8)))))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srli_epi16(a, imm8) simde_mm_srli_epi16(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srli_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  if (HEDLEY_UNLIKELY((imm8 > 31))) {
+    return simde_mm_setzero_si128();
+  }
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+    r_.u32 = a_.u32 >> (imm8 & 0xff);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] >> (imm8 & 0xff);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srli_epi32(a, imm8) _mm_srli_epi32(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_srli_epi32(a, imm8) \
+    (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 31) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_neon_u32( \
+              vshrq_n_u32(simde__m128i_to_neon_u32(a), (((imm8) & 31) | (((imm8) & 31) == 0)))); \
+        } \
+        ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_srli_epi32(a, imm8) \
+    ((imm8 < 32) ? wasm_u32x4_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i32x4_const(0,0,0,0))
+#elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+  #define simde_mm_srli_epi32(a, imm8) \
+    (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 31) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_altivec_i32( \
+              vec_sr(simde__m128i_to_altivec_i32(a), \
+                vec_splats(HEDLEY_STATIC_CAST(unsigned int, (imm8) & 31)))); \
+        } \
+        ret; \
+    }))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srli_epi32(a, imm8) simde_mm_srli_epi32(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_srli_epi64 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  if (HEDLEY_UNLIKELY((imm8 & 63) != imm8))
+    return simde_mm_setzero_si128();
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_u64 = vshlq_u64(a_.neon_u64, vdupq_n_s64(-imm8));
+  #else
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_94488)
+      r_.u64 = a_.u64 >> imm8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] >> imm8;
+      }
+    #endif
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE2_NATIVE)
+  #define simde_mm_srli_epi64(a, imm8) _mm_srli_epi64(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_srli_epi64(a, imm8) \
+    (__extension__ ({ \
+        simde__m128i ret; \
+        if ((imm8) <= 0) { \
+            ret = a; \
+        } else if ((imm8) > 63) { \
+            ret = simde_mm_setzero_si128(); \
+        } else { \
+            ret = simde__m128i_from_neon_u64( \
+              vshrq_n_u64(simde__m128i_to_neon_u64(a), (((imm8) & 63) | (((imm8) & 63) == 0)))); \
+        } \
+        ret; \
+    }))
+#elif defined(SIMDE_WASM_SIMD128_NATIVE)
+  #define simde_mm_srli_epi64(a, imm8) \
+    ((imm8 < 64) ? wasm_u64x2_shr(simde__m128i_to_private(a).wasm_v128, imm8) : wasm_i64x2_const(0,0))
+#endif
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_srli_epi64(a, imm8) simde_mm_srli_epi64(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_pd(mem_addr, a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), simde__m128d_to_private(a).neon_i64);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_store_pd(mem_addr, a) simde_mm_store_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store1_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store1_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      vst1q_f64(mem_addr, vdupq_laneq_f64(a_.neon_f64, 0));
+    #else
+      mem_addr[0] = a_.f64[0];
+      mem_addr[1] = a_.f64[0];
+    #endif
+  #endif
+}
+#define simde_mm_store_pd1(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_store1_pd(mem_addr, a) simde_mm_store1_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+  #define _mm_store_pd1(mem_addr, a) simde_mm_store_pd1(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_sd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_sd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      const simde_float64 v = vgetq_lane_f64(a_.neon_f64, 0);
+      simde_memcpy(mem_addr, &v, sizeof(v));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int64_t v = vgetq_lane_s64(a_.neon_i64, 0);
+      simde_memcpy(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), &v, sizeof(v));
+    #else
+      simde_float64 v = a_.f64[0];
+      simde_memcpy(mem_addr, &v, sizeof(simde_float64));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_store_sd(mem_addr, a) simde_mm_store_sd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_store_si128 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_store_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_s32(HEDLEY_REINTERPRET_CAST(int32_t*, mem_addr), a_.neon_i32);
+    #else
+      simde_memcpy(SIMDE_ASSUME_ALIGNED(16, mem_addr), &a_, sizeof(a_));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_store_si128(mem_addr, a) simde_mm_store_si128(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+  simde_mm_storeh_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeh_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      *mem_addr = vgetq_lane_f64(a_.neon_f64, 1);
+    #else
+      *mem_addr = a_.f64[1];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storeh_pd(mem_addr, a) simde_mm_storeh_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storel_epi64 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storel_epi64(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+    int64_t tmp;
+
+    /* memcpy to prevent aliasing, tmp because we can't take the
+     * address of a vector element. */
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      tmp = vgetq_lane_s64(a_.neon_i64, 0);
+    #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+      #if defined(SIMDE_BUG_GCC_95227)
+        (void) a_;
+      #endif
+      tmp = vec_extract(a_.altivec_i64, 0);
+    #else
+      tmp = a_.i64[0];
+    #endif
+
+    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storel_epi64(mem_addr, a) simde_mm_storel_epi64(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storel_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storel_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    simde_float64 tmp;
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      tmp = vgetq_lane_f64(a_.neon_f64, 0);
+    #else
+      tmp = a_.f64[0];
+    #endif
+    simde_memcpy(mem_addr, &tmp, sizeof(tmp));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storel_pd(mem_addr, a) simde_mm_storel_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storer_pd (simde_float64 mem_addr[2], simde__m128d a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storer_pd(mem_addr, a);
+  #else
+    simde__m128d_private a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      vst1q_s64(HEDLEY_REINTERPRET_CAST(int64_t*, mem_addr), vextq_s64(a_.neon_i64, a_.neon_i64, 1));
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      a_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 1, 0);
+      simde_mm_store_pd(mem_addr, simde__m128d_from_private(a_));
+    #else
+      mem_addr[0] = a_.f64[1];
+      mem_addr[1] = a_.f64[0];
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storer_pd(mem_addr, a) simde_mm_storer_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storeu_pd (simde_float64* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeu_pd(mem_addr, a);
+  #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    vst1q_f64(mem_addr, simde__m128d_to_private(a).neon_f64);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storeu_pd(mem_addr, a) simde_mm_storeu_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_storeu_si128 (simde__m128i* mem_addr, simde__m128i a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_storeu_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_storeu_si128(mem_addr, a) simde_mm_storeu_si128(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_pd (simde_float64 mem_addr[HEDLEY_ARRAY_PARAM(2)], simde__m128d a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_stream_pd(mem_addr, a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_stream_pd(mem_addr, a) simde_mm_stream_pd(HEDLEY_REINTERPRET_CAST(double*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_si128 (simde__m128i* mem_addr, simde__m128i a) {
+  simde_assert_aligned(16, mem_addr);
+
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    _mm_stream_si128(HEDLEY_STATIC_CAST(__m128i*, mem_addr), a);
+  #else
+    simde_memcpy(mem_addr, &a, sizeof(a));
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_stream_si128(mem_addr, a) simde_mm_stream_si128(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_si32 (int32_t* mem_addr, int32_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_stream_si32(mem_addr, a);
+  #else
+    *mem_addr = a;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_stream_si32(mem_addr, a) simde_mm_stream_si32(mem_addr, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_stream_si64 (int64_t* mem_addr, int64_t a) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_ARCH_AMD64) && !defined(HEDLEY_MSVC_VERSION)
+    _mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(long long int*, int64_t*, mem_addr), a);
+  #else
+    *mem_addr = a;
+  #endif
+}
+#define simde_mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(mem_addr, a)
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_stream_si64(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
+  #define _mm_stream_si64x(mem_addr, a) simde_mm_stream_si64(SIMDE_CHECKED_REINTERPRET_CAST(int64_t*, __int64*, mem_addr), a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sub_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vsubq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 - b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] - b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_epi8(a, b) simde_mm_sub_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sub_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vsubq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 - b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] - b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_epi16(a, b) simde_mm_sub_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sub_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vsubq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 - b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] - b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_epi32(a, b) simde_mm_sub_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sub_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsubq_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] - b_.i64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_epi64(a, b) simde_mm_sub_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_sub_epu32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.u32 = a_.u32 - b_.u32;
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_u32 = vsubq_u32(a_.neon_u32, b_.neon_u32);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+      r_.u32[i] = a_.u32[i] - b_.u32[i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sub_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.f64 = a_.f64 - b_.f64;
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsubq_f64(a_.neon_f64, b_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_f64x2_sub(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = a_.f64[i] - b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_pd(a, b) simde_mm_sub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sub_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_sub_sd(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_sd(a, simde_mm_sub_pd(a, b));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    r_.f64[0] = a_.f64[0] - b_.f64[0];
+    r_.f64[1] = a_.f64[1];
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_sd(a, b) simde_mm_sub_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sub_si64 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sub_si64(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 - b_.i64;
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vsub_s64(a_.neon_i64, b_.neon_i64);
+    #else
+      r_.i64[0] = a_.i64[0] - b_.i64[0];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_sub_si64(a, b) simde_mm_sub_si64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_subs_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vqsubq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_sub_saturate(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i8[0])) ; i++) {
+        if (((b_.i8[i]) > 0 && (a_.i8[i]) < INT8_MIN + (b_.i8[i]))) {
+          r_.i8[i] = INT8_MIN;
+        } else if ((b_.i8[i]) < 0 && (a_.i8[i]) > INT8_MAX + (b_.i8[i])) {
+          r_.i8[i] = INT8_MAX;
+        } else {
+          r_.i8[i] = (a_.i8[i]) - (b_.i8[i]);
+        }
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_subs_epi8(a, b) simde_mm_subs_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_subs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vqsubq_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x8_sub_saturate(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
+        if (((b_.i16[i]) > 0 && (a_.i16[i]) < INT16_MIN + (b_.i16[i]))) {
+          r_.i16[i] = INT16_MIN;
+        } else if ((b_.i16[i]) < 0 && (a_.i16[i]) > INT16_MAX + (b_.i16[i])) {
+          r_.i16[i] = INT16_MAX;
+        } else {
+          r_.i16[i] = (a_.i16[i]) - (b_.i16[i]);
+        }
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_subs_epi16(a, b) simde_mm_subs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_subs_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u8 = vqsubq_u8(a_.neon_u8, b_.neon_u8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_sub_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u8 = vec_subs(a_.altivec_u8, b_.altivec_u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i8[0])) ; i++) {
+        const int32_t x = a_.u8[i] - b_.u8[i];
+        if (x < 0) {
+          r_.u8[i] = 0;
+        } else if (x > UINT8_MAX) {
+          r_.u8[i] = UINT8_MAX;
+        } else {
+          r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, x);
+        }
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_subs_epu8(a, b) simde_mm_subs_epu8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_subs_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_subs_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vqsubq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_sub_saturate(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_subs(a_.altivec_u16, b_.altivec_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_) / sizeof(r_.i16[0])) ; i++) {
+        const int32_t x = a_.u16[i] - b_.u16[i];
+        if (x < 0) {
+          r_.u16[i] = 0;
+        } else if (x > UINT16_MAX) {
+          r_.u16[i] = UINT16_MAX;
+        } else {
+          r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, x);
+        }
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_subs_epu16(a, b) simde_mm_subs_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomieq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomieq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_eq_b = vceqq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_eq_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) == wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r =  a_.f64[0] == b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r =  a_.f64[0] == b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomieq_sd(a, b) simde_mm_ucomieq_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomige_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomige_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_ge_b = vcgeq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_ge_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) >= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] >= b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] >= b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomige_sd(a, b) simde_mm_ucomige_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomigt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomigt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_gt_b = vcgtq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_gt_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) > wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] > b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] > b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomigt_sd(a, b) simde_mm_ucomigt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomile_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomile_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_le_b = vcleq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_le_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) <= wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] <= b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] <= b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomile_sd(a, b) simde_mm_ucomile_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomilt_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomilt_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_or_b_nan = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vandq_u64(a_not_nan, b_not_nan))));
+      uint64x2_t a_lt_b = vcltq_f64(a_.neon_f64, b_.neon_f64);
+      r = !!(vgetq_lane_u64(vorrq_u64(a_or_b_nan, a_lt_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) < wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] < b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] < b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomilt_sd(a, b) simde_mm_ucomilt_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_ucomineq_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_ucomineq_sd(a, b);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+    int r;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      uint64x2_t a_not_nan = vceqq_f64(a_.neon_f64, a_.neon_f64);
+      uint64x2_t b_not_nan = vceqq_f64(b_.neon_f64, b_.neon_f64);
+      uint64x2_t a_and_b_not_nan = vandq_u64(a_not_nan, b_not_nan);
+      uint64x2_t a_neq_b = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(vceqq_f64(a_.neon_f64, b_.neon_f64))));
+      r = !!(vgetq_lane_u64(vandq_u64(a_and_b_not_nan, a_neq_b), 0) != 0);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      return wasm_f64x2_extract_lane(a_.wasm_v128, 0) != wasm_f64x2_extract_lane(b_.wasm_v128, 0);
+    #elif defined(SIMDE_HAVE_FENV_H)
+      fenv_t envp;
+      int x = feholdexcept(&envp);
+      r = a_.f64[0] != b_.f64[0];
+      if (HEDLEY_LIKELY(x == 0))
+        fesetenv(&envp);
+    #else
+      r = a_.f64[0] != b_.f64[0];
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_ucomineq_sd(a, b) simde_mm_ucomineq_sd(a, b)
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_PUSH
+  SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_
+#endif
+
+#if defined(SIMDE_DIAGNOSTIC_DISABLE_UNINITIALIZED_)
+  HEDLEY_DIAGNOSTIC_POP
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_lfence (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_lfence();
+  #else
+    simde_mm_sfence();
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_lfence() simde_mm_lfence()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_mm_mfence (void) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    _mm_mfence();
+  #else
+    simde_mm_sfence();
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_mfence() simde_mm_mfence()
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpackhi_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip2q_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x8_t a1 = vreinterpret_s8_s16(vget_high_s16(a_.neon_i16));
+      int8x8_t b1 = vreinterpret_s8_s16(vget_high_s16(b_.neon_i16));
+      int8x8x2_t result = vzip_s8(a1, b1);
+      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
+        r_.i8[(i * 2)]     = a_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+        r_.i8[(i * 2) + 1] = b_.i8[i + ((sizeof(r_) / sizeof(r_.i8[0])) / 2)];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpackhi_epi8(a, b) simde_mm_unpackhi_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpackhi_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip2q_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a1 = vget_high_s16(a_.neon_i16);
+      int16x4_t b1 = vget_high_s16(b_.neon_i16);
+      int16x4x2_t result = vzip_s16(a1, b1);
+      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 4, 12, 5, 13, 6, 14, 7, 15);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
+        r_.i16[(i * 2)]     = a_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+        r_.i16[(i * 2) + 1] = b_.i16[i + ((sizeof(r_) / sizeof(r_.i16[0])) / 2)];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpackhi_epi16(a, b) simde_mm_unpackhi_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpackhi_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip2q_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x2_t a1 = vget_high_s32(a_.neon_i32);
+      int32x2_t b1 = vget_high_s32(b_.neon_i32);
+      int32x2x2_t result = vzip_s32(a1, b1);
+      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 2, 6, 3, 7);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
+        r_.i32[(i * 2)]     = a_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+        r_.i32[(i * 2) + 1] = b_.i32[i + ((sizeof(r_) / sizeof(r_.i32[0])) / 2)];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpackhi_epi32(a, b) simde_mm_unpackhi_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpackhi_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x1_t a_h = vget_high_s64(a_.neon_i64);
+      int64x1_t b_h = vget_high_s64(b_.neon_i64);
+      r_.neon_i64 = vcombine_s64(a_h, b_h);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 1, 3);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
+        r_.i64[(i * 2)]     = a_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+        r_.i64[(i * 2) + 1] = b_.i64[i + ((sizeof(r_) / sizeof(r_.i64[0])) / 2)];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpackhi_epi64(a, b) simde_mm_unpackhi_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_unpackhi_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpackhi_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x1_t a_l = vget_high_f64(a_.f64);
+      float64x1_t b_l = vget_high_f64(b_.f64);
+      r_.neon_f64 = vcombine_f64(a_l, b_l);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
+        r_.f64[(i * 2)]     = a_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+        r_.f64[(i * 2) + 1] = b_.f64[i + ((sizeof(r_) / sizeof(r_.f64[0])) / 2)];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpackhi_pd(a, b) simde_mm_unpackhi_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpacklo_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vzip1q_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x8_t a1 = vreinterpret_s8_s16(vget_low_s16(a_.neon_i16));
+      int8x8_t b1 = vreinterpret_s8_s16(vget_low_s16(b_.neon_i16));
+      int8x8x2_t result = vzip_s8(a1, b1);
+      r_.neon_i8 = vcombine_s8(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i8 = SIMDE_SHUFFLE_VECTOR_(8, 16, a_.i8, b_.i8, 0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i8[0])) / 2) ; i++) {
+        r_.i8[(i * 2)]     = a_.i8[i];
+        r_.i8[(i * 2) + 1] = b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpacklo_epi8(a, b) simde_mm_unpacklo_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpacklo_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vzip1q_s16(a_.neon_i16, b_.neon_i16);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x4_t a1 = vget_low_s16(a_.neon_i16);
+      int16x4_t b1 = vget_low_s16(b_.neon_i16);
+      int16x4x2_t result = vzip_s16(a1, b1);
+      r_.neon_i16 = vcombine_s16(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 8, 1, 9, 2, 10, 3, 11);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i16[0])) / 2) ; i++) {
+        r_.i16[(i * 2)]     = a_.i16[i];
+        r_.i16[(i * 2) + 1] = b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpacklo_epi16(a, b) simde_mm_unpacklo_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpacklo_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vzip1q_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x2_t a1 = vget_low_s32(a_.neon_i32);
+      int32x2_t b1 = vget_low_s32(b_.neon_i32);
+      int32x2x2_t result = vzip_s32(a1, b1);
+      r_.neon_i32 = vcombine_s32(result.val[0], result.val[1]);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 4, 1, 5);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i32[0])) / 2) ; i++) {
+        r_.i32[(i * 2)]     = a_.i32[i];
+        r_.i32[(i * 2) + 1] = b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpacklo_epi32(a, b) simde_mm_unpacklo_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_unpacklo_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x1_t a_l = vget_low_s64(a_.i64);
+      int64x1_t b_l = vget_low_s64(b_.i64);
+      r_.neon_i64 = vcombine_s64(a_l, b_l);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.i64, b_.i64, 0, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.i64[0])) / 2) ; i++) {
+        r_.i64[(i * 2)]     = a_.i64[i];
+        r_.i64[(i * 2) + 1] = b_.i64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpacklo_epi64(a, b) simde_mm_unpacklo_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_unpacklo_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_unpacklo_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x1_t a_l = vget_low_f64(a_.f64);
+      float64x1_t b_l = vget_low_f64(b_.f64);
+      r_.neon_f64 = vcombine_f64(a_l, b_l);
+    #elif defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < ((sizeof(r_) / sizeof(r_.f64[0])) / 2) ; i++) {
+        r_.f64[(i * 2)]     = a_.f64[i];
+        r_.f64[(i * 2) + 1] = b_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_unpacklo_pd(a, b) simde_mm_unpacklo_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_negate_pd(simde__m128d a) {
+  #if defined(SIMDE_X86_SSE_NATIVE)
+    return simde_mm_xor_pd(a, _mm_set1_pd(SIMDE_FLOAT64_C(-0.0)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_POWER_ALTIVEC_P8_NATIVE) && \
+        (!defined(HEDLEY_GCC_VERSION) || HEDLEY_GCC_VERSION_CHECK(8,1,0))
+      r_.altivec_f64 = vec_neg(a_.altivec_f64);
+    #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vnegq_f64(a_.neon_f64);
+    #elif defined(SIMDE_WASM_SIMD128d_NATIVE)
+      r_.wasm_v128d = wasm_f64x2_neg(a_.wasm_v128d);
+    #elif defined(SIMDE_VECTOR_NEGATE)
+      r_.f64 = -a_.f64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = -a_.f64[i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_xor_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_xor_si128(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = veorq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_xor(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32f = a_.i32f ^ b_.i32f;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+        r_.i32f[i] = a_.i32f[i] ^ b_.i32f[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _mm_xor_si128(a, b) simde_mm_xor_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_not_si128 (simde__m128i a) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    r_.neon_i32 = vmvnq_s32(a_.neon_i32);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    r_.altivec_i32 = vec_nor(a_.altivec_i32, a_.altivec_i32);
+  #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+    r_.wasm_v128 = wasm_v128_not(a_.wasm_v128);
+  #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+    r_.i32f = ~a_.i32f;
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i32f) / sizeof(r_.i32f[0])) ; i++) {
+      r_.i32f[i] = ~(a_.i32f[i]);
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+#define SIMDE_MM_SHUFFLE2(x, y) (((x) << 1) | (y))
+#if defined(SIMDE_X86_SSE2_ENABLE_NATIVE_ALIASES)
+  #define _MM_SHUFFLE2(x, y) SIMDE_MM_SHUFFLE2(x, y)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE2_H) */

--- a/2.0/simde/x86/sse3.h
+++ b/2.0/simde/x86/sse3.h
@@ -1,0 +1,496 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_SSE3_H)
+#define SIMDE_X86_SSE3_H
+
+#include "sse2.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_deinterleaveeven_epi16 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_i16 = vuzp1q_s16(a_.neon_i16, b_.neon_i16);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 0, 2, 4, 6, 8, 10, 12, 14);
+  #else
+    const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.i16[i] = a_.i16[2 * i];
+      r_.i16[i + halfway_point] = b_.i16[2 * i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_deinterleaveodd_epi16 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_i16 = vuzp2q_s16(a_.neon_i16, b_.neon_i16);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i16 = SIMDE_SHUFFLE_VECTOR_(16, 16, a_.i16, b_.i16, 1, 3, 5, 7, 9, 11, 13, 15);
+  #else
+    const size_t halfway_point = (sizeof(r_.i16) / sizeof(r_.i16[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.i16[i] = a_.i16[2 * i + 1];
+      r_.i16[i + halfway_point] = b_.i16[2 * i + 1];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_deinterleaveeven_epi32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_i32 = vuzp1q_s32(a_.neon_i32, b_.neon_i32);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 0, 2, 4, 6);
+  #else
+    const size_t halfway_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.i32[i] = a_.i32[2 * i];
+      r_.i32[i + halfway_point] = b_.i32[2 * i];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_deinterleaveodd_epi32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_i32 = vuzp2q_s32(a_.neon_i32, b_.neon_i32);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.i32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.i32, b_.i32, 1, 3, 5, 7);
+  #else
+    const size_t halfway_point = (sizeof(r_.i32) / sizeof(r_.i32[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.i32[i] = a_.i32[2 * i + 1];
+      r_.i32[i + halfway_point] = b_.i32[2 * i + 1];
+    }
+  #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_deinterleaveeven_ps (simde__m128 a, simde__m128 b) {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_f32 = vuzp1q_f32(a_.neon_f32, b_.neon_f32);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 0, 2, 4, 6);
+  #else
+    const size_t halfway_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.f32[i] = a_.f32[2 * i];
+      r_.f32[i + halfway_point] = b_.f32[2 * i];
+    }
+  #endif
+
+  return simde__m128_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_deinterleaveodd_ps (simde__m128 a, simde__m128 b) {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_f32 = vuzp2q_f32(a_.neon_f32, b_.neon_f32);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, b_.f32, 1, 3, 5, 7);
+  #else
+    const size_t halfway_point = (sizeof(r_.f32) / sizeof(r_.f32[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.f32[i] = a_.f32[2 * i + 1];
+      r_.f32[i + halfway_point] = b_.f32[2 * i + 1];
+    }
+  #endif
+
+  return simde__m128_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_deinterleaveeven_pd (simde__m128d a, simde__m128d b) {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_f64 = vuzp1q_f64(a_.neon_f64, b_.neon_f64);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 0, 2);
+  #else
+    const size_t halfway_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.f64[i] = a_.f64[2 * i];
+      r_.f64[i + halfway_point] = b_.f64[2 * i];
+    }
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_deinterleaveodd_pd (simde__m128d a, simde__m128d b) {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    r_.neon_f64 = vuzp2q_f64(a_.neon_f64, b_.neon_f64);
+  #elif defined(SIMDE_SHUFFLE_VECTOR_)
+    r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, b_.f64, 1, 3);
+  #else
+    const size_t halfway_point = (sizeof(r_.f64) / sizeof(r_.f64[0])) / 2;
+    for(size_t i = 0 ; i < halfway_point ; i++) {
+      r_.f64[i] = a_.f64[2 * i + 1];
+      r_.f64[i + halfway_point] = b_.f64[2 * i + 1];
+    }
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_addsub_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_addsub_pd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float64x2_t rs = vsubq_f64(a_.neon_f64, b_.neon_f64);
+      float64x2_t ra = vaddq_f64(a_.neon_f64, b_.neon_f64);
+      return vcombine_f64(vget_low_f64(rs), vget_high_f64(ra));
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64 - b_.f64, a_.f64 + b_.f64, 0, 3);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i += 2) {
+        r_.f64[  i  ] = a_.f64[  i  ] - b_.f64[  i  ];
+        r_.f64[1 + i] = a_.f64[1 + i] + b_.f64[1 + i];
+      }
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_addsub_pd(a, b) simde_mm_addsub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_addsub_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_addsub_ps(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      float32x4_t rs = vsubq_f32(a_.neon_f32, b_.neon_f32);
+      float32x4_t ra = vaddq_f32(a_.neon_f32, b_.neon_f32);
+      return vtrn2q_f32(vreinterpretq_f32_s32(vrev64q_s32(vreinterpretq_s32_f32(rs))), ra);
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32 - b_.f32, a_.f32 + b_.f32, 0, 5, 2, 7);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+        r_.f32[  i  ] = a_.f32[  i  ] - b_.f32[  i  ];
+        r_.f32[1 + i] = a_.f32[1 + i] + b_.f32[1 + i];
+      }
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_addsub_ps(a, b) simde_mm_addsub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_hadd_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hadd_pd(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      simde_float64 res[2] = { vaddvq_f64(simde__m128d_to_private(a).neon_f64), vaddvq_f64(simde__m128d_to_private(b).neon_f64)};
+      return vld1q_f64(res);
+    #else
+      return simde_mm_add_pd(simde_x_mm_deinterleaveeven_pd(a, b), simde_x_mm_deinterleaveodd_pd(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_pd(a, b) simde_mm_hadd_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_hadd_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hadd_ps(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vpaddq_f32(simde__m128_to_private(a).neon_f32, simde__m128_to_private(b).neon_f32);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32x2_t a10 = vget_low_f32(simde__m128_to_private(a).neon_f32);
+      float32x2_t a32 = vget_high_f32(simde__m128_to_private(a).neon_f32);
+      float32x2_t b10 = vget_low_f32(simde__m128_to_private(b).neon_f32);
+      float32x2_t b32 = vget_high_f32(simde__m128_to_private(b).neon_f32);
+      return vcombine_f32(vpadd_f32(a10, a32), vpadd_f32(b10, b32));
+    #else
+      return simde_mm_add_ps(simde_x_mm_deinterleaveeven_ps(a, b), simde_x_mm_deinterleaveodd_ps(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_ps(a, b) simde_mm_hadd_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_hsub_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hsub_pd(a, b);
+  #else
+    return simde_mm_sub_pd(simde_x_mm_deinterleaveeven_pd(a, b), simde_x_mm_deinterleaveodd_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_pd(a, b) simde_mm_hsub_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_hsub_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_hsub_ps(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vsubq_f32(vuzp1q_f32(simde__m128_to_private(a).neon_f32, simde__m128_to_private(b).neon_f32), vuzp2q_f32(simde__m128_to_private(a).neon_f32, simde__m128_to_private(b).neon_f32));
+    #else
+      return simde_mm_sub_ps(simde_x_mm_deinterleaveeven_ps(a, b), simde_x_mm_deinterleaveodd_ps(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_ps(a, b) simde_mm_hsub_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_lddqu_si128 (simde__m128i const* mem_addr) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_lddqu_si128(mem_addr);
+  #else
+    simde__m128i_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr));
+    #else
+      simde_memcpy(&r_, mem_addr, sizeof(r_));
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_lddqu_si128(mem_addr) simde_mm_lddqu_si128(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_loaddup_pd (simde_float64 const* mem_addr) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_loaddup_pd(mem_addr);
+  #else
+    simde__m128d_private r_;
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vsetq_lane_f64(*mem_addr, vsetq_lane_f64(*mem_addr, vdupq_n_f64(0), 0), 1);
+    #else
+      r_.f64[0] = *mem_addr;
+      r_.f64[1] = *mem_addr;
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_loaddup_pd(mem_addr) simde_mm_loaddup_pd(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_movedup_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_movedup_pd(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f64 = SIMDE_SHUFFLE_VECTOR_(64, 16, a_.f64, a_.f64, 0, 0);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float64_t a0 = vgetq_lane_f64(a_.neon_f64, 0);
+      simde_float64 data[2] = { a0, a0 };
+      r_.neon_f64 = vld1q_f64(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v64x2_shuffle(a_.wasm_v128, a_.wasm_v128, 0, 0);
+    #else
+      r_.f64[0] = a_.f64[0];
+      r_.f64[1] = a_.f64[0];
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_movedup_pd(a) simde_mm_movedup_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_movehdup_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SSE3_NATIVE)
+    return _mm_movehdup_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, a_.f32, 1, 1, 3, 3);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t a1 = vgetq_lane_f32(a_.neon_f32, 1);
+      float32_t a3 = vgetq_lane_f32(a_.neon_f32, 3);
+      SIMDE_ALIGN(16) simde_float32 data[4] = { a1, a1, a3, a3 };
+      r_.neon_f32 = vld1q_f32(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v32x4_shuffle(a_.wasm_v128, a_.wasm_v128, 1, 1, 3, 3);
+    #else
+      r_.f32[0] = a_.f32[1];
+      r_.f32[1] = a_.f32[1];
+      r_.f32[2] = a_.f32[3];
+      r_.f32[3] = a_.f32[3];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_movehdup_ps(a) simde_mm_movehdup_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_moveldup_ps (simde__m128 a) {
+  #if defined(SIMDE__SSE3_NATIVE)
+    return _mm_moveldup_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.f32 = SIMDE_SHUFFLE_VECTOR_(32, 16, a_.f32, a_.f32, 0, 0, 2, 2);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      float32_t a0 = vgetq_lane_f32(a_.neon_f32, 0);
+      float32_t a2 = vgetq_lane_f32(a_.neon_f32, 2);
+      SIMDE_ALIGN(16) simde_float32 data[4] = { a0, a0, a2, a2 };
+      r_.neon_f32 = vld1q_f32(data);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_v32x4_shuffle(a_.wasm_v128, a_.wasm_v128, 0, 0, 2, 2);
+    #else
+      r_.f32[0] = a_.f32[0];
+      r_.f32[1] = a_.f32[0];
+      r_.f32[2] = a_.f32[2];
+      r_.f32[3] = a_.f32[2];
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_moveldup_ps(a) simde_mm_moveldup_ps(a)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE3_H) */

--- a/2.0/simde/x86/sse4.1.h
+++ b/2.0/simde/x86/sse4.1.h
@@ -1,0 +1,2145 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#include "sse.h"
+#if !defined(SIMDE_X86_SSE4_1_H)
+#define SIMDE_X86_SSE4_1_H
+
+#include "ssse3.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+#  define SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_blend_epi16 (simde__m128i a, simde__m128i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+    r_.u16[i] = ((imm8 >> i) & 1) ? b_.u16[i] : a_.u16[i];
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_blend_epi16(a, b, imm8) _mm_blend_epi16(a, b, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_blend_epi16(a, b, imm8) \
+     (__extension__ ({ \
+           const uint16_t _mask[8] = {               \
+               ((imm8) & (1 << 0)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 1)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 2)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 3)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 4)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 5)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 6)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 7)) ? 0xFFFF : 0x0000  \
+           };                                        \
+           uint16x8_t _mask_vec = vld1q_u16(_mask);  \
+           simde__m128i_from_neon_u16(vbslq_u16(_mask_vec, simde__m128i_to_neon_u16(b), simde__m128i_to_neon_u16(a))); \
+       }))
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#  define simde_mm_blend_epi16(a, b, imm8)      \
+     (__extension__ ({ \
+           const SIMDE_POWER_ALTIVEC_VECTOR(unsigned short) _mask = {      \
+               ((imm8) & (1 << 0)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 1)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 2)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 3)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 4)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 5)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 6)) ? 0xFFFF : 0x0000, \
+               ((imm8) & (1 << 7)) ? 0xFFFF : 0x0000  \
+           };                                         \
+           simde__m128i_from_altivec_u16(vec_sel(simde__m128i_to_altivec_u16(a), simde__m128i_to_altivec_u16(b), _mask)); \
+       }))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blend_epi16
+  #define _mm_blend_epi16(a, b, imm8) simde_mm_blend_epi16(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_blend_pd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3)  {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+    r_.f64[i] = ((imm8 >> i) & 1) ? b_.f64[i] : a_.f64[i];
+  }
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_blend_pd(a, b, imm8) _mm_blend_pd(a, b, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_blend_pd(a, b, imm8) \
+     (__extension__ ({ \
+           const uint64_t _mask[2] = {               \
+               ((imm8) & (1 << 0)) ? UINT64_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT64_MAX : 0  \
+           };                                        \
+           uint64x2_t _mask_vec = vld1q_u64(_mask);  \
+           simde__m128d_from_neon_u64(vbslq_u64(_mask_vec, simde__m128d_to_neon_u64(b), simde__m128d_to_neon_u64(a))); \
+       }))
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#  define simde_mm_blend_pd(a, b, imm8)         \
+     (__extension__ ({ \
+           const SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long) _mask = { \
+               ((imm8) & (1 << 0)) ? UINT64_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT64_MAX : 0  \
+           };                                        \
+           simde__m128d_from_altivec_f64(vec_sel(simde__m128d_to_altivec_f64(a), simde__m128d_to_altivec_f64(b), _mask)); \
+       }))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blend_pd
+  #define _mm_blend_pd(a, b, imm8) simde_mm_blend_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_blend_ps (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 15)  {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    r_.f32[i] = ((imm8 >> i) & 1) ? b_.f32[i] : a_.f32[i];
+  }
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_blend_ps(a, b, imm8) _mm_blend_ps(a, b, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_blend_ps(a, b, imm8) \
+     (__extension__ ({ \
+           const uint32_t _mask[4] = {               \
+               ((imm8) & (1 << 0)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 2)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 3)) ? UINT32_MAX : 0  \
+           };                                        \
+           uint32x4_t _mask_vec = vld1q_u32(_mask);  \
+           simde__m128_from_neon_f32(vbslq_f32(_mask_vec, simde__m128_to_neon_f32(b), simde__m128_to_neon_f32(a))); \
+       }))
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#  define simde_mm_blend_ps(a, b, imm8) \
+     (__extension__ ({ \
+           const SIMDE_POWER_ALTIVEC_VECTOR(unsigned int) _mask = {       \
+               ((imm8) & (1 << 0)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 1)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 2)) ? UINT32_MAX : 0, \
+               ((imm8) & (1 << 3)) ? UINT32_MAX : 0  \
+           };                                        \
+           simde__m128_from_altivec_f32(vec_sel(simde__m128_to_altivec_f32(a), simde__m128_to_altivec_f32(b), _mask)); \
+       }))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blend_ps
+  #define _mm_blend_ps(a, b, imm8) simde_mm_blend_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_blendv_epi8 (simde__m128i a, simde__m128i b, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_epi8(a, b, mask);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b),
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* Use a signed shift right to create a mask with the sign bit */
+      mask_.neon_i8 = vshrq_n_s8(mask_.neon_i8, 7);
+      r_.neon_i8 = vbslq_s8(mask_.neon_u8, b_.neon_i8, a_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_i8x16_shr(mask_.wasm_v128, 7);
+      r_.wasm_v128 = wasm_v128_or(wasm_v128_and(b_.wasm_v128, m), wasm_v128_andnot(a_.wasm_v128, m));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_sel(a_.altivec_i8, b_.altivec_i8, vec_cmplt(mask_.altivec_i8, vec_splat_s8(0)));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      /* https://software.intel.com/en-us/forums/intel-c-compiler/topic/850087 */
+      #if defined(HEDLEY_INTEL_VERSION_CHECK)
+        __typeof__(mask_.i8) z = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        mask_.i8 = HEDLEY_STATIC_CAST(__typeof__(mask_.i8), mask_.i8 < z);
+      #else
+        mask_.i8 >>= (CHAR_BIT * sizeof(mask_.i8[0])) - 1;
+      #endif
+
+      r_.i8 = (mask_.i8 & b_.i8) | (~mask_.i8 & a_.i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        int8_t m = mask_.i8[i] >> 7;
+        r_.i8[i] = (m & b_.i8[i]) | (~m & a_.i8[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blendv_epi8
+  #define _mm_blendv_epi8(a, b, mask) simde_mm_blendv_epi8(a, b, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_blendv_epi16 (simde__m128i a, simde__m128i b, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE2_NATIVE)
+    mask = simde_mm_srai_epi16(mask, 15);
+    return simde_mm_or_si128(simde_mm_and_si128(mask, b), simde_mm_andnot_si128(mask, a));
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b),
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      mask_ = simde__m128i_to_private(simde_mm_cmplt_epi16(mask, simde_mm_setzero_si128()));
+      r_.neon_i16 = vbslq_s16(mask_.neon_u16, b_.neon_i16, a_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_sel(a_.altivec_i16, b_.altivec_i16, vec_cmplt(mask_.altivec_i16, vec_splat_s16(0)));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      #if defined(HEDLEY_INTEL_VERSION_CHECK)
+        __typeof__(mask_.i16) z = { 0, 0, 0, 0, 0, 0, 0, 0 };
+        mask_.i16 = mask_.i16 < z;
+      #else
+        mask_.i16 >>= (CHAR_BIT * sizeof(mask_.i16[0])) - 1;
+      #endif
+
+      r_.i16 = (mask_.i16 & b_.i16) | (~mask_.i16 & a_.i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        int16_t m = mask_.i16[i] >> 15;
+        r_.i16[i] = (m & b_.i16[i]) | (~m & a_.i16[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_blendv_epi32 (simde__m128i a, simde__m128i b, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_castps_si128(_mm_blendv_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), _mm_castsi128_ps(mask)));
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b),
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      mask_ = simde__m128i_to_private(simde_mm_cmplt_epi32(mask, simde_mm_setzero_si128()));
+      r_.neon_i32 = vbslq_s32(mask_.neon_u32, b_.neon_i32, a_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_i32x4_shr(mask_.wasm_v128, 31);
+      r_.wasm_v128 = wasm_v128_or(wasm_v128_and(b_.wasm_v128, m), wasm_v128_andnot(a_.wasm_v128, m));
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_sel(a_.altivec_i32, b_.altivec_i32, vec_cmplt(mask_.altivec_i32, vec_splat_s32(0)));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      #if defined(HEDLEY_INTEL_VERSION_CHECK)
+        __typeof__(mask_.i32) z = { 0, 0, 0, 0 };
+        mask_.i32 = HEDLEY_STATIC_CAST(__typeof__(mask_.i32), mask_.i32 < z);
+      #else
+        mask_.i32 >>= (CHAR_BIT * sizeof(mask_.i32[0])) - 1;
+      #endif
+
+      r_.i32 = (mask_.i32 & b_.i32) | (~mask_.i32 & a_.i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        int32_t m = mask_.i32[i] >> 31;
+        r_.i32[i] = (m & b_.i32[i]) | (~m & a_.i32[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_blendv_epi64 (simde__m128i a, simde__m128i b, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_castpd_si128(_mm_blendv_pd(_mm_castsi128_pd(a), _mm_castsi128_pd(b), _mm_castsi128_pd(mask)));
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b),
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      mask_.u64 = vcltq_s64(mask_.i64, vdupq_n_s64(UINT64_C(0)));
+      r_.neon_i64 = vbslq_s64(mask_.neon_u64, b_.neon_i64, a_.neon_i64);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      v128_t m = wasm_i64x2_shr(mask_.wasm_v128, 63);
+      r_.wasm_v128 = wasm_v128_or(wasm_v128_and(b_.wasm_v128, m), wasm_v128_andnot(a_.wasm_v128, m));
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      /* Using int due to clang bug #46770 */
+      SIMDE_POWER_ALTIVEC_VECTOR(signed long long) selector = vec_sra(mask_.altivec_i64, vec_splats(HEDLEY_STATIC_CAST(unsigned long long, 63)));
+      r_.altivec_i32 = vec_sel(a_.altivec_i32, b_.altivec_i32, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned int), selector));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      #if defined(HEDLEY_INTEL_VERSION_CHECK)
+        __typeof__(mask_.i64) z = { 0, 0 };
+        mask_.i64 = HEDLEY_STATIC_CAST(__typeof__(mask_.i64), mask_.i64 < z);
+      #else
+        mask_.i64 >>= (CHAR_BIT * sizeof(mask_.i64[0])) - 1;
+      #endif
+
+    r_.i64 = (mask_.i64 & b_.i64) | (~mask_.i64 & a_.i64);
+  #else
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+      int64_t m = mask_.i64[i] >> 63;
+      r_.i64[i] = (m & b_.i64[i]) | (~m & a_.i64[i]);
+    }
+  #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_blendv_pd (simde__m128d a, simde__m128d b, simde__m128d mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_pd(a, b, mask);
+  #else
+    return simde_mm_castsi128_pd(simde_x_mm_blendv_epi64(simde_mm_castpd_si128(a), simde_mm_castpd_si128(b), simde_mm_castpd_si128(mask)));
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blendv_pd
+  #define _mm_blendv_pd(a, b, mask) simde_mm_blendv_pd(a, b, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_blendv_ps (simde__m128 a, simde__m128 b, simde__m128 mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_blendv_ps(a, b, mask);
+  #else
+    return simde_mm_castsi128_ps(simde_x_mm_blendv_epi32(simde_mm_castps_si128(a), simde_mm_castps_si128(b), simde_mm_castps_si128(mask)));
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_blendv_ps
+  #define _mm_blendv_ps(a, b, mask) simde_mm_blendv_ps(a, b, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_round_pd (simde__m128d a, int rounding)
+    SIMDE_REQUIRE_CONSTANT_RANGE(rounding, 0, 15) {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a);
+
+  /* For architectures which lack a current direction SIMD instruction. */
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    if ((rounding & 7) == SIMDE_MM_FROUND_CUR_DIRECTION)
+      rounding = HEDLEY_STATIC_CAST(int, SIMDE_MM_GET_ROUNDING_MODE()) << 13;
+  #endif
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    case SIMDE_MM_FROUND_CUR_DIRECTION:
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+        r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_round(a_.altivec_f64));
+      #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
+        r_.neon_f64 = vrndiq_f64(a_.neon_f64);
+      #elif defined(simde_math_nearbyint)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_nearbyint(a_.f64[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_NEAREST_INT:
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+        r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_round(a_.altivec_f64));
+      #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
+        r_.neon_f64 = vrndaq_f64(a_.neon_f64);
+      #elif defined(simde_math_round)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_round(a_.f64[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_NEG_INF:
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+        r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_floor(a_.altivec_f64));
+      #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
+        r_.neon_f64 = vrndmq_f64(a_.neon_f64);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_floor(a_.f64[i]);
+        }
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_POS_INF:
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+        r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_ceil(a_.altivec_f64));
+      #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
+        r_.neon_f64 = vrndpq_f64(a_.neon_f64);
+      #elif defined(simde_math_ceil)
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_ceil(a_.f64[i]);
+        }
+      #else
+        HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+      #endif
+      break;
+
+    case SIMDE_MM_FROUND_TO_ZERO:
+      #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+        r_.altivec_f64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(double), vec_trunc(a_.altivec_f64));
+      #elif defined(SIMDE_ARM_NEON_A64V8_NATIVE) && 0
+        r_.neon_f64 = vrndq_f64(a_.neon_f64);
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+          r_.f64[i] = simde_math_trunc(a_.f64[i]);
+        }
+      #endif
+      break;
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+  #define simde_mm_round_pd(a, rounding) _mm_round_pd(a, rounding)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_round_pd
+  #define _mm_round_pd(a, rounding) simde_mm_round_pd(a, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_ceil_pd (simde__m128d a) {
+  return simde_mm_round_pd(a, SIMDE_MM_FROUND_TO_POS_INF);
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_ceil_pd
+  #define _mm_ceil_pd(a) simde_mm_ceil_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_ceil_ps (simde__m128 a) {
+  return simde_mm_round_ps(a, SIMDE_MM_FROUND_TO_POS_INF);
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_ceil_ps
+  #define _mm_ceil_ps(a) simde_mm_ceil_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_ceil_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_ceil_sd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_ceilf)
+      r_ = simde__m128d_to_private(simde_mm_set_pd(a_.f64[1], simde_math_ceil(b_.f64[0])));
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_ceil_sd
+  #define _mm_ceil_sd(a, b) simde_mm_ceil_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_ceil_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_ceil_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    return simde_mm_move_ss(a, simde_mm_ceil_ps(b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(simde_math_ceilf)
+      r_ = simde__m128_to_private(simde_mm_set_ps(a_.f32[3], a_.f32[2], a_.f32[1], simde_math_ceilf(b_.f32[0])));
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_ceil_ss
+  #define _mm_ceil_ss(a, b) simde_mm_ceil_ss(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpeq_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cmpeq_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vceqq_u64(a_.neon_u64, b_.neon_u64);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* (a == b) -> (a_lo == b_lo) && (a_hi == b_hi) */
+      uint32x4_t cmp = vceqq_u32(a_.neon_u32, b_.neon_u32);
+      uint32x4_t swapped = vrev64q_u32(cmp);
+      r_.neon_u32 = vandq_u32(cmp, swapped);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), a_.i64 == b_.i64);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed long long), vec_cmpeq(a_.altivec_i64, b_.altivec_i64));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = (a_.u64[i] == b_.u64[i]) ? ~UINT64_C(0) : UINT64_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpeq_epi64
+  #define _mm_cmpeq_epi64(a, b) simde_mm_cmpeq_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi8_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi8_epi16(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x16_t s8x16 = a_.neon_i8;                   /* xxxx xxxx xxxx DCBA */
+      int16x8_t s16x8 = vmovl_s8(vget_low_s8(s8x16)); /* 0x0x 0x0x 0D0C 0B0A */
+      r_.neon_i16 = s16x8;
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i16, a_.m64_private[0].i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi8_epi16
+  #define _mm_cvtepi8_epi16(a) simde_mm_cvtepi8_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi8_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi8_epi32(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x16_t s8x16 = a_.neon_i8;                     /* xxxx xxxx xxxx DCBA */
+      int16x8_t s16x8 = vmovl_s8(vget_low_s8(s8x16));   /* 0x0x 0x0x 0D0C 0B0A */
+      int32x4_t s32x4 = vmovl_s16(vget_low_s16(s16x8)); /* 000D 000C 000B 000A */
+      r_.neon_i32 = s32x4;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi8_epi32
+  #define _mm_cvtepi8_epi32(a) simde_mm_cvtepi8_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi8_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi8_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int8x16_t s8x16 = a_.neon_i8;                     /* xxxx xxxx xxxx xxBA */
+      int16x8_t s16x8 = vmovl_s8(vget_low_s8(s8x16));   /* 0x0x 0x0x 0x0x 0B0A */
+      int32x4_t s32x4 = vmovl_s16(vget_low_s16(s16x8)); /* 000x 000x 000B 000A */
+      int64x2_t s64x2 = vmovl_s32(vget_low_s32(s32x4)); /* 0000 000B 0000 000A */
+      r_.neon_i64 = s64x2;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi8_epi64
+  #define _mm_cvtepi8_epi64(a) simde_mm_cvtepi8_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu8_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu8_epi16(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint8x16_t u8x16 = a_.neon_u8;                   /* xxxx xxxx xxxx DCBA */
+      uint16x8_t u16x8 = vmovl_u8(vget_low_u8(u8x16)); /* 0x0x 0x0x 0D0C 0B0A */
+      r_.neon_u16 = u16x8;
+    #elif defined(SIMDE_CONVERT_VECTOR_) && !defined(SIMDE_BUG_CLANG_45541) && (!defined(SIMDE_ARCH_POWER) || !defined(__clang__))
+      SIMDE_CONVERT_VECTOR_(r_.i16, a_.m64_private[0].u8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu8_epi16
+  #define _mm_cvtepu8_epi16(a) simde_mm_cvtepu8_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu8_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu8_epi32(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint8x16_t u8x16 = a_.neon_u8;                     /* xxxx xxxx xxxx DCBA */
+      uint16x8_t u16x8 = vmovl_u8(vget_low_u8(u8x16));   /* 0x0x 0x0x 0D0C 0B0A */
+      uint32x4_t u32x4 = vmovl_u16(vget_low_u16(u16x8)); /* 000D 000C 000B 000A */
+      r_.neon_u32 = u32x4;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu8_epi32
+  #define _mm_cvtepu8_epi32(a) simde_mm_cvtepu8_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu8_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu8_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint8x16_t u8x16 = a_.neon_u8;                     /* xxxx xxxx xxxx xxBA */
+      uint16x8_t u16x8 = vmovl_u8(vget_low_u8(u8x16));   /* 0x0x 0x0x 0x0x 0B0A */
+      uint32x4_t u32x4 = vmovl_u16(vget_low_u16(u16x8)); /* 000x 000x 000B 000A */
+      uint64x2_t u64x2 = vmovl_u32(vget_low_u32(u32x4)); /* 0000 000B 0000 000A */
+      r_.neon_u64 = u64x2;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu8_epi64
+  #define _mm_cvtepu8_epi64(a) simde_mm_cvtepu8_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi16_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi16_epi32(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmovl_s16(vget_low_s16(a_.neon_i16));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi16_epi32
+  #define _mm_cvtepi16_epi32(a) simde_mm_cvtepi16_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu16_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu16_epi32(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vmovl_u16(vget_low_u16(a_.neon_u16));
+    #elif defined(SIMDE_CONVERT_VECTOR_) && !defined(SIMDE_BUG_CLANG_45541) && (!defined(SIMDE_ARCH_POWER) || !defined(__clang__))
+      SIMDE_CONVERT_VECTOR_(r_.i32, a_.m64_private[0].u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu16_epi32
+  #define _mm_cvtepu16_epi32(a) simde_mm_cvtepu16_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu16_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu16_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x8_t u16x8 = a_.neon_u16;                    /* xxxx xxxx xxxx 0B0A */
+      uint32x4_t u32x4 = vmovl_u16(vget_low_u16(u16x8)); /* 000x 000x 000B 000A */
+      uint64x2_t u64x2 = vmovl_u32(vget_low_u32(u32x4)); /* 0000 000B 0000 000A */
+      r_.neon_u64 = u64x2;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu16_epi64
+  #define _mm_cvtepu16_epi64(a) simde_mm_cvtepu16_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi16_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi16_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int16x8_t s16x8 = a_.neon_i16;                    /* xxxx xxxx xxxx 0B0A */
+      int32x4_t s32x4 = vmovl_s16(vget_low_s16(s16x8)); /* 000x 000x 000B 000A */
+      int64x2_t s64x2 = vmovl_s32(vget_low_s32(s32x4)); /* 0000 000B 0000 000A */
+      r_.neon_i64 = s64x2;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi16_epi64
+  #define _mm_cvtepi16_epi64(a) simde_mm_cvtepi16_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepi32_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepi32_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i64 = vmovl_s32(vget_low_s32(a_.neon_i32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.m64_private[0].i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepi32_epi64
+  #define _mm_cvtepi32_epi64(a) simde_mm_cvtepi32_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cvtepu32_epi64 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_cvtepu32_epi64(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u64 = vmovl_u32(vget_low_u32(a_.neon_u32));
+    #elif defined(SIMDE_CONVERT_VECTOR_)
+      SIMDE_CONVERT_VECTOR_(r_.i64, a_.m64_private[0].u32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.u32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cvtepu32_epi64
+  #define _mm_cvtepu32_epi64(a) simde_mm_cvtepu32_epi64(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_x_kadd_f32(simde_float32 *sum, simde_float32 *c, simde_float32 y)
+{
+  /* Kahan summation for accurate summation of floating-point numbers.
+   * http://blog.zachbjornson.com/2019/08/11/fast-float-summation.html */
+    y -= *c;
+    simde_float32 t = *sum + y;
+    *c = (t - *sum) - y;
+    *sum = t;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+void
+simde_x_kadd_f64(simde_float64 *sum, simde_float64 *c, simde_float64 y) {
+  /* Kahan summation for accurate summation of floating-point numbers.
+   * http://blog.zachbjornson.com/2019/08/11/fast-float-summation.html */
+    y -= *c;
+    simde_float64 t = *sum + y;
+    *c = (t - *sum) - y;
+    *sum = t;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_dp_pd (simde__m128d a, simde__m128d b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128d_private
+    r_,
+    a_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    /* shortcut cases */
+    if (imm8 == 0xFF) {
+      r_.neon_f64 = vdupq_n_f64(vaddvq_f64(simde_mm_mul_pd(a, b)));
+      return simde__m128d_from_private(r_);
+    }
+    if (imm8 == 0x13) {
+      float64x2_t m = simde_mm_mul_pd(a, b);
+      m = vsetq_lane_f64(0, m, 1);
+      r_.neon_f64 = vdupq_n_f64(vaddvq_f64(m));
+      return simde__m128d_from_private(r_);
+    }
+    simde_float64 s = 0, c = 0;
+    float64x2_t f64a = a_.neon_f64;
+    float64x2_t f64b = b_.neon_f64;
+
+    /* To improve the accuracy of floating-point summation, Kahan algorithm
+     * is used for each operation. */
+    if (imm8 & (1 << 4))
+      simde_x_kadd_f64(&s, &c, vgetq_lane_f64(f64a, 0) * vgetq_lane_f64(f64b, 0));
+    if (imm8 & (1 << 5))
+      simde_x_kadd_f64(&s, &c, vgetq_lane_f64(f64a, 1) * vgetq_lane_f64(f64b, 1));
+    s += c;
+
+    simde_float64 res[2] = {
+      (imm8 & 0x1) ? s : 0,
+      (imm8 & 0x2) ? s : 0
+    };
+    r_.neon_f64 = vld1q_f64(res);
+  #else
+    simde_float64 sum = SIMDE_FLOAT64_C(0.0);
+
+    SIMDE_VECTORIZE_REDUCTION(+:sum)
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      sum += ((imm8 >> (i + 4)) & 1) ? (a_.f64[i] * b_.f64[i]) : 0.0;
+    }
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = ((imm8 >> i) & 1) ? sum : 0.0;
+    }
+  #endif
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_dp_pd(a, b, imm8) _mm_dp_pd(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_dp_pd
+  #define _mm_dp_pd(a, b, imm8) simde_mm_dp_pd(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_dp_ps (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      /* shortcut cases */
+      if (imm8 == 0xFF) {
+        r_.neon_f32 = vdupq_n_f32(vaddvq_f32(simde_mm_mul_ps(a, b)));
+        return simde__m128_from_private(r_);
+      }
+      if (imm8 == 0x7F) {
+        float32x4_t m = simde_mm_mul_ps(a, b);
+        m = vsetq_lane_f32(0, m, 3);
+        r_.neon_f32 = vdupq_n_f32(vaddvq_f32(m));
+        return simde__m128_from_private(r_);
+      }
+    #endif
+
+    simde_float32 s = 0, c = 0;
+    float32x4_t f32a = a_.neon_f32;
+    float32x4_t f32b = b_.neon_f32;
+
+    /* To improve the accuracy of floating-point summation, Kahan algorithm
+     * is used for each operation. */
+    if (imm8 & (1 << 4))
+      simde_x_kadd_f32(&s, &c, vgetq_lane_f32(f32a, 0) * vgetq_lane_f32(f32b, 0));
+    if (imm8 & (1 << 5))
+      simde_x_kadd_f32(&s, &c, vgetq_lane_f32(f32a, 1) * vgetq_lane_f32(f32b, 1));
+    if (imm8 & (1 << 6))
+      simde_x_kadd_f32(&s, &c, vgetq_lane_f32(f32a, 2) * vgetq_lane_f32(f32b, 2));
+    if (imm8 & (1 << 7))
+      simde_x_kadd_f32(&s, &c, vgetq_lane_f32(f32a, 3) * vgetq_lane_f32(f32b, 3));
+    s += c;
+
+    simde_float32 res[4] = {
+      (imm8 & 0x1) ? s : 0,
+      (imm8 & 0x2) ? s : 0,
+      (imm8 & 0x4) ? s : 0,
+      (imm8 & 0x8) ? s : 0
+    };
+    r_.neon_f32 = vld1q_f32(res);
+  #else
+    simde_float32 sum = SIMDE_FLOAT32_C(0.0);
+
+    SIMDE_VECTORIZE_REDUCTION(+:sum)
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      sum += ((imm8 >> (i + 4)) & 1) ? (a_.f32[i] * b_.f32[i]) : SIMDE_FLOAT32_C(0.0);
+    }
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = ((imm8 >> i) & 1) ? sum : SIMDE_FLOAT32_C(0.0);
+    }
+  #endif
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_dp_ps(a, b, imm8) _mm_dp_ps(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_dp_ps
+  #define _mm_dp_ps(a, b, imm8) simde_mm_dp_ps(a, b, imm8)
+#endif
+
+#if defined(simde_mm_extract_epi8)
+#  undef simde_mm_extract_epi8
+#endif
+SIMDE_FUNCTION_ATTRIBUTES
+int8_t
+simde_mm_extract_epi8 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 15)  {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+      (void) imm8;
+    #endif
+    return vec_extract(a_.altivec_i8, imm8);
+  #else
+    return a_.i8[imm8 & 15];
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(SIMDE_BUG_GCC_BAD_MM_EXTRACT_EPI8)
+#  define simde_mm_extract_epi8(a, imm8) HEDLEY_STATIC_CAST(int8_t, _mm_extract_epi8(a, imm8))
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_extract_epi8(a, imm8) vgetq_lane_s8(simde__m128i_to_private(a).neon_i8, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_extract_epi8
+  #define _mm_extract_epi8(a, imm8) HEDLEY_STATIC_CAST(int, simde_mm_extract_epi8(a, imm8))
+#endif
+
+#if defined(simde_mm_extract_epi32)
+#  undef simde_mm_extract_epi32
+#endif
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_extract_epi32 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3)  {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+      (void) imm8;
+    #endif
+    return vec_extract(a_.altivec_i32, imm8);
+  #else
+    return a_.i32[imm8 & 3];
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_extract_epi32(a, imm8) _mm_extract_epi32(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_extract_epi32(a, imm8) vgetq_lane_s32(simde__m128i_to_private(a).neon_i32, imm8)
+#elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+#  define simde_mm_extract_epi32(a, imm8) HEDLEY_STATIC_CAST(int32_t, vec_extract(simde__m128i_to_private(a).altivec_i32, imm8))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_extract_epi32
+  #define _mm_extract_epi32(a, imm8) simde_mm_extract_epi32(a, imm8)
+#endif
+
+#if defined(simde_mm_extract_epi64)
+#  undef simde_mm_extract_epi64
+#endif
+SIMDE_FUNCTION_ATTRIBUTES
+int64_t
+simde_mm_extract_epi64 (simde__m128i a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1)  {
+  simde__m128i_private
+    a_ = simde__m128i_to_private(a);
+
+  #if defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+    #if defined(SIMDE_BUG_GCC_95227)
+      (void) a_;
+      (void) imm8;
+    #endif
+    return vec_extract(a_.altivec_i64, imm8);
+  #else
+    return a_.i64[imm8 & 1];
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#  define simde_mm_extract_epi64(a, imm8) _mm_extract_epi64(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_extract_epi64(a, imm8) vgetq_lane_s64(simde__m128i_to_private(a).neon_i64, imm8)
+#elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE)
+#  define simde_mm_extract_epi64(a, imm8) HEDLEY_STATIC_CAST(int64_t, vec_extract(simde__m128i_to_private(a).altivec_i64, imm8))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_extract_epi64
+  #define _mm_extract_epi64(a, imm8) simde_mm_extract_epi64(a, imm8)
+#endif
+
+#if defined(simde_mm_extract_ps)
+#  undef simde_mm_extract_ps
+#endif
+SIMDE_FUNCTION_ATTRIBUTES
+int32_t
+simde_mm_extract_ps (simde__m128 a, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3)  {
+  simde__m128_private
+    a_ = simde__m128_to_private(a);
+
+  return a_.i32[imm8 & 3];
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+  #define simde_mm_extract_ps(a, imm8) _mm_extract_ps(a, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_extract_ps(a, imm8) vgetq_lane_s32(simde__m128_to_private(a).neon_i32, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_extract_ps
+  #define _mm_extract_ps(a, imm8) simde_mm_extract_ps(a, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_floor_pd (simde__m128d a) {
+  return simde_mm_round_pd(a, SIMDE_MM_FROUND_TO_NEG_INF);
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_floor_pd
+  #define _mm_floor_pd(a) simde_mm_floor_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_floor_ps (simde__m128 a) {
+  return simde_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEG_INF);
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_floor_ps
+  #define _mm_floor_ps(a) simde_mm_floor_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_floor_sd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_floor_sd(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    #if defined(simde_math_floor)
+      r_.f64[0] = simde_math_floor(b_.f64[0]);
+      r_.f64[1] = a_.f64[1];
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_floor_sd
+  #define _mm_floor_sd(a, b) simde_mm_floor_sd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_floor_ss (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_floor_ss(a, b);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+      return simde_mm_move_ss(a, simde_mm_floor_ps(b));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    #if defined(simde_math_floorf)
+      r_.f32[0] = simde_math_floorf(b_.f32[0]);
+      for (size_t i = 1 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = a_.f32[i];
+      }
+    #else
+      HEDLEY_UNREACHABLE();
+    #endif
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_floor_ss
+  #define _mm_floor_ss(a, b) simde_mm_floor_ss(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_insert_epi8 (simde__m128i a, int i, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 15)  {
+  simde__m128i_private
+    r_ = simde__m128i_to_private(a);
+
+  r_.i8[imm8] = HEDLEY_STATIC_CAST(int8_t, i);
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+  /* clang-3.8 returns an incompatible type, so we need the cast.  MSVC
+   * can't handle the cast ("error C2440: 'type cast': cannot convert
+   * from '__m128i' to '__m128i'").  */
+  #if defined(__clang__)
+    #define simde_mm_insert_epi8(a, i, imm8) HEDLEY_STATIC_CAST(__m128i, _mm_insert_epi8(a, i, imm8))
+  #else
+    #define simde_mm_insert_epi8(a, i, imm8) _mm_insert_epi8(a, i, imm8)
+  #endif
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_insert_epi8(a, i, imm8) simde__m128i_from_neon_i8(vsetq_lane_s8(i, simde__m128i_to_private(a).i8, imm8))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_insert_epi8
+  #define _mm_insert_epi8(a, i, imm8) simde_mm_insert_epi8(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_insert_epi32 (simde__m128i a, int i, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 3)  {
+  simde__m128i_private
+    r_ = simde__m128i_to_private(a);
+
+  r_.i32[imm8] = HEDLEY_STATIC_CAST(int32_t, i);
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+  #if defined(__clang__)
+    #define simde_mm_insert_epi32(a, i, imm8) HEDLEY_STATIC_CAST(__m128i, _mm_insert_epi32(a, i, imm8))
+  #else
+    #define simde_mm_insert_epi32(a, i, imm8) _mm_insert_epi32(a, i, imm8)
+  #endif
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_insert_epi32(a, i, imm8) simde__m128i_from_neon_i32(vsetq_lane_s32(i, simde__m128i_to_private(a).i32, imm8))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_insert_epi32
+  #define _mm_insert_epi32(a, i, imm8) simde_mm_insert_epi32(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_insert_epi64 (simde__m128i a, int64_t i, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 1)  {
+  #if defined(SIMDE_BUG_GCC_94482)
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a);
+
+    switch(imm8) {
+      case 0:
+        return simde_mm_set_epi64x(a_.i64[1], i);
+        break;
+      case 1:
+        return simde_mm_set_epi64x(i, a_.i64[0]);
+        break;
+      default:
+        HEDLEY_UNREACHABLE();
+        break;
+    }
+  #else
+    simde__m128i_private
+      r_ = simde__m128i_to_private(a);
+
+    r_.i64[imm8] = i;
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE) && defined(SIMDE_ARCH_AMD64)
+#  define simde_mm_insert_epi64(a, i, imm8) _mm_insert_epi64(a, i, imm8)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+#  define simde_mm_insert_epi64(a, i, imm8) simde__m128i_from_neon_i64(vsetq_lane_s64(i, simde__m128i_to_private(a).i64, imm8))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_insert_epi64
+  #define _mm_insert_epi64(a, i, imm8) simde_mm_insert_epi64(a, i, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_insert_ps (simde__m128 a, simde__m128 b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 255)  {
+  simde__m128_private
+    r_,
+    a_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  a_.f32[0] = b_.f32[(imm8 >> 6) & 3];
+  a_.f32[(imm8 >> 4) & 3] = a_.f32[0];
+
+  SIMDE_VECTORIZE
+  for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+    r_.f32[i] = (imm8 >> i) ? SIMDE_FLOAT32_C(0.0) : a_.f32[i];
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_insert_ps(a, b, imm8) _mm_insert_ps(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_insert_ps
+  #define _mm_insert_ps(a, b, imm8) simde_mm_insert_ps(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(__PGI)
+    return _mm_max_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vmaxq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i8 = vec_max(a_.altivec_i8, b_.altivec_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] > b_.i8[i] ? a_.i8[i] : b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_max_epi8
+  #define _mm_max_epi8(a, b) simde_mm_max_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(__PGI)
+    return _mm_max_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmaxq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_max(a_.altivec_i32, b_.altivec_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] > b_.i32[i] ? a_.i32[i] : b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_max_epi32
+  #define _mm_max_epi32(a, b) simde_mm_max_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vmaxq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u16 = vec_max(a_.altivec_u16, b_.altivec_u16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] > b_.u16[i] ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_max_epu16
+  #define _mm_max_epu16(a, b) simde_mm_max_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_max_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_max_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vmaxq_u32(a_.neon_u32, b_.neon_u32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x4_max(a_.wasm_v128, b_.wasm_v128);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_u32 = vec_max(a_.altivec_u32, b_.altivec_u32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] > b_.u32[i] ? a_.u32[i] : b_.u32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_max_epu32
+  #define _mm_max_epu32(a, b) simde_mm_max_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(__PGI)
+    return _mm_min_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vminq_s8(a_.neon_i8, b_.neon_i8);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x16_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] < b_.i8[i] ? a_.i8[i] : b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_min_epi8
+  #define _mm_min_epi8(a, b) simde_mm_min_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE) && !defined(__PGI)
+    return _mm_min_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vminq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] < b_.i32[i] ? a_.i32[i] : b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_min_epi32
+  #define _mm_min_epi32(a, b) simde_mm_min_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u16 = vminq_u16(a_.neon_u16, b_.neon_u16);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x8_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] < b_.u16[i] ? a_.u16[i] : b_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_min_epu16
+  #define _mm_min_epu16(a, b) simde_mm_min_epu16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_min_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_min_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vminq_u32(a_.neon_u32, b_.neon_u32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x4_min(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] < b_.u32[i] ? a_.u32[i] : b_.u32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_min_epu32
+  #define _mm_min_epu32(a, b) simde_mm_min_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_minpos_epu16 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_minpos_epu16(a);
+  #else
+    simde__m128i_private
+      r_ = simde__m128i_to_private(simde_mm_setzero_si128()),
+      a_ = simde__m128i_to_private(a);
+
+    r_.u16[0] = UINT16_MAX;
+    for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+      if (a_.u16[i] < r_.u16[0]) {
+        r_.u16[0] = a_.u16[i];
+        r_.u16[1] = HEDLEY_STATIC_CAST(uint16_t, i);
+      }
+    }
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_minpos_epu16
+  #define _mm_minpos_epu16(a) simde_mm_minpos_epu16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mpsadbw_epu8 (simde__m128i a, simde__m128i b, const int imm8)
+    SIMDE_REQUIRE_RANGE(imm8, 0, 7)  {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  const int a_offset = imm8 & 4;
+  const int b_offset = (imm8 & 3) << 2;
+
+#if defined(simde_math_abs)
+  for (int i = 0 ; i < HEDLEY_STATIC_CAST(int, (sizeof(r_.u16) / sizeof(r_.u16[0]))) ; i++) {
+    r_.u16[i] =
+      HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset + i + 0] - b_.u8[b_offset + 0]))) +
+      HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset + i + 1] - b_.u8[b_offset + 1]))) +
+      HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset + i + 2] - b_.u8[b_offset + 2]))) +
+      HEDLEY_STATIC_CAST(uint16_t, simde_math_abs(HEDLEY_STATIC_CAST(int, a_.u8[a_offset + i + 3] - b_.u8[b_offset + 3])));
+  }
+#else
+  HEDLEY_UNREACHABLE();
+#endif
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_mpsadbw_epu8(a, b, imm8) _mm_mpsadbw_epu8(a, b, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mpsadbw_epu8
+  #define _mm_mpsadbw_epu8(a, b, imm8) simde_mm_mpsadbw_epu8(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mul_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_mul_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // vmull_s32 upcasts instead of masking, so we downcast.
+      int32x2_t a_lo = vmovn_s64(a_.neon_i64);
+      int32x2_t b_lo = vmovn_s64(b_.neon_i64);
+      r_.neon_i64 = vmull_s32(a_lo, b_lo);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x2_make(
+        wasm_i32x4_extract_lane(a_.wasm_v128, 0) * HEDLEY_STATIC_CAST(int64_t, wasm_i32x4_extract_lane(b_.wasm_v128, 0)),
+        wasm_i32x4_extract_lane(a_.wasm_v128, 2) * HEDLEY_STATIC_CAST(int64_t, wasm_i32x4_extract_lane(b_.wasm_v128, 2)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] =
+          HEDLEY_STATIC_CAST(int64_t, a_.i32[i * 2]) *
+          HEDLEY_STATIC_CAST(int64_t, b_.i32[i * 2]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mul_epi32
+  #define _mm_mul_epi32(a, b) simde_mm_mul_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mullo_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_mullo_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vmulq_s32(a_.neon_i32, b_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      (void) a_;
+      (void) b_;
+      r_.altivec_i32 = vec_mul(a_.altivec_i32, b_.altivec_i32);
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_mul(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t, (HEDLEY_STATIC_CAST(uint64_t, (HEDLEY_STATIC_CAST(int64_t, a_.i32[i]) * HEDLEY_STATIC_CAST(int64_t, b_.i32[i]))) & 0xffffffff));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_mullo_epi32
+  #define _mm_mullo_epi32(a, b) simde_mm_mullo_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_x_mm_mullo_epu32 (simde__m128i a, simde__m128i b) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_u32 = vmulq_u32(a_.neon_u32, b_.neon_u32);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 * b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] * b_.u32[i];
+      }
+    #endif
+
+  return simde__m128i_from_private(r_);
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_packus_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_packus_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      const int32x4_t z = vdupq_n_s32(0);
+      r_.neon_u16 = vcombine_u16(
+          vqmovn_u32(vreinterpretq_u32_s32(vmaxq_s32(z, a_.neon_i32))),
+          vqmovn_u32(vreinterpretq_u32_s32(vmaxq_s32(z, b_.neon_i32))));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.u16[i + 0] = (a_.i32[i] < 0) ? UINT16_C(0) : ((a_.i32[i] > UINT16_MAX) ? (UINT16_MAX) : HEDLEY_STATIC_CAST(uint16_t, a_.i32[i]));
+        r_.u16[i + 4] = (b_.i32[i] < 0) ? UINT16_C(0) : ((b_.i32[i] > UINT16_MAX) ? (UINT16_MAX) : HEDLEY_STATIC_CAST(uint16_t, b_.i32[i]));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_packus_epi32
+  #define _mm_packus_epi32(a, b) simde_mm_packus_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_round_sd (simde__m128d a, simde__m128d b, int rounding)
+    SIMDE_REQUIRE_CONSTANT_RANGE(rounding, 0, 15) {
+  simde__m128d_private
+    r_ = simde__m128d_to_private(a),
+    b_ = simde__m128d_to_private(b);
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(simde_math_nearbyint)
+      case SIMDE_MM_FROUND_TO_NEAREST_INT:
+      case SIMDE_MM_FROUND_CUR_DIRECTION:
+        r_.f64[0] = simde_math_nearbyint(b_.f64[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_floor)
+      case SIMDE_MM_FROUND_TO_NEG_INF:
+        r_.f64[0] = simde_math_floor(b_.f64[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_ceil)
+      case SIMDE_MM_FROUND_TO_POS_INF:
+        r_.f64[0] = simde_math_ceil(b_.f64[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_trunc)
+      case SIMDE_MM_FROUND_TO_ZERO:
+        r_.f64[0] = simde_math_trunc(b_.f64[0]);
+        break;
+    #endif
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+  }
+
+  return simde__m128d_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_round_sd(a, b, rounding) _mm_round_sd(a, b, rounding)
+#elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+#  define simde_mm_round_sd(a, b, rounding) simde_mm_move_sd(a, simde_mm_round_pd(b, rounding))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_round_sd
+  #define _mm_round_sd(a, b, rounding) simde_mm_round_sd(a, b, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_round_ss (simde__m128 a, simde__m128 b, int rounding)
+    SIMDE_REQUIRE_CONSTANT_RANGE(rounding, 0, 15) {
+  simde__m128_private
+    r_ = simde__m128_to_private(a),
+    b_ = simde__m128_to_private(b);
+
+  switch (rounding & ~SIMDE_MM_FROUND_NO_EXC) {
+    #if defined(simde_math_nearbyintf)
+      case SIMDE_MM_FROUND_TO_NEAREST_INT:
+      case SIMDE_MM_FROUND_CUR_DIRECTION:
+        r_.f32[0] = simde_math_nearbyintf(b_.f32[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_floorf)
+      case SIMDE_MM_FROUND_TO_NEG_INF:
+        r_.f32[0] = simde_math_floorf(b_.f32[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_ceilf)
+      case SIMDE_MM_FROUND_TO_POS_INF:
+        r_.f32[0] = simde_math_ceilf(b_.f32[0]);
+        break;
+    #endif
+
+    #if defined(simde_math_truncf)
+      case SIMDE_MM_FROUND_TO_ZERO:
+        r_.f32[0] = simde_math_truncf(b_.f32[0]);
+        break;
+    #endif
+
+    default:
+      HEDLEY_UNREACHABLE_RETURN(simde_mm_undefined_pd());
+  }
+
+  return simde__m128_from_private(r_);
+}
+#if defined(SIMDE_X86_SSE4_1_NATIVE)
+#  define simde_mm_round_ss(a, b, rounding) _mm_round_ss(a, b, rounding)
+#elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+#  define simde_mm_round_ss(a, b, rounding) simde_mm_move_ss(a, simde_mm_round_ps(b, rounding))
+#endif
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_round_ss
+  #define _mm_round_ss(a, b, rounding) simde_mm_round_ss(a, b, rounding)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_stream_load_si128 (const simde__m128i* mem_addr) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_stream_load_si128(HEDLEY_CONST_CAST(simde__m128i*, mem_addr));
+  #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+    return vreinterpretq_s64_s32(vld1q_s32(HEDLEY_REINTERPRET_CAST(int32_t const*, mem_addr)));
+  #else
+    return *mem_addr;
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_stream_load_si128
+  #define _mm_stream_load_si128(mem_addr) simde_mm_stream_load_si128(mem_addr)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_test_all_ones (simde__m128i a) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_test_all_ones(a);
+  #else
+    simde__m128i_private a_ = simde__m128i_to_private(a);
+    int r;
+
+    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r = vec_all_eq(a_.altivec_i32, vec_splats(~0));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return r = ((vgetq_lane_s64(a_.neon_i64, 0) & vgetq_lane_s64(a_.neon_i64, 1)) == ~HEDLEY_STATIC_CAST(int64_t, 0));
+    #else
+      int_fast32_t r_ = ~HEDLEY_STATIC_CAST(int_fast32_t, 0);
+
+      SIMDE_VECTORIZE_REDUCTION(&:r_)
+      for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+        r_ &= a_.i32f[i];
+      }
+
+      r = (r_ == ~HEDLEY_STATIC_CAST(int_fast32_t, 0));
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_test_all_ones
+  #define _mm_test_all_ones(a) simde_mm_test_all_ones(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_test_all_zeros (simde__m128i a, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_test_all_zeros(a, mask);
+  #else
+    simde__m128i_private tmp_ = simde__m128i_to_private(simde_mm_and_si128(a, mask));
+    int r;
+
+    #if defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r = vec_all_eq(tmp_.altivec_i32, vec_splats(0));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return !(vgetq_lane_s64(tmp_.neon_i64, 0) | vgetq_lane_s64(tmp_.neon_i64, 1));
+    #else
+      int_fast32_t r_ = HEDLEY_STATIC_CAST(int_fast32_t, 0);
+
+      SIMDE_VECTORIZE_REDUCTION(|:r_)
+      for (size_t i = 0 ; i < (sizeof(tmp_.i32f) / sizeof(tmp_.i32f[0])) ; i++) {
+        r_ |= tmp_.i32f[i];
+      }
+
+      r = !r_;
+    #endif
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_test_all_zeros
+  #define _mm_test_all_zeros(a, mask) simde_mm_test_all_zeros(a, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_test_mix_ones_zeros (simde__m128i a, simde__m128i mask) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_test_mix_ones_zeros(a, mask);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      mask_ = simde__m128i_to_private(mask);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x2_t s640 = vandq_s64(a_.neon_i64, mask_.neon_i64);
+      int64x2_t s641 = vandq_s64(vreinterpretq_s64_s32(vmvnq_s32(vreinterpretq_s32_s64(a_.neon_i64))), mask_.neon_i64);
+      return (((vgetq_lane_s64(s640, 0) | vgetq_lane_s64(s640, 1)) & (vgetq_lane_s64(s641, 0) | vgetq_lane_s64(s641, 1)))!=0);
+    #else
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++)
+        if (((a_.u64[i] & mask_.u64[i]) != 0) && ((~a_.u64[i] & mask_.u64[i]) != 0))
+          return 1;
+
+      return 0;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_test_mix_ones_zeros
+  #define _mm_test_mix_ones_zeros(a, mask) simde_mm_test_mix_ones_zeros(a, mask)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testc_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_testc_si128(a, b);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x2_t s64 = vandq_s64(~a_.neon_i64, b_.neon_i64);
+      return !(vgetq_lane_s64(s64, 0) & vgetq_lane_s64(s64, 1));
+    #else
+      int_fast32_t r = 0;
+
+      SIMDE_VECTORIZE_REDUCTION(|:r)
+      for (size_t i = 0 ; i < (sizeof(a_.i32f) / sizeof(a_.i32f[0])) ; i++) {
+        r |= ~a_.i32f[i] & b_.i32f[i];
+      }
+
+      return HEDLEY_STATIC_CAST(int, !r);
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testc_si128
+  #define _mm_testc_si128(a, b) simde_mm_testc_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testnzc_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_testnzc_si128(a, b);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x2_t s640 = vandq_s64(a_.neon_i64, b_.neon_i64);
+      int64x2_t s641 = vandq_s64(~a_.neon_i64, b_.neon_i64);
+      return (((vgetq_lane_s64(s640, 0) | vgetq_lane_s64(s640, 1)) & (vgetq_lane_s64(s641, 0) | vgetq_lane_s64(s641, 1)))!=0);
+    #else
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        if (((a_.u64[i] & b_.u64[i]) != 0) && ((~a_.u64[i] & b_.u64[i]) != 0))
+          return 1;
+      }
+
+      return 0;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testnzc_si128
+  #define _mm_testnzc_si128(a, b) simde_mm_testnzc_si128(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_testz_si128 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_1_NATIVE)
+    return _mm_testz_si128(a, b);
+  #else
+    simde__m128i_private
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int64x2_t s64 = vandq_s64(a_.neon_i64, b_.neon_i64);
+      return !(vgetq_lane_s64(s64, 0) | vgetq_lane_s64(s64, 1));
+    #else
+      for (size_t i = 0 ; i < (sizeof(a_.u64) / sizeof(a_.u64[0])) ; i++) {
+        if ((a_.u64[i] & b_.u64[i]) == 0)
+          return 1;
+      }
+    #endif
+
+    return 0;
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_1_ENABLE_NATIVE_ALIASES)
+  #undef _mm_testz_si128
+  #define _mm_testz_si128(a, b) simde_mm_testz_si128(a, b)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE4_1_H) */

--- a/2.0/simde/x86/sse4.2.h
+++ b/2.0/simde/x86/sse4.2.h
@@ -1,0 +1,365 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017      Evan Nemerson <evan@nemerson.com>
+ *   2020      Hidayat Khan <huk2209@gmail.com>
+ */
+
+#if !defined(SIMDE_X86_SSE4_2_H)
+#define SIMDE_X86_SSE4_2_H
+
+#include "sse4.1.h"
+
+#if defined(__ARM_ACLE) || (defined(__GNUC__) && defined(__ARM_FEATURE_CRC32))
+  #include <arm_acle.h>
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  #define SIMDE_SIDD_UBYTE_OPS _SIDD_UBYTE_OPS
+  #define SIMDE_SIDD_UWORD_OPS _SIDD_UWORD_OPS
+  #define SIMDE_SIDD_SBYTE_OPS _SIDD_SBYTE_OPS
+  #define SIMDE_SIDD_SWORD_OPS _SIDD_SWORD_OPS
+  #define SIMDE_SIDD_CMP_EQUAL_ANY _SIDD_CMP_EQUAL_ANY
+  #define SIMDE_SIDD_CMP_RANGES _SIDD_CMP_RANGES
+  #define SIMDE_SIDD_CMP_EQUAL_EACH _SIDD_CMP_EQUAL_EACH
+  #define SIMDE_SIDD_CMP_EQUAL_ORDERED _SIDD_CMP_EQUAL_ORDERED
+  #define SIMDE_SIDD_POSITIVE_POLARITY _SIDD_POSITIVE_POLARITY
+  #define SIMDE_SIDD_NEGATIVE_POLARITY _SIDD_NEGATIVE_POLARITY
+  #define SIMDE_SIDD_MASKED_POSITIVE_POLARITY _SIDD_MASKED_POSITIVE_POLARITY
+  #define SIMDE_SIDD_MASKED_NEGATIVE_POLARITY _SIDD_MASKED_NEGATIVE_POLARITY
+  #define SIMDE_SIDD_LEAST_SIGNIFICANT _SIDD_LEAST_SIGNIFICANT
+  #define SIMDE_SIDD_MOST_SIGNIFICANT _SIDD_MOST_SIGNIFICANT
+  #define SIMDE_SIDD_BIT_MASK _SIDD_BIT_MASK
+  #define SIMDE_SIDD_UNIT_MASK _SIDD_UNIT_MASK
+#else
+  #define SIMDE_SIDD_UBYTE_OPS 0x00
+  #define SIMDE_SIDD_UWORD_OPS 0x01
+  #define SIMDE_SIDD_SBYTE_OPS 0x02
+  #define SIMDE_SIDD_SWORD_OPS 0x03
+  #define SIMDE_SIDD_CMP_EQUAL_ANY 0x00
+  #define SIMDE_SIDD_CMP_RANGES 0x04
+  #define SIMDE_SIDD_CMP_EQUAL_EACH 0x08
+  #define SIMDE_SIDD_CMP_EQUAL_ORDERED 0x0c
+  #define SIMDE_SIDD_POSITIVE_POLARITY 0x00
+  #define SIMDE_SIDD_NEGATIVE_POLARITY 0x10
+  #define SIMDE_SIDD_MASKED_POSITIVE_POLARITY 0x20
+  #define SIMDE_SIDD_MASKED_NEGATIVE_POLARITY 0x30
+  #define SIMDE_SIDD_LEAST_SIGNIFICANT 0x00
+  #define SIMDE_SIDD_MOST_SIGNIFICANT 0x40
+  #define SIMDE_SIDD_BIT_MASK 0x00
+  #define SIMDE_SIDD_UNIT_MASK 0x40
+#endif
+
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES) && !defined(_SIDD_UBYTE_OPS)
+  #define _SIDD_UBYTE_OPS SIMDE_SIDD_UBYTE_OPS
+  #define _SIDD_UWORD_OPS SIMDE_SIDD_UWORD_OPS
+  #define _SIDD_SBYTE_OPS SIMDE_SIDD_SBYTE_OPS
+  #define _SIDD_SWORD_OPS SIMDE_SIDD_SWORD_OPS
+  #define _SIDD_CMP_EQUAL_ANY SIMDE_SIDD_CMP_EQUAL_ANY
+  #define _SIDD_CMP_RANGES SIMDE_SIDD_CMP_RANGES
+  #define _SIDD_CMP_EQUAL_EACH SIMDE_SIDD_CMP_EQUAL_EACH
+  #define _SIDD_CMP_EQUAL_ORDERED SIMDE_SIDD_CMP_EQUAL_ORDERED
+  #define _SIDD_POSITIVE_POLARITY SIMDE_SIDD_POSITIVE_POLARITY
+  #define _SIDD_NEGATIVE_POLARITY SIMDE_SIDD_NEGATIVE_POLARITY
+  #define _SIDD_MASKED_POSITIVE_POLARITY SIMDE_SIDD_MASKED_POSITIVE_POLARITY
+  #define _SIDD_MASKED_NEGATIVE_POLARITY SIMDE_SIDD_MASKED_NEGATIVE_POLARITY
+  #define _SIDD_LEAST_SIGNIFICANT SIMDE_SIDD_LEAST_SIGNIFICANT
+  #define _SIDD_MOST_SIGNIFICANT SIMDE_SIDD_MOST_SIGNIFICANT
+  #define _SIDD_BIT_MASK SIMDE_SIDD_BIT_MASK
+  #define _SIDD_UNIT_MASK SIMDE_SIDD_UNIT_MASK
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int simde_mm_cmpestrs (simde__m128i a, int la, simde__m128i b, int lb, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 127) {
+  #if !defined(HEDLEY_PGI_VERSION)
+    /* https://www.pgroup.com/userforum/viewtopic.php?f=4&p=27590&sid=cf89f8bf30be801831fe4a2ff0a2fa6c */
+    (void) a;
+    (void) b;
+  #endif
+  (void) la;
+  (void) lb;
+  return la <= ((128 / ((imm8 & SIMDE_SIDD_UWORD_OPS) ? 16 : 8)) - 1);
+}
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  #define simde_mm_cmpestrs(a, la, b, lb, imm8) _mm_cmpestrs(a, la, b, lb, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpestrs
+  #define _mm_cmpestrs(a, la, b, lb, imm8) simde_mm_cmpestrs(a, la, b, lb, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int simde_mm_cmpestrz (simde__m128i a, int la, simde__m128i b, int lb, const int imm8)
+    SIMDE_REQUIRE_CONSTANT_RANGE(imm8, 0, 127) {
+  #if !defined(HEDLEY_PGI_VERSION)
+    /* https://www.pgroup.com/userforum/viewtopic.php?f=4&p=27590&sid=cf89f8bf30be801831fe4a2ff0a2fa6c */
+    (void) a;
+    (void) b;
+  #endif
+  (void) la;
+  (void) lb;
+  return lb <= ((128 / ((imm8 & SIMDE_SIDD_UWORD_OPS) ? 16 : 8)) - 1);
+}
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  #define simde_mm_cmpestrz(a, la, b, lb, imm8) _mm_cmpestrz(a, la, b, lb, imm8)
+#endif
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpestrz
+  #define _mm_cmpestrz(a, la, b, lb, imm8) simde_mm_cmpestrz(a, la, b, lb, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_cmpgt_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_cmpgt_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_u64 = vcgtq_s64(a_.neon_i64, b_.neon_i64);
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // ARMv7 lacks vcgtq_s64.
+      // This is based off of Clang's SSE2 polyfill:
+      // (a > b) -> ((a_hi > b_hi) || (a_lo > b_lo && a_hi == b_hi))
+
+      // Mask the sign bit out since we need a signed AND an unsigned comparison
+      // and it is ugly to try and split them.
+      int32x4_t mask   = vreinterpretq_s32_s64(vdupq_n_s64(0x80000000ull));
+      int32x4_t a_mask = veorq_s32(a_.neon_i32, mask);
+      int32x4_t b_mask = veorq_s32(b_.neon_i32, mask);
+      // Check if a > b
+      int64x2_t greater = vreinterpretq_s64_u32(vcgtq_s32(a_mask, b_mask));
+      // Copy upper mask to lower mask
+      // a_hi > b_hi
+      int64x2_t gt_hi = vshrq_n_s64(greater, 63);
+      // Copy lower mask to upper mask
+      // a_lo > b_lo
+      int64x2_t gt_lo = vsliq_n_s64(greater, greater, 32);
+      // Compare for equality
+      int64x2_t equal = vreinterpretq_s64_u32(vceqq_s32(a_mask, b_mask));
+      // Copy upper mask to lower mask
+      // a_hi == b_hi
+      int64x2_t eq_hi = vshrq_n_s64(equal, 63);
+      // a_hi > b_hi || (a_lo > b_lo && a_hi == b_hi)
+      int64x2_t ret = vorrq_s64(gt_hi, vandq_s64(gt_lo, eq_hi));
+      r_.neon_i64 = ret;
+    #elif defined(SIMDE_POWER_ALTIVEC_P8_NATIVE)
+      r_.altivec_u64 = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned long long), vec_cmpgt(a_.altivec_i64, b_.altivec_i64));
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = HEDLEY_STATIC_CAST(__typeof__(r_.i64), a_.i64 > b_.i64);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = (a_.i64[i] > b_.i64[i]) ? ~INT64_C(0) : INT64_C(0);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpgt_epi64
+  #define _mm_cmpgt_epi64(a, b) simde_mm_cmpgt_epi64(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_cmpistrs_8_(simde__m128i a) {
+  simde__m128i_private a_= simde__m128i_to_private(a);
+  const int upper_bound = (128 / 8) - 1;
+  int a_invalid = 0;
+  SIMDE_VECTORIZE
+  for (int i = 0 ; i <= upper_bound ; i++) {
+    if(!a_.i8[i])
+      a_invalid = 1;
+  }
+  return a_invalid;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_cmpistrs_16_(simde__m128i a) {
+  simde__m128i_private a_= simde__m128i_to_private(a);
+  const int upper_bound = (128 / 16) - 1;
+  int a_invalid = 0;
+  SIMDE_VECTORIZE
+  for (int i = 0 ; i <= upper_bound ; i++) {
+    if(!a_.i16[i])
+      a_invalid = 1;
+  }
+  return a_invalid;
+}
+
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  #define simde_mm_cmpistrs(a, b, imm8) _mm_cmpistrs(a, b, imm8)
+#else
+  #define simde_mm_cmpistrs(a, b, imm8) \
+     (((imm8) & SIMDE_SIDD_UWORD_OPS) \
+       ? simde_mm_cmpistrs_16_((a)) \
+       : simde_mm_cmpistrs_8_((a)))
+#endif
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpistrs
+  #define _mm_cmpistrs(a, b, imm8) simde_mm_cmpistrs(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_cmpistrz_8_(simde__m128i b) {
+  simde__m128i_private b_= simde__m128i_to_private(b);
+  const int upper_bound = (128 / 8) - 1;
+  int b_invalid = 0;
+  SIMDE_VECTORIZE
+  for (int i = 0 ; i <= upper_bound ; i++) {
+    if(!b_.i8[i])
+      b_invalid = 1;
+  }
+  return b_invalid;
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+int
+simde_mm_cmpistrz_16_(simde__m128i b) {
+  simde__m128i_private b_= simde__m128i_to_private(b);
+  const int upper_bound = (128 / 16) - 1;
+  int b_invalid = 0;
+  SIMDE_VECTORIZE
+  for (int i = 0 ; i <= upper_bound ; i++) {
+    if(!b_.i16[i])
+      b_invalid = 1;
+  }
+  return b_invalid;
+}
+
+#if defined(SIMDE_X86_SSE4_2_NATIVE)
+  #define simde_mm_cmpistrz(a, b, imm8) _mm_cmpistrz(a, b, imm8)
+#else
+  #define simde_mm_cmpistrz(a, b, imm8) \
+     (((imm8) & SIMDE_SIDD_UWORD_OPS) \
+       ? simde_mm_cmpistrz_16_((b)) \
+       : simde_mm_cmpistrz_8_((b)))
+#endif
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cmpistrz
+  #define _mm_cmpistrz(a, b, imm8) simde_mm_cmpistrz(a, b, imm8)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_mm_crc32_u8(uint32_t prevcrc, uint8_t v) {
+  #if defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_crc32_u8(prevcrc, v);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_CRC32)
+      return __crc32cb(prevcrc, v);
+    #else
+      uint32_t crc = prevcrc;
+      crc ^= v;
+      for(int bit = 0 ; bit < 8 ; bit++) {
+        if (crc & 1)
+          crc = (crc >> 1) ^ UINT32_C(0x82f63b78);
+        else
+          crc = (crc >> 1);
+      }
+      return crc;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #define _mm_crc32_u8(prevcrc, v) simde_mm_crc32_u8(prevcrc, v)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_mm_crc32_u16(uint32_t prevcrc, uint16_t v) {
+  #if defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_crc32_u16(prevcrc, v);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_CRC32)
+      return __crc32ch(prevcrc, v);
+    #else
+      uint32_t crc = prevcrc;
+      crc = simde_mm_crc32_u8(crc, v & 0xff);
+      crc = simde_mm_crc32_u8(crc, (v >> 8) & 0xff);
+      return crc;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #define _mm_crc32_u16(prevcrc, v) simde_mm_crc32_u16(prevcrc, v)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint32_t
+simde_mm_crc32_u32(uint32_t prevcrc, uint32_t v) {
+  #if defined(SIMDE_X86_SSE4_2_NATIVE)
+    return _mm_crc32_u32(prevcrc, v);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_CRC32)
+      return __crc32cw(prevcrc, v);
+    #else
+      uint32_t crc = prevcrc;
+      crc = simde_mm_crc32_u16(crc, v & 0xffff);
+      crc = simde_mm_crc32_u16(crc, (v >> 16) & 0xffff);
+      return crc;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #define _mm_crc32_u32(prevcrc, v) simde_mm_crc32_u32(prevcrc, v)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+uint64_t
+simde_mm_crc32_u64(uint64_t prevcrc, uint64_t v) {
+  #if defined(SIMDE_X86_SSE4_2_NATIVE) && defined(SIMDE_ARCH_AMD64)
+    return _mm_crc32_u64(prevcrc, v);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE) && defined(__ARM_FEATURE_CRC32)
+      return __crc32cd(HEDLEY_STATIC_CAST(uint32_t, prevcrc), v);
+    #else
+      uint64_t crc = prevcrc;
+      crc = simde_mm_crc32_u32(HEDLEY_STATIC_CAST(uint32_t, crc), v & 0xffffffff);
+      crc = simde_mm_crc32_u32(HEDLEY_STATIC_CAST(uint32_t, crc), (v >> 32) & 0xffffffff);
+      return crc;
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSE4_2_ENABLE_NATIVE_ALIASES)
+  #define _mm_crc32_u64(prevcrc, v) simde_mm_crc32_u64(prevcrc, v)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE4_2_H) */

--- a/2.0/simde/x86/ssse3.h
+++ b/2.0/simde/x86/ssse3.h
@@ -1,0 +1,1065 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2017-2020 Evan Nemerson <evan@nemerson.com>
+ */
+
+#if !defined(SIMDE_X86_SSSE3_H)
+#define SIMDE_X86_SSSE3_H
+
+#include "sse3.h"
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_abs_epi8 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi8(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vabsq_s8(a_.neon_i8);
+  #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+    r_.altivec_i8 = vec_abs(a_.altivec_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, (a_.i8[i] < 0) ? (- a_.i8[i]) : a_.i8[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_epi8(a) simde_mm_abs_epi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_abs_epi16 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi16(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vabsq_s16(a_.neon_i16);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i16 = vec_abs(a_.altivec_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.i16[i] < 0) ? (- a_.i16[i]) : a_.i16[i]);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_epi16(a) simde_mm_abs_epi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_abs_epi32 (simde__m128i a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_abs_epi32(a);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vabsq_s32(a_.neon_i32);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      r_.altivec_i32 = vec_abs(a_.altivec_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        #if defined(_MSC_VER)
+          HEDLEY_DIAGNOSTIC_PUSH
+          #pragma warning(disable:4146)
+        #endif
+        r_.u32[i] = (a_.i32[i] < 0) ? (- HEDLEY_STATIC_CAST(uint32_t, a_.i32[i])) : HEDLEY_STATIC_CAST(uint32_t, a_.i32[i]);
+        #if defined(_MSC_VER)
+          HEDLEY_DIAGNOSTIC_POP
+        #endif
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_epi32(a) simde_mm_abs_epi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_abs_pi8 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi8(a);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i8 = vabs_s8(a_.neon_i8);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.u8[i] = HEDLEY_STATIC_CAST(uint8_t, (a_.i8[i] < 0) ? (- a_.i8[i]) : a_.i8[i]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_pi8(a) simde_mm_abs_pi8(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_abs_pi16 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi16(a);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i16 = vabs_s16(a_.neon_i16);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.u16[i] = HEDLEY_STATIC_CAST(uint16_t, (a_.i16[i] < 0) ? (- a_.i16[i]) : a_.i16[i]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_pi16(a) simde_mm_abs_pi16(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_abs_pi32 (simde__m64 a) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_abs_pi32(a);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_i32 = vabs_s32(a_.neon_i32);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.u32[i] = HEDLEY_STATIC_CAST(uint32_t, (a_.i32[i] < 0) ? (- a_.i32[i]) : a_.i32[i]);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_abs_pi32(a) simde_mm_abs_pi32(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_alignr_epi8 (simde__m128i a, simde__m128i b, int count)
+    SIMDE_REQUIRE_CONSTANT_RANGE(count, 0, 31) {
+  simde__m128i_private
+    r_,
+    a_ = simde__m128i_to_private(a),
+    b_ = simde__m128i_to_private(b);
+
+  if (HEDLEY_UNLIKELY(count > 31))
+    return simde_mm_setzero_si128();
+
+  for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+    const int srcpos = count + HEDLEY_STATIC_CAST(int, i);
+    if (srcpos > 31) {
+      r_.i8[i] = 0;
+    } else if (srcpos > 15) {
+      r_.i8[i] = a_.i8[(srcpos) & 15];
+    } else {
+      r_.i8[i] = b_.i8[srcpos];
+    }
+  }
+
+  return simde__m128i_from_private(r_);
+}
+#if defined(SIMDE_X86_SSSE3_NATIVE)
+  #define simde_mm_alignr_epi8(a, b, count) _mm_alignr_epi8(a, b, count)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_alignr_epi8(a, b, count) \
+    ( \
+      ((count) > 31) \
+        ? simde__m128i_from_neon_i8(vdupq_n_s8(0)) \
+        : ( \
+          ((count) > 15) \
+            ? (simde__m128i_from_neon_i8(vextq_s8(simde__m128i_to_neon_i8(a), vdupq_n_s8(0), (count) & 15))) \
+            : (simde__m128i_from_neon_i8(vextq_s8(simde__m128i_to_neon_i8(b), simde__m128i_to_neon_i8(a), ((count) & 15))))))
+#endif
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+  #define _mm_alignr_epi8(a, b, count) simde_mm_alignr_epi8(a, b, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_alignr_pi8 (simde__m64 a, simde__m64 b, const int count) {
+  simde__m64_private
+    r_,
+    a_ = simde__m64_to_private(a),
+    b_ = simde__m64_to_private(b);
+
+  if (HEDLEY_UNLIKELY(count > 15))
+    return simde_mm_setzero_si64();
+
+  for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+    const int srcpos = count + HEDLEY_STATIC_CAST(int, i);
+    if (srcpos > 15) {
+      r_.i8[i] = 0;
+    } else if (srcpos > 7) {
+      r_.i8[i] = a_.i8[(srcpos) & 7];
+    } else {
+      r_.i8[i] = b_.i8[srcpos];
+    }
+  }
+
+  return simde__m64_from_private(r_);
+}
+#if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+#  define simde_mm_alignr_pi8(a, b, count) _mm_alignr_pi8(a, b, count)
+#elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+  #define simde_mm_alignr_pi8(a, b, count) \
+    ( \
+      ((count) > 15) \
+        ? simde__m64_from_neon_i8(vdup_n_s8(0)) \
+        : ( \
+          ((count) > 7) \
+            ? (simde__m64_from_neon_i8(vext_s8(simde__m64_to_neon_i8(a), vdup_n_s8(0), (count) & 7))) \
+            : (simde__m64_from_neon_i8(vext_s8(simde__m64_to_neon_i8(b), simde__m64_to_neon_i8(a), ((count) & 7))))))
+#endif
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_alignr_pi8(a, b, count) simde_mm_alignr_pi8(a, b, count)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_shuffle_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_shuffle_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i8 = vqtbl1q_s8(a_.neon_i8, vandq_u8(b_.neon_u8, vdupq_n_u8(0x8F)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      /* Mask out the bits we're not interested in.  vtbl will result in 0
+         for any values outside of [0, 15], so if the high bit is set it
+         will return 0, just like in SSSE3. */
+      b_.neon_i8 = vandq_s8(b_.neon_i8, vdupq_n_s8(HEDLEY_STATIC_CAST(int8_t, (1 << 7) | 15)));
+
+      /* Convert a from an int8x16_t to an int8x8x2_t */
+      int8x8x2_t i;
+      i.val[0] = vget_low_s8(a_.neon_i8);
+      i.val[1] = vget_high_s8(a_.neon_i8);
+
+      /* Table lookups */
+      int8x8_t l = vtbl2_s8(i, vget_low_s8(b_.neon_i8));
+      int8x8_t h = vtbl2_s8(i, vget_high_s8(b_.neon_i8));
+
+      r_.neon_i8 = vcombine_s8(l, h);
+    #elif defined(SIMDE_POWER_ALTIVEC_P6_NATIVE)
+      /* This is a bit ugly because of the casts and the awful type
+      * macros (SIMDE_POWER_ALTIVEC_VECTOR), but it's really just
+       * vec_sel(vec_perm(a, a, b), 0, vec_cmplt(b, 0)) */
+      SIMDE_POWER_ALTIVEC_VECTOR(signed char) z = { 0, };
+      SIMDE_POWER_ALTIVEC_VECTOR(signed char) msb_mask = HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(signed char), vec_cmplt(b_.altivec_i8, z));
+      SIMDE_POWER_ALTIVEC_VECTOR(signed char) c = vec_perm(a_.altivec_i8, a_.altivec_i8, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), b_.altivec_i8));
+      r_.altivec_i8 = vec_sel(c, z, HEDLEY_REINTERPRET_CAST(SIMDE_POWER_ALTIVEC_VECTOR(unsigned char), msb_mask));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[b_.i8[i] & 15] & (~(b_.i8[i]) >> 7);
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+#endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_shuffle_epi8(a, b) simde_mm_shuffle_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_shuffle_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_shuffle_pi8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      b_.neon_i8 = vand_s8(b_.neon_i8, vdup_n_s8(HEDLEY_STATIC_CAST(int8_t, (1 << 7) | 7)));
+      r_.neon_i8 = vtbl1_s8(a_.neon_i8, b_.neon_i8);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.i8[i] = a_.i8[b_.i8[i] & 7] & (~(b_.i8[i]) >> 7);
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_shuffle_pi8(a, b) simde_mm_shuffle_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hadd_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hadd_epi16(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vreinterpretq_s64_s16(vpaddq_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return vreinterpretq_s64_s16(vcombine_s16(vpadd_s16(vget_low_s16(simde__m128i_to_private(a).neon_i16), vget_high_s16(simde__m128i_to_private(a).neon_i16)),
+                      vpadd_s16(vget_low_s16(simde__m128i_to_private(b).neon_i16), vget_high_s16(simde__m128i_to_private(b).neon_i16))));
+    #else
+      return simde_mm_add_epi16(simde_x_mm_deinterleaveeven_epi16(a, b), simde_x_mm_deinterleaveodd_epi16(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_epi16(a, b) simde_mm_hadd_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hadd_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hadd_epi32(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      return vreinterpretq_s64_s32(vcombine_s32(vpadd_s32(vget_low_s32(simde__m128i_to_private(a).neon_i32), vget_high_s32(simde__m128i_to_private(a).neon_i32)),
+                      vpadd_s32(vget_low_s32(simde__m128i_to_private(b).neon_i32), vget_high_s32(simde__m128i_to_private(b).neon_i32))));
+    #else
+      return simde_mm_add_epi32(simde_x_mm_deinterleaveeven_epi32(a, b), simde_x_mm_deinterleaveodd_epi32(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_epi32(a, b) simde_mm_hadd_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hadd_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hadd_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vadd_s16(vuzp1_s16(a_.neon_i16, b_.neon_i16), vuzp2_s16(a_.neon_i16, b_.neon_i16));
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 =
+        SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 0, 2, 4, 6) +
+        SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 1, 3, 5, 7);
+    #else
+      r_.i16[0] = a_.i16[0] + a_.i16[1];
+      r_.i16[1] = a_.i16[2] + a_.i16[3];
+      r_.i16[2] = b_.i16[0] + b_.i16[1];
+      r_.i16[3] = b_.i16[2] + b_.i16[3];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_pi16(a, b) simde_mm_hadd_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hadd_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hadd_pi32(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vadd_s32(vuzp1_s32(a_.neon_i32, b_.neon_i32), vuzp2_s32(a_.neon_i32, b_.neon_i32));
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 =
+        SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 0, 2) +
+        SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 1, 3);
+    #else
+      r_.i32[0] = a_.i32[0] + a_.i32[1];
+      r_.i32[1] = b_.i32[0] + b_.i32[1];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadd_pi32(a, b) simde_mm_hadd_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hadds_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hadds_epi16(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vreinterpretq_s64_s16(vqaddq_s16(vuzp1q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16), vuzp2q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      int32x4_t ax = simde__m128i_to_private(a).neon_i32;
+      int32x4_t bx = simde__m128i_to_private(b).neon_i32;
+      // Interleave using vshrn/vmovn
+      // [a0|a2|a4|a6|b0|b2|b4|b6]
+      // [a1|a3|a5|a7|b1|b3|b5|b7]
+      int16x8_t ab0246 = vcombine_s16(vmovn_s32(ax), vmovn_s32(bx));
+      int16x8_t ab1357 = vcombine_s16(vshrn_n_s32(ax, 16), vshrn_n_s32(bx, 16));
+      // Saturated add
+      return vreinterpretq_s64_s16(vqaddq_s16(ab0246, ab1357));
+    #else
+      return simde_mm_adds_epi16(simde_x_mm_deinterleaveeven_epi16(a, b), simde_x_mm_deinterleaveodd_epi16(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadds_epi16(a, b) simde_mm_hadds_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hadds_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hadds_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vqadd_s16(vuzp1_s16(a_.neon_i16, b_.neon_i16), vuzp2_s16(a_.neon_i16, b_.neon_i16));
+    #else
+      for (size_t i = 0 ; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2) ; i++) {
+        int32_t ta = HEDLEY_STATIC_CAST(int32_t, a_.i16[i * 2]) + HEDLEY_STATIC_CAST(int32_t, a_.i16[(i * 2) + 1]);
+        r_.i16[  i  ] = HEDLEY_LIKELY(ta > INT16_MIN) ? (HEDLEY_LIKELY(ta < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, ta) : INT16_MAX) : INT16_MIN;
+        int32_t tb = HEDLEY_STATIC_CAST(int32_t, b_.i16[i * 2]) + HEDLEY_STATIC_CAST(int32_t, b_.i16[(i * 2) + 1]);
+        r_.i16[i + 2] = HEDLEY_LIKELY(tb > INT16_MIN) ? (HEDLEY_LIKELY(tb < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, tb) : INT16_MAX) : INT16_MIN;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hadds_pi16(a, b) simde_mm_hadds_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hsub_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hsub_epi16(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vreinterpretq_s64_s16(vsubq_s16(vuzp1q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16), vuzp2q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Interleave using vshrn/vmovn
+      // [a0|a2|a4|a6|b0|b2|b4|b6]
+      // [a1|a3|a5|a7|b1|b3|b5|b7]
+      int16x8_t ab0246 = vcombine_s16(vmovn_s32(simde__m128i_to_private(a).neon_i32), vmovn_s32(simde__m128i_to_private(b).neon_i32));
+      int16x8_t ab1357 = vcombine_s16(vshrn_n_s32(simde__m128i_to_private(a).neon_i32, 16), vshrn_n_s32(simde__m128i_to_private(b).neon_i32, 16));
+      // Subtract
+      return vreinterpretq_s64_s16(vsubq_s16(ab0246, ab1357));
+    #else
+      return simde_mm_sub_epi16(simde_x_mm_deinterleaveeven_epi16(a, b), simde_x_mm_deinterleaveodd_epi16(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_epi16(a, b) simde_mm_hsub_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hsub_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hsub_epi32(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vreinterpretq_s64_s32(vsubq_s32(vuzp1q_s32(simde__m128i_to_private(a).neon_i32, simde__m128i_to_private(b).neon_i32), vuzp2q_s32(simde__m128i_to_private(a).neon_i32, simde__m128i_to_private(b).neon_i32)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Interleave using vshrn/vmovn
+      // [a0|a2|b0|b2]
+      // [a1|a2|b1|b3]
+      int32x4_t ab02 = vcombine_s32(vmovn_s64(simde__m128i_to_private(a).neon_i64), vmovn_s64(simde__m128i_to_private(b).neon_i64));
+      int32x4_t ab13 = vcombine_s32(vshrn_n_s64(simde__m128i_to_private(a).neon_i64, 32), vshrn_n_s64(simde__m128i_to_private(b).neon_i64, 32));
+      // Subtract
+      return vreinterpretq_s64_s32(vsubq_s32(ab02, ab13));
+    #else
+      return simde_mm_sub_epi32(simde_x_mm_deinterleaveeven_epi32(a, b), simde_x_mm_deinterleaveodd_epi32(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_epi32(a, b) simde_mm_hsub_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hsub_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hsub_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vsub_s16(vuzp1_s16(a_.neon_i16, b_.neon_i16), vuzp2_s16(a_.neon_i16, b_.neon_i16));
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i16 =
+        SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 0, 2, 4, 6) -
+        SIMDE_SHUFFLE_VECTOR_(16, 8, a_.i16, b_.i16, 1, 3, 5, 7);
+    #else
+      r_.i16[0] = a_.i16[0] - a_.i16[1];
+      r_.i16[1] = a_.i16[2] - a_.i16[3];
+      r_.i16[2] = b_.i16[0] - b_.i16[1];
+      r_.i16[3] = b_.i16[2] - b_.i16[3];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_pi16(a, b) simde_mm_hsub_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hsub_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hsub_pi32(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i32 = vsub_s32(vuzp1_s32(a_.neon_i32, b_.neon_i32), vuzp2_s32(a_.neon_i32, b_.neon_i32));
+    #elif (SIMDE_NATURAL_VECTOR_SIZE > 0) && defined(SIMDE_SHUFFLE_VECTOR_)
+      r_.i32 =
+        SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 0, 2) -
+        SIMDE_SHUFFLE_VECTOR_(32, 8, a_.i32, b_.i32, 1, 3);
+    #else
+      r_.i32[0] = a_.i32[0] - a_.i32[1];
+      r_.i32[1] = b_.i32[0] - b_.i32[1];
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsub_pi32(a, b) simde_mm_hsub_pi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_hsubs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_hsubs_epi16(a, b);
+  #else
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      return vreinterpretq_s64_s16(vqsubq_s16(vuzp1q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16), vuzp2q_s16(simde__m128i_to_private(a).neon_i16, simde__m128i_to_private(b).neon_i16)));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Interleave using vshrn/vmovn
+      // [a0|a2|a4|a6|b0|b2|b4|b6]
+      // [a1|a3|a5|a7|b1|b3|b5|b7]
+      int16x8_t ab0246 = vcombine_s16(vmovn_s32(simde__m128i_to_private(a).neon_i32), vmovn_s32(simde__m128i_to_private(b).neon_i32));
+      int16x8_t ab1357 = vcombine_s16(vshrn_n_s32(simde__m128i_to_private(a).neon_i32, 16), vshrn_n_s32(simde__m128i_to_private(b).neon_i32, 16));
+      // Saturated subtract
+      return vreinterpretq_s64_s16(vqsubq_s16(ab0246, ab1357));
+    #else
+      return simde_mm_subs_epi16(simde_x_mm_deinterleaveeven_epi16(a, b), simde_x_mm_deinterleaveodd_epi16(a, b));
+    #endif
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsubs_epi16(a, b) simde_mm_hsubs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_hsubs_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_hsubs_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_i16 = vqsub_s16(vuzp1_s16(a_.neon_i16, b_.neon_i16), vuzp2_s16(a_.neon_i16, b_.neon_i16));
+    #else
+      for (size_t i = 0 ; i < ((sizeof(r_.i16) / sizeof(r_.i16[0])) / 2) ; i++) {
+        int32_t ta = HEDLEY_STATIC_CAST(int32_t, a_.i16[i * 2]) - HEDLEY_STATIC_CAST(int32_t, a_.i16[(i * 2) + 1]);
+        r_.i16[  i  ] = HEDLEY_LIKELY(ta > INT16_MIN) ? (HEDLEY_LIKELY(ta < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, ta) : INT16_MAX) : INT16_MIN;
+        int32_t tb = HEDLEY_STATIC_CAST(int32_t, b_.i16[i * 2]) - HEDLEY_STATIC_CAST(int32_t, b_.i16[(i * 2) + 1]);
+        r_.i16[i + 2] = HEDLEY_LIKELY(tb > INT16_MIN) ? (HEDLEY_LIKELY(tb < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, tb) : INT16_MAX) : INT16_MIN;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_hsubs_pi16(a, b) simde_mm_hsubs_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_maddubs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_maddubs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      int16x8_t tl = vmulq_s16(vreinterpretq_s16_u16(vmovl_u8(vget_low_u8(a_.neon_u8))), vmovl_s8(vget_low_s8(b_.neon_i8)));
+      int16x8_t th = vmulq_s16(vreinterpretq_s16_u16(vmovl_u8(vget_high_u8(a_.neon_u8))), vmovl_s8(vget_high_s8(b_.neon_i8)));
+      r_.neon_i16 = vqaddq_s16(vuzp1q_s16(tl, th), vuzp2q_s16(tl, th));
+    #elif defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // This would be much simpler if x86 would choose to zero extend OR sign extend,
+      // not both.
+      // This could probably be optimized better.
+
+      // Zero extend a
+      int16x8_t a_odd = vreinterpretq_s16_u16(vshrq_n_u16(a_.neon_u16, 8));
+      int16x8_t a_even = vreinterpretq_s16_u16(vbicq_u16(a_.neon_u16, vdupq_n_u16(0xff00)));
+
+      // Sign extend by shifting left then shifting right.
+      int16x8_t b_even = vshrq_n_s16(vshlq_n_s16(b_.neon_i16, 8), 8);
+      int16x8_t b_odd = vshrq_n_s16(b_.neon_i16, 8);
+
+      // multiply
+      int16x8_t prod1 = vmulq_s16(a_even, b_even);
+      int16x8_t prod2 = vmulq_s16(a_odd, b_odd);
+
+      // saturated add
+      r_.neon_i16 = vqaddq_s16(prod1, prod2);
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int idx = HEDLEY_STATIC_CAST(int, i) << 1;
+        int32_t ts =
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[  idx  ]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[  idx  ])) +
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[idx + 1]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[idx + 1]));
+        r_.i16[i] = HEDLEY_LIKELY(ts > INT16_MIN) ? (HEDLEY_LIKELY(ts < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, ts) : INT16_MAX) : INT16_MIN;
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_maddubs_epi16(a, b) simde_mm_maddubs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_maddubs_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_maddubs_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      int16x8_t ai = vreinterpretq_s16_u16(vmovl_u8(a_.neon_u8));
+      int16x8_t bi = vmovl_s8(b_.neon_i8);
+      int16x8_t p = vmulq_s16(ai, bi);
+      int16x4_t l = vget_low_s16(p);
+      int16x4_t h = vget_high_s16(p);
+      r_.neon_i16 = vqadd_s16(vuzp1_s16(l, h), vuzp2_s16(l, h));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        const int idx = HEDLEY_STATIC_CAST(int, i) << 1;
+        int32_t ts =
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[  idx  ]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[  idx  ])) +
+          (HEDLEY_STATIC_CAST(int16_t, a_.u8[idx + 1]) * HEDLEY_STATIC_CAST(int16_t, b_.i8[idx + 1]));
+        r_.i16[i] = HEDLEY_LIKELY(ts > INT16_MIN) ? (HEDLEY_LIKELY(ts < INT16_MAX) ? HEDLEY_STATIC_CAST(int16_t, ts) : INT16_MAX) : INT16_MIN;
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_maddubs_pi16(a, b) simde_mm_maddubs_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_mulhrs_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_mulhrs_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Has issues due to saturation
+      // r_.neon_i16 =  vqrdmulhq_s16(a, b);
+
+      // Multiply
+      int32x4_t mul_lo = vmull_s16(vget_low_s16(a_.neon_i16),
+                                  vget_low_s16(b_.neon_i16));
+      int32x4_t mul_hi = vmull_s16(vget_high_s16(a_.neon_i16),
+                                  vget_high_s16(b_.neon_i16));
+
+      // Rounding narrowing shift right
+      // narrow = (int16_t)((mul + 16384) >> 15);
+      int16x4_t narrow_lo = vrshrn_n_s32(mul_lo, 15);
+      int16x4_t narrow_hi = vrshrn_n_s32(mul_hi, 15);
+
+      // Join together
+      r_.neon_i16 = vcombine_s16(narrow_lo, narrow_hi);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, (((HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) + 0x4000) >> 15));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_mulhrs_epi16(a, b) simde_mm_mulhrs_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_mulhrs_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_mulhrs_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      // Has issues due to saturation
+      // r_.neon_i16 =  vqrdmulh_s16(a, b);
+
+      // Multiply
+      int32x4_t mul = vmull_s16(a_.neon_i16, b_.neon_i16);
+
+      // Rounding narrowing shift right
+      // narrow = (int16_t)((mul + 16384) >> 15);
+      int16x4_t narrow = vrshrn_n_s32(mul, 15);
+
+      // Join together
+      r_.neon_i16 = narrow;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = HEDLEY_STATIC_CAST(int16_t, (((HEDLEY_STATIC_CAST(int32_t, a_.i16[i]) * HEDLEY_STATIC_CAST(int32_t, b_.i16[i])) + 0x4000) >> 15));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_mulhrs_pi16(a, b) simde_mm_mulhrs_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sign_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_sign_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint8x16_t aneg_mask = vreinterpretq_u8_s8(vshrq_n_s8(b_.neon_i8, 7));
+      uint8x16_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqzq_s8(b_.neon_i8);
+      #else
+        bnz_mask = vceqq_s8(b_.neon_i8, vdupq_n_s8(0));
+      #endif
+      bnz_mask = vmvnq_u8(bnz_mask);
+
+      r_.neon_i8 = vbslq_s8(aneg_mask, vnegq_s8(a_.neon_i8), vandq_s8(a_.neon_i8, vreinterpretq_s8_u8(bnz_mask)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (b_.i8[i] < 0) ? (- a_.i8[i]) : ((b_.i8[i] != 0) ? (a_.i8[i]) : INT8_C(0));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_epi8(a, b) simde_mm_sign_epi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sign_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_sign_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x8_t aneg_mask = vreinterpretq_u16_s16(vshrq_n_s16(b_.neon_i16, 15));
+      uint16x8_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqzq_s16(b_.neon_i16);
+      #else
+        bnz_mask = vceqq_s16(b_.neon_i16, vdupq_n_s16(0));
+      #endif
+      bnz_mask = vmvnq_u16(bnz_mask);
+
+      r_.neon_i16 = vbslq_s16(aneg_mask, vnegq_s16(a_.neon_i16), vandq_s16(a_.neon_i16, vreinterpretq_s16_u16(bnz_mask)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (b_.i16[i] < 0) ? (- a_.i16[i]) : ((b_.i16[i] != 0) ? (a_.i16[i]) : INT16_C(0));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_epi16(a, b) simde_mm_sign_epi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_sign_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE)
+    return _mm_sign_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x4_t aneg_mask = vreinterpretq_u32_s32(vshrq_n_s32(b_.neon_i32, 31));
+      uint32x4_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqzq_s32(b_.neon_i32);
+      #else
+        bnz_mask = vceqq_s32(b_.neon_i32, vdupq_n_s32(0));
+      #endif
+      bnz_mask = vmvnq_u32(bnz_mask);
+
+      r_.neon_i32 = vbslq_s32(aneg_mask, vnegq_s32(a_.neon_i32), vandq_s32(a_.neon_i32, vreinterpretq_s32_u32(bnz_mask)));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (b_.i32[i] < 0) ? (- a_.i32[i]) : ((b_.i32[i] != 0) ? (a_.i32[i]) : INT32_C(0));
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_epi32(a, b) simde_mm_sign_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sign_pi8 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sign_pi8(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint8x8_t aneg_mask = vreinterpret_u8_s8(vshr_n_s8(b_.neon_i8, 7));
+      uint8x8_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqz_s8(b_.neon_i8);
+      #else
+        bnz_mask = vceq_s8(b_.neon_i8, vdup_n_s8(0));
+      #endif
+      bnz_mask = vmvn_u8(bnz_mask);
+
+      r_.neon_i8 = vbsl_s8(aneg_mask, vneg_s8(a_.neon_i8), vand_s8(a_.neon_i8, vreinterpret_s8_u8(bnz_mask)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = (b_.i8[i] < 0) ? (- a_.i8[i]) : ((b_.i8[i] != 0) ? (a_.i8[i]) : INT8_C(0));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_pi8(a, b) simde_mm_sign_pi8(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sign_pi16 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sign_pi16(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint16x4_t aneg_mask = vreinterpret_u16_s16(vshr_n_s16(b_.neon_i16, 15));
+      uint16x4_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqz_s16(b_.neon_i16);
+      #else
+        bnz_mask = vceq_s16(b_.neon_i16, vdup_n_s16(0));
+      #endif
+      bnz_mask = vmvn_u16(bnz_mask);
+
+      r_.neon_i16 = vbsl_s16(aneg_mask, vneg_s16(a_.neon_i16), vand_s16(a_.neon_i16, vreinterpret_s16_u16(bnz_mask)));
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = (b_.i16[i] < 0) ? (- a_.i16[i]) : ((b_.i16[i] > 0) ? (a_.i16[i]) : INT16_C(0));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_pi16(a, b) simde_mm_sign_pi16(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m64
+simde_mm_sign_pi32 (simde__m64 a, simde__m64 b) {
+  #if defined(SIMDE_X86_SSSE3_NATIVE) && defined(SIMDE_X86_MMX_NATIVE)
+    return _mm_sign_pi32(a, b);
+  #else
+    simde__m64_private
+      r_,
+      a_ = simde__m64_to_private(a),
+      b_ = simde__m64_to_private(b);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      uint32x2_t aneg_mask = vreinterpret_u32_s32(vshr_n_s32(b_.neon_i32, 31));
+      uint32x2_t bnz_mask;
+      #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+        bnz_mask = vceqz_s32(b_.neon_i32);
+      #else
+        bnz_mask = vceq_s32(b_.neon_i32, vdup_n_s32(0));
+      #endif
+      bnz_mask = vmvn_u32(bnz_mask);
+
+      r_.neon_i32 = vbsl_s32(aneg_mask, vneg_s32(a_.neon_i32), vand_s32(a_.neon_i32, vreinterpret_s32_u32(bnz_mask)));
+    #else
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = (b_.i32[i] < 0) ? (- a_.i32[i]) : ((b_.i32[i] > 0) ? (a_.i32[i]) : INT32_C(0));
+      }
+    #endif
+
+    return simde__m64_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SSSE3_ENABLE_NATIVE_ALIASES)
+#  define _mm_sign_pi32(a, b) simde_mm_sign_pi32(a, b)
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SSE2_H) */

--- a/2.0/simde/x86/svml.h
+++ b/2.0/simde/x86/svml.h
@@ -1,0 +1,11948 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Copyright:
+ *   2020      Evan Nemerson <evan@nemerson.com>
+ *   2020      Himanshi Mathur <himanshi18037@iiitd.ac.in>
+ */
+
+#if !defined(SIMDE_X86_SVML_H)
+#define SIMDE_X86_SVML_H
+
+#include "fma.h"
+#include "avx2.h"
+#include "avx512/abs.h"
+#include "avx512/add.h"
+#include "avx512/cmp.h"
+#include "avx512/copysign.h"
+#include "avx512/xorsign.h"
+#include "avx512/div.h"
+#include "avx512/fmadd.h"
+#include "avx512/mov.h"
+#include "avx512/mul.h"
+#include "avx512/negate.h"
+#include "avx512/or.h"
+#include "avx512/set1.h"
+#include "avx512/setone.h"
+#include "avx512/setzero.h"
+#include "avx512/sqrt.h"
+#include "avx512/sub.h"
+
+#if !defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+#  define SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES
+#endif
+
+HEDLEY_DIAGNOSTIC_PUSH
+SIMDE_DISABLE_UNWANTED_DIAGNOSTICS
+SIMDE_BEGIN_DECLS_
+
+#if !defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_ENABLE_NATIVE_ALIASES)
+#  define SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_acos_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_acos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosf4_u10(a);
+    #else
+      return Sleef_acosf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_acosf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_acos_ps
+  #define _mm_acos_ps(a) simde_mm_acos_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_acos_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_acos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosd2_u10(a);
+    #else
+      return Sleef_acosd2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_acos(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_acos_pd
+  #define _mm_acos_pd(a) simde_mm_acos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_acos_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_acos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosf8_u10(a);
+    #else
+      return Sleef_acosf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_acos_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_acosf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_acos_ps
+  #define _mm256_acos_ps(a) simde_mm256_acos_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_acos_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_acos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosd4_u10(a);
+    #else
+      return Sleef_acosd4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_acos_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_acos(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_acos_pd
+  #define _mm256_acos_pd(a) simde_mm256_acos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_acos_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_acos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosf16_u10(a);
+    #else
+      return Sleef_acosf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_acos_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_acosf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_acos_ps
+  #define _mm512_acos_ps(a) simde_mm512_acos_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_acos_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_acos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_acosd8_u10(a);
+    #else
+      return Sleef_acosd8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_acos_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_acos(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_acos_pd
+  #define _mm512_acos_pd(a) simde_mm512_acos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_acos_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_acos_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_acos_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_acos_ps
+  #define _mm512_mask_acos_ps(src, k, a) simde_mm512_mask_acos_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_acos_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_acos_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_acos_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_acos_pd
+  #define _mm512_mask_acos_pd(src, k, a) simde_mm512_mask_acos_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_acosh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_acosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_acoshf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_acoshf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_acosh_ps
+  #define _mm_acosh_ps(a) simde_mm_acosh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_acosh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_acosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_acoshd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_acosh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_acosh_pd
+  #define _mm_acosh_pd(a) simde_mm_acosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_acosh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_acosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_acoshf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_acosh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_acoshf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_acosh_ps
+  #define _mm256_acosh_ps(a) simde_mm256_acosh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_acosh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_acosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_acoshd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_acosh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_acosh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_acosh_pd
+  #define _mm256_acosh_pd(a) simde_mm256_acosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_acosh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_acosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_acoshf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_acosh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_acoshf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_acosh_ps
+  #define _mm512_acosh_ps(a) simde_mm512_acosh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_acosh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_acosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_acoshd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_acosh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_acosh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_acosh_pd
+  #define _mm512_acosh_pd(a) simde_mm512_acosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_acosh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_acosh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_acosh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_acosh_ps
+  #define _mm512_mask_acosh_ps(src, k, a) simde_mm512_mask_acosh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_acosh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_acosh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_acosh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_acosh_pd
+  #define _mm512_mask_acosh_pd(src, k, a) simde_mm512_mask_acosh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_asin_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_asin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asinf4_u10(a);
+    #else
+      return Sleef_asinf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_asinf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_asin_ps
+  #define _mm_asin_ps(a) simde_mm_asin_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_asin_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_asin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asind2_u10(a);
+    #else
+      return Sleef_asind2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_asin(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_asin_pd
+  #define _mm_asin_pd(a) simde_mm_asin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_asin_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_asin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asinf8_u10(a);
+    #else
+      return Sleef_asinf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_asin_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_asinf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_asin_ps
+  #define _mm256_asin_ps(a) simde_mm256_asin_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_asin_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_asin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asind4_u10(a);
+    #else
+      return Sleef_asind4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_asin_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_asin(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_asin_pd
+  #define _mm256_asin_pd(a) simde_mm256_asin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_asin_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_asin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asinf16_u10(a);
+    #else
+      return Sleef_asinf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_asin_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_asinf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_asin_ps
+  #define _mm512_asin_ps(a) simde_mm512_asin_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_asin_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_asin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_asind8_u10(a);
+    #else
+      return Sleef_asind8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_asin_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_asin(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_asin_pd
+  #define _mm512_asin_pd(a) simde_mm512_asin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_asin_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_asin_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_asin_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_asin_ps
+  #define _mm512_mask_asin_ps(src, k, a) simde_mm512_mask_asin_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_asin_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_asin_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_asin_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_asin_pd
+  #define _mm512_mask_asin_pd(src, k, a) simde_mm512_mask_asin_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_asinh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_asinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_asinhf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_asinhf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_asinh_ps
+  #define _mm_asinh_ps(a) simde_mm_asinh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_asinh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_asinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_asinhd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_asinh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_asinh_pd
+  #define _mm_asinh_pd(a) simde_mm_asinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_asinh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_asinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_asinhf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_asinh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_asinhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_asinh_ps
+  #define _mm256_asinh_ps(a) simde_mm256_asinh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_asinh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_asinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_asinhd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_asinh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_asinh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_asinh_pd
+  #define _mm256_asinh_pd(a) simde_mm256_asinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_asinh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_asinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_asinhf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_asinh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_asinhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_asinh_ps
+  #define _mm512_asinh_ps(a) simde_mm512_asinh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_asinh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_asinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_asinhd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_asinh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_asinh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_asinh_pd
+  #define _mm512_asinh_pd(a) simde_mm512_asinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_asinh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_asinh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_asinh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_asinh_ps
+  #define _mm512_mask_asinh_ps(src, k, a) simde_mm512_mask_asinh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_asinh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_asinh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_asinh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_asinh_pd
+  #define _mm512_mask_asinh_pd(src, k, a) simde_mm512_mask_asinh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_atan_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atanf4_u10(a);
+    #else
+      return Sleef_atanf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_atanf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atan_ps
+  #define _mm_atan_ps(a) simde_mm_atan_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_atan_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atand2_u10(a);
+    #else
+      return Sleef_atand2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_atan(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atan_pd
+  #define _mm_atan_pd(a) simde_mm_atan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_atan_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atanf8_u10(a);
+    #else
+      return Sleef_atanf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_atan_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atanf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atan_ps
+  #define _mm256_atan_ps(a) simde_mm256_atan_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_atan_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atand4_u10(a);
+    #else
+      return Sleef_atand4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_atan_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atan(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atan_pd
+  #define _mm256_atan_pd(a) simde_mm256_atan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_atan_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atanf16_u10(a);
+    #else
+      return Sleef_atanf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_atan_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atanf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atan_ps
+  #define _mm512_atan_ps(a) simde_mm512_atan_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_atan_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atand8_u10(a);
+    #else
+      return Sleef_atand8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_atan_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atan(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atan_pd
+  #define _mm512_atan_pd(a) simde_mm512_atan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_atan_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atan_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_atan_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atan_ps
+  #define _mm512_mask_atan_ps(src, k, a) simde_mm512_mask_atan_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_atan_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atan_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_atan_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atan_pd
+  #define _mm512_mask_atan_pd(src, k, a) simde_mm512_mask_atan_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_atan2_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atan2_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2f4_u10(a, b);
+    #else
+      return Sleef_atan2f4_u35(a, b);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_atan2f(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atan2_ps
+  #define _mm_atan2_ps(a, b) simde_mm_atan2_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_atan2_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atan2_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2d2_u10(a, b);
+    #else
+      return Sleef_atan2d2_u35(a, b);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_atan2(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atan2_pd
+  #define _mm_atan2_pd(a, b) simde_mm_atan2_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_atan2_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atan2_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2f8_u10(a, b);
+    #else
+      return Sleef_atan2f8_u35(a, b);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_atan2_ps(a_.m128[i], b_.m128[i]);
+    }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atan2f(a_.f32[i], b_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atan2_ps
+  #define _mm256_atan2_ps(a, b) simde_mm256_atan2_ps(a, b)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_atan2_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atan2_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2d4_u10(a, b);
+    #else
+      return Sleef_atan2d4_u35(a, b);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_atan2_pd(a_.m128d[i], b_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atan2(a_.f64[i], b_.f64[i]);
+      }
+  #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atan2_pd
+  #define _mm256_atan2_pd(a, b) simde_mm256_atan2_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_atan2_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atan2_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2f16_u10(a, b);
+    #else
+      return Sleef_atan2f16_u35(a, b);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_atan2_ps(a_.m256[i], b_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atan2f(a_.f32[i], b_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atan2_ps
+  #define _mm512_atan2_ps(a, b) simde_mm512_atan2_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_atan2_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atan2_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_atan2d8_u10(a, b);
+    #else
+      return Sleef_atan2d8_u35(a, b);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_atan2_pd(a_.m256d[i], b_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atan2(a_.f64[i], b_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atan2_pd
+  #define _mm512_atan2_pd(a, b) simde_mm512_atan2_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_atan2_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atan2_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_atan2_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atan2_ps
+  #define _mm512_mask_atan2_ps(src, k, a, b) simde_mm512_mask_atan2_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_atan2_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atan2_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_atan2_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atan2_pd
+  #define _mm512_mask_atan2_pd(src, k, a, b) simde_mm512_mask_atan2_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_atanh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_atanhf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_atanhf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atanh_ps
+  #define _mm_atanh_ps(a) simde_mm_atanh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_atanh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_atanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_atanhd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_atanh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_atanh_pd
+  #define _mm_atanh_pd(a) simde_mm_atanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_atanh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_atanhf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_atanh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atanhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atanh_ps
+  #define _mm256_atanh_ps(a) simde_mm256_atanh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_atanh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_atanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_atanhd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_atanh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atanh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_atanh_pd
+  #define _mm256_atanh_pd(a) simde_mm256_atanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_atanh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_atanhf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_atanh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_atanhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atanh_ps
+  #define _mm512_atanh_ps(a) simde_mm512_atanh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_atanh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_atanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_atanhd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_atanh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_atanh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_atanh_pd
+  #define _mm512_atanh_pd(a) simde_mm512_atanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_atanh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atanh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_atanh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atanh_ps
+  #define _mm512_mask_atanh_ps(src, k, a) simde_mm512_mask_atanh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_atanh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_atanh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_atanh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_atanh_pd
+  #define _mm512_mask_atanh_pd(src, k, a) simde_mm512_mask_atanh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cbrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cbrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_cbrtf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_cbrtf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cbrt_ps
+  #define _mm_cbrt_ps(a) simde_mm_cbrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cbrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cbrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_cbrtd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cbrt(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cbrt_pd
+  #define _mm_cbrt_pd(a) simde_mm_cbrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cbrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cbrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_cbrtf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cbrt_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cbrtf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cbrt_ps
+  #define _mm256_cbrt_ps(a) simde_mm256_cbrt_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cbrt_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cbrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_cbrtd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cbrt_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cbrt(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cbrt_pd
+  #define _mm256_cbrt_pd(a) simde_mm256_cbrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cbrt_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cbrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_cbrtf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_cbrt_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cbrtf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cbrt_ps
+  #define _mm512_cbrt_ps(a) simde_mm512_cbrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cbrt_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cbrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_cbrtd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_cbrt_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cbrt(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cbrt_pd
+  #define _mm512_cbrt_pd(a) simde_mm512_cbrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cbrt_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cbrt_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cbrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cbrt_ps
+  #define _mm512_mask_cbrt_ps(src, k, a) simde_mm512_mask_cbrt_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cbrt_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cbrt_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cbrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cbrt_pd
+  #define _mm512_mask_cbrt_pd(src, k, a) simde_mm512_mask_cbrt_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cexp_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cexp_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=2) {
+      simde_cfloat32 val = simde_math_cexpf(SIMDE_MATH_CMPLXF(a_.f32[i], a_.f32[i+1]));
+      r_.f32[  i  ] = simde_math_crealf(val);
+      r_.f32[i + 1] = simde_math_cimagf(val);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cexp_ps
+  #define _mm_cexp_ps(a) simde_mm_cexp_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cexp_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cexp_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=2) {
+      simde_cfloat32 val = simde_math_cexpf(SIMDE_MATH_CMPLXF(a_.f32[i], a_.f32[i+1]));
+      r_.f32[  i  ] = simde_math_crealf(val);
+      r_.f32[i + 1] = simde_math_cimagf(val);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cexp_ps
+  #define _mm256_cexp_ps(a) simde_mm256_cexp_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cos_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf4_u10(a);
+    #else
+      return Sleef_cosf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_cosf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cos_ps
+  #define _mm_cos_ps(a) simde_mm_cos_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cos_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd2_u10(a);
+    #else
+      return Sleef_cosd2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cos(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cos_pd
+  #define _mm_cos_pd(a) simde_mm_cos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cos_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf8_u10(a);
+    #else
+      return Sleef_cosf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cos_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cosf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cos_ps
+  #define _mm256_cos_ps(a) simde_mm256_cos_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cos_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd4_u10(a);
+    #else
+      return Sleef_cosd4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cos_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cos(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cos_pd
+  #define _mm256_cos_pd(a) simde_mm256_cos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cos_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cos_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf16_u10(a);
+    #else
+      return Sleef_cosf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_cos_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cosf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cos_ps
+  #define _mm512_cos_ps(a) simde_mm512_cos_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cos_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cos_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd8_u10(a);
+    #else
+      return Sleef_cosd8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_cos_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cos(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cos_pd
+  #define _mm512_cos_pd(a) simde_mm512_cos_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cos_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cos_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cos_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cos_ps
+  #define _mm512_mask_cos_ps(src, k, a) simde_mm512_mask_cos_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cos_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cos_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cos_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cos_pd
+  #define _mm512_mask_cos_pd(src, k, a) simde_mm512_mask_cos_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_x_mm_deg2rad_ps(simde__m128 a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    return simde_mm_mul_ps(a, simde_mm_set1_ps(SIMDE_MATH_PI_OVER_180F));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A32V7_NATIVE)
+      r_.neon_f32 = vmulq_n_f32(a_.neon_i32, SIMDE_MATH_PI_OVER_180F);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      const __typeof__(r_.f32) tmp = { SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F, SIMDE_MATH_PI_OVER_180F };
+      r_.f32 = a_.f32 * tmp;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_deg2radf(a_.f32[i]);
+      }
+
+    #endif
+    return simde__m128_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_x_mm_deg2rad_pd(simde__m128d a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+      return simde_mm_mul_pd(a, simde_mm_set1_pd(SIMDE_MATH_PI_OVER_180));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    #if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+      r_.neon_f64 = vmulq_n_f64(a_.neon_i64, SIMDE_MATH_PI_OVER_180);
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR) && !defined(SIMDE_BUG_GCC_53784)
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      const __typeof__(r_.f64) tmp = { SIMDE_MATH_PI_OVER_180, SIMDE_MATH_PI_OVER_180 };
+      r_.f64 = a_.f64 * tmp;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_deg2rad(a_.f64[i]);
+      }
+
+    #endif
+    return simde__m128d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_x_mm256_deg2rad_ps(simde__m256 a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    return simde_mm256_mul_ps(a, simde_mm256_set1_ps(SIMDE_MATH_PI_OVER_180F));
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_x_mm_deg2rad_ps(a_.m128[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_deg2radf(a_.f32[i]);
+      }
+
+    #endif
+    return simde__m256_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_x_mm256_deg2rad_pd(simde__m256d a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    return simde_mm256_mul_pd(a, simde_mm256_set1_pd(SIMDE_MATH_PI_OVER_180));
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_x_mm_deg2rad_pd(a_.m128d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_deg2rad(a_.f64[i]);
+      }
+
+    #endif
+    return simde__m256d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_x_mm512_deg2rad_ps(simde__m512 a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(512)
+      return simde_mm512_mul_ps(a, simde_mm512_set1_ps(SIMDE_MATH_PI_OVER_180F));
+  #else
+    simde__m512_private
+        r_,
+        a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_x_mm256_deg2rad_ps(a_.m256[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.f32 = a_.f32 * SIMDE_MATH_PI_OVER_180F;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_x_mm256_deg2rad_ps(a_.m256[i]);
+      }
+
+    #endif
+    return simde__m512_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_x_mm512_deg2rad_pd(simde__m512d a) {
+  #if SIMDE_NATURAL_VECTOR_SIZE_GE(512)
+      return simde_mm512_mul_pd(a, simde_mm512_set1_pd(SIMDE_MATH_PI_OVER_180));
+  #else
+    simde__m512d_private
+        r_,
+        a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_x_mm256_deg2rad_pd(a_.m256d[i]);
+      }
+    #elif defined(SIMDE_VECTOR_SUBSCRIPT_SCALAR)
+      r_.f64 = a_.f64 * SIMDE_MATH_PI_OVER_180;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_x_mm256_deg2rad_pd(a_.m256d[i]);
+      }
+
+    #endif
+    return simde__m512d_from_private(r_);
+  #endif
+}
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cosd_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cosd_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf4_u10(simde_x_mm_deg2rad_ps(a));
+    #else
+      return Sleef_cosf4_u35(simde_x_mm_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_cosf(simde_math_deg2radf(a_.f32[i]));
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cosd_ps
+  #define _mm_cosd_ps(a) simde_mm_cosd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cosd_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cosd_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd2_u10(simde_x_mm_deg2rad_pd(a));
+    #else
+      return Sleef_cosd2_u35(simde_x_mm_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cos(simde_math_deg2rad(a_.f64[i]));
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cosd_pd
+  #define _mm_cosd_pd(a) simde_mm_cosd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cosd_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cosd_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf8_u10(simde_x_mm256_deg2rad_ps(a));
+    #else
+      return Sleef_cosf8_u35(simde_x_mm256_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cosd_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cosf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cosd_ps
+  #define _mm256_cosd_ps(a) simde_mm256_cosd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cosd_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cosd_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd4_u10(simde_x_mm256_deg2rad_pd(a));
+    #else
+      return Sleef_cosd4_u35(simde_x_mm256_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cosd_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cos(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cosd_pd
+  #define _mm256_cosd_pd(a) simde_mm256_cosd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cosd_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cosd_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosf16_u10(simde_x_mm512_deg2rad_ps(a));
+    #else
+      return Sleef_cosf16_u35(simde_x_mm512_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_cosd_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cosf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cosd_ps
+  #define _mm512_cosd_ps(a) simde_mm512_cosd_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cosd_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cosd_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_cosd8_u10(simde_x_mm512_deg2rad_pd(a));
+    #else
+      return Sleef_cosd8_u35(simde_x_mm512_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_cosd_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cos(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cosd_pd
+  #define _mm512_cosd_pd(a) simde_mm512_cosd_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cosd_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cosd_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cosd_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cosd_ps
+  #define _mm512_mask_cosd_ps(src, k, a) simde_mm512_mask_cosd_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cosd_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cosd_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cosd_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cosd_pd
+  #define _mm512_mask_cosd_pd(src, k, a) simde_mm512_mask_cosd_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cosh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_coshf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_coshf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cosh_ps
+  #define _mm_cosh_ps(a) simde_mm_cosh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cosh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_coshd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cosh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cosh_pd
+  #define _mm_cosh_pd(a) simde_mm_cosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cosh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_coshf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cosh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_coshf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cosh_ps
+  #define _mm256_cosh_ps(a) simde_mm256_cosh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cosh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_coshd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cosh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cosh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cosh_pd
+  #define _mm256_cosh_pd(a) simde_mm256_cosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cosh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cosh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_coshf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_cosh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_coshf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cosh_ps
+  #define _mm512_cosh_ps(a) simde_mm512_cosh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cosh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cosh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_coshd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_cosh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cosh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cosh_pd
+  #define _mm512_cosh_pd(a) simde_mm512_cosh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cosh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cosh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cosh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cosh_ps
+  #define _mm512_mask_cosh_ps(src, k, a) simde_mm512_mask_cosh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cosh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cosh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cosh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cosh_pd
+  #define _mm512_mask_cosh_pd(src, k, a) simde_mm512_mask_cosh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 / b_.i8;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i8x4_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] / b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epi8
+  #define _mm_div_epi8(a, b) simde_mm_div_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 / b_.i16;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i16x4_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] / b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epi16
+  #define _mm_div_epi16(a, b) simde_mm_div_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 / b_.i32;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i32x4_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] / b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_idiv_epi32(a, b) simde_mm_div_epi32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epi32
+  #define _mm_div_epi32(a, b) simde_mm_div_epi32(a, b)
+  #undef _mm_idiv_epi32
+  #define _mm_idiv_epi32(a, b) simde_mm_div_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 / b_.i64;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_i64x4_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] / b_.i64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epi64
+  #define _mm_div_epi64(a, b) simde_mm_div_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 / b_.u8;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u8x16_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] / b_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epu8
+  #define _mm_div_epu8(a, b) simde_mm_div_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 / b_.u16;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u16x16_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] / b_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epu16
+  #define _mm_div_epu16(a, b) simde_mm_div_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 / b_.u32;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u32x16_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] / b_.u32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_udiv_epi32(a, b) simde_mm_div_epu32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epu32
+  #define _mm_div_epu32(a, b) simde_mm_div_epu32(a, b)
+  #undef _mm_udiv_epi32
+  #define _mm_udiv_epi32(a, b) simde_mm_div_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_div_epu64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_div_epu64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 / b_.u64;
+    #elif defined(SIMDE_WASM_SIMD128_NATIVE)
+      r_.wasm_v128 = wasm_u64x16_div(a_.wasm_v128, b_.wasm_v128);
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] / b_.u64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_div_epu64
+  #define _mm_div_epu64(a, b) simde_mm_div_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 / b_.i8;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_div_epi8(a_.m128i[i], b_.m128i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+          r_.i8[i] = a_.i8[i] / b_.i8[i];
+        }
+      #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epi8
+  #define _mm256_div_epi8(a, b) simde_mm256_div_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 / b_.i16;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_div_epi16(a_.m128i[i], b_.m128i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = a_.i16[i] / b_.i16[i];
+        }
+       #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epi16
+  #define _mm256_div_epi16(a, b) simde_mm256_div_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 / b_.i32;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_div_epi32(a_.m128i[i], b_.m128i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = a_.i32[i] / b_.i32[i];
+        }
+       #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#define simde_mm256_idiv_epi32(a, b) simde_mm256_div_epi32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epi32
+  #define _mm256_div_epi32(a, b) simde_mm256_div_epi32(a, b)
+  #undef _mm256_idiv_epi32
+  #define _mm256_idiv_epi32(a, b) simde_mm256_div_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 / b_.i64;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+        for (size_t i = 0 ; i < (sizeof(r_.m128i) / sizeof(r_.m128i[0])) ; i++) {
+          r_.m128i[i] = simde_mm_div_epi64(a_.m128i[i], b_.m128i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.i64[i] = a_.i64[i] / b_.i64[i];
+        }
+        #endif
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epi64
+  #define _mm256_div_epi64(a, b) simde_mm256_div_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 / b_.u8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] / b_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epu8
+  #define _mm256_div_epu8(a, b) simde_mm256_div_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 / b_.u16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] / b_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epu16
+  #define _mm256_div_epu16(a, b) simde_mm256_div_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epu32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epu32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 / b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] / b_.u32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#define simde_mm256_udiv_epi32(a, b) simde_mm256_div_epu32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epu32
+  #define _mm256_div_epu32(a, b) simde_mm256_div_epu32(a, b)
+  #undef _mm256_udiv_epi32
+  #define _mm256_udiv_epi32(a, b) simde_mm256_div_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_div_epu64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_div_epu64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 / b_.u64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] / b_.u64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_div_epu64
+  #define _mm256_div_epu64(a, b) simde_mm256_div_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 / b_.i8;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_div_epi8(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+          r_.i8[i] = a_.i8[i] / b_.i8[i];
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epi8
+  #define _mm512_div_epi8(a, b) simde_mm512_div_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 / b_.i16;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_div_epi16(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+          r_.i16[i] = a_.i16[i] / b_.i16[i];
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epi16
+  #define _mm512_div_epi16(a, b) simde_mm512_div_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 / b_.i32;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_div_epi32(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+          r_.i32[i] = a_.i32[i] / b_.i32[i];
+        }
+        #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epi32
+  #define _mm512_div_epi32(a, b) simde_mm512_div_epi32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_div_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_div_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_div_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_div_epi32
+  #define _mm512_mask_div_epi32(src, k, a, b) simde_mm512_mask_div_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 / b_.i64;
+    #else
+      #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+        for (size_t i = 0 ; i < (sizeof(r_.m256i) / sizeof(r_.m256i[0])) ; i++) {
+          r_.m256i[i] = simde_mm256_div_epi64(a_.m256i[i], b_.m256i[i]);
+        }
+      #else
+        SIMDE_VECTORIZE
+        for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+          r_.i64[i] = a_.i64[i] / b_.i64[i];
+        }
+      #endif
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epi64
+  #define _mm512_div_epi64(a, b) simde_mm512_div_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 / b_.u8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] / b_.u8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epu8
+  #define _mm512_div_epu8(a, b) simde_mm512_div_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 / b_.u16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] / b_.u16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epu16
+  #define _mm512_div_epu16(a, b) simde_mm512_div_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epu32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epu32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 / b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] / b_.u32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epu32
+  #define _mm512_div_epu32(a, b) simde_mm512_div_epu32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_div_epu32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_div_epu32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_div_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_div_epu32
+  #define _mm512_mask_div_epu32(src, k, a, b) simde_mm512_mask_div_epu32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_div_epu64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_div_epu64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 / b_.u64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] / b_.u64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_div_epu64
+  #define _mm512_div_epu64(a, b) simde_mm512_div_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_erf_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erf_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_erff4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erff(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erf_ps
+  #define _mm_erf_ps(a) simde_mm_erf_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_erf_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erf_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_erfd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erf(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erf_pd
+  #define _mm_erf_pd(a) simde_mm_erf_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_erf_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erf_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_erff8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_erf_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_erff(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erf_ps
+  #define _mm256_erf_ps(a) simde_mm256_erf_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_erf_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erf_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_erfd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_erf_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_erf(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erf_pd
+  #define _mm256_erf_pd(a) simde_mm256_erf_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_erf_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erf_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_erff16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_erf_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_erff(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erf_ps
+  #define _mm512_erf_ps(a) simde_mm512_erf_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_erf_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erf_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_erfd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_erf_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_erf(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erf_pd
+  #define _mm512_erf_pd(a) simde_mm512_erf_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_erf_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erf_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_erf_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erf_ps
+  #define _mm512_mask_erf_ps(src, k, a) simde_mm512_mask_erf_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_erf_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erf_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_erf_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erf_pd
+  #define _mm512_mask_erf_pd(src, k, a) simde_mm512_mask_erf_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_erfc_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_erfcf4_u15(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erfcf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfc_ps
+  #define _mm_erfc_ps(a) simde_mm_erfc_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_erfc_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_erfcd2_u15(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erfc(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfc_pd
+  #define _mm_erfc_pd(a) simde_mm_erfc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_erfc_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_erfcf8_u15(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_erfc_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_erfcf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfc_ps
+  #define _mm256_erfc_ps(a) simde_mm256_erfc_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_erfc_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_erfcd4_u15(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_erfc_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_erfc(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfc_pd
+  #define _mm256_erfc_pd(a) simde_mm256_erfc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_erfc_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_erfcf16_u15(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_erfc_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_erfcf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfc_ps
+  #define _mm512_erfc_ps(a) simde_mm512_erfc_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_erfc_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_erfcd8_u15(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_erfc_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_erfc(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfc_pd
+  #define _mm512_erfc_pd(a) simde_mm512_erfc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_erfc_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfc_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_erfc_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfc_ps
+  #define _mm512_mask_erfc_ps(src, k, a) simde_mm512_mask_erfc_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_erfc_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfc_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_erfc_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfc_pd
+  #define _mm512_mask_erfc_pd(src, k, a) simde_mm512_mask_erfc_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_exp_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_expf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_expf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp_ps
+  #define _mm_exp_ps(a) simde_mm_exp_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_exp_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_expd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_exp(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp_pd
+  #define _mm_exp_pd(a) simde_mm_exp_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_exp_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_expf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_exp_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_expf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp_ps
+  #define _mm256_exp_ps(a) simde_mm256_exp_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_exp_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_expd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_exp_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp_pd
+  #define _mm256_exp_pd(a) simde_mm256_exp_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_exp_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_expf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_exp_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_expf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp_ps
+  #define _mm512_exp_ps(a) simde_mm512_exp_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_exp_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_expd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_exp_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp_pd
+  #define _mm512_exp_pd(a) simde_mm512_exp_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_exp_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_exp_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp_ps
+  #define _mm512_mask_exp_ps(src, k, a) simde_mm512_mask_exp_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_exp_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_exp_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp_pd
+  #define _mm512_mask_exp_pd(src, k, a) simde_mm512_mask_exp_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_expm1_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_expm1_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_expm1f4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_expm1f(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_expm1_ps
+  #define _mm_expm1_ps(a) simde_mm_expm1_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_expm1_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_expm1_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_expm1d2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_expm1(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_expm1_pd
+  #define _mm_expm1_pd(a) simde_mm_expm1_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_expm1_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_expm1_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_expm1f8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_expm1_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_expm1f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_expm1_ps
+  #define _mm256_expm1_ps(a) simde_mm256_expm1_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_expm1_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_expm1_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_expm1d4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_expm1_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_expm1(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_expm1_pd
+  #define _mm256_expm1_pd(a) simde_mm256_expm1_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_expm1_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_expm1_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_expm1f16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_expm1_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_expm1f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_expm1_ps
+  #define _mm512_expm1_ps(a) simde_mm512_expm1_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_expm1_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_expm1_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_expm1d8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_expm1_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_expm1(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_expm1_pd
+  #define _mm512_expm1_pd(a) simde_mm512_expm1_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_expm1_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_expm1_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_expm1_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_expm1_ps
+  #define _mm512_mask_expm1_ps(src, k, a) simde_mm512_mask_expm1_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_expm1_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_expm1_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_expm1_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_expm1_pd
+  #define _mm512_mask_expm1_pd(src, k, a) simde_mm512_mask_expm1_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_exp2_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_exp2f4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_exp2f(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp2_ps
+  #define _mm_exp2_ps(a) simde_mm_exp2_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_exp2_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_exp2d2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_exp2(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp2_pd
+  #define _mm_exp2_pd(a) simde_mm_exp2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_exp2_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_exp2f8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_exp2_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_exp2f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp2_ps
+  #define _mm256_exp2_ps(a) simde_mm256_exp2_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_exp2_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_exp2d4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_exp2_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp2(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp2_pd
+  #define _mm256_exp2_pd(a) simde_mm256_exp2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_exp2_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_exp2f16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_exp2_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_exp2f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp2_ps
+  #define _mm512_exp2_ps(a) simde_mm512_exp2_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_exp2_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_exp2d8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_exp2_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp2(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp2_pd
+  #define _mm512_exp2_pd(a) simde_mm512_exp2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_exp2_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp2_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_exp2_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp2_ps
+  #define _mm512_mask_exp2_ps(src, k, a) simde_mm512_mask_exp2_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_exp2_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp2_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_exp2_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp2_pd
+  #define _mm512_mask_exp2_pd(src, k, a) simde_mm512_mask_exp2_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_exp10_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_exp10f4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_exp10f(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp10_ps
+  #define _mm_exp10_ps(a) simde_mm_exp10_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_exp10_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_exp10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_exp10d2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_exp10(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_exp10_pd
+  #define _mm_exp10_pd(a) simde_mm_exp10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_exp10_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_exp10f8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_exp10_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_exp10f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp10_ps
+  #define _mm256_exp10_ps(a) simde_mm256_exp10_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_exp10_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_exp10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_exp10d4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_exp10_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp10(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_exp10_pd
+  #define _mm256_exp10_pd(a) simde_mm256_exp10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_exp10_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_exp10f16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_exp10_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_exp10f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp10_ps
+  #define _mm512_exp10_ps(a) simde_mm512_exp10_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_exp10_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_exp10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_exp10d8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_exp10_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_exp10(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_exp10_pd
+  #define _mm512_exp10_pd(a) simde_mm512_exp10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_exp10_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp10_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_exp10_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp10_ps
+  #define _mm512_mask_exp10_ps(src, k, a) simde_mm512_mask_exp10_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_exp10_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_exp10_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_exp10_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_exp10_pd
+  #define _mm512_mask_exp10_pd(src, k, a) simde_mm512_mask_exp10_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cdfnorm_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cdfnorm_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m128 a1 = simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.254829592));
+    const simde__m128 a2 = simde_mm_set1_ps(SIMDE_FLOAT32_C(-0.284496736));
+    const simde__m128 a3 = simde_mm_set1_ps(SIMDE_FLOAT32_C(1.421413741));
+    const simde__m128 a4 = simde_mm_set1_ps(SIMDE_FLOAT32_C(-1.453152027));
+    const simde__m128 a5 = simde_mm_set1_ps(SIMDE_FLOAT32_C(1.061405429));
+    const simde__m128 p = simde_mm_set1_ps(SIMDE_FLOAT32_C(0.3275911));
+    const simde__m128 one = simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0));
+
+    /* simde_math_fabsf(x) / sqrtf(2.0) */
+    const simde__m128 x = simde_mm_div_ps(simde_x_mm_abs_ps(a), simde_mm_sqrt_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m128 t = simde_mm_div_ps(one, simde_mm_add_ps(one, simde_mm_mul_ps(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m128 y = simde_mm_mul_ps(a5, t);
+    y = simde_mm_add_ps(y, a4);
+    y = simde_mm_mul_ps(y, t);
+    y = simde_mm_add_ps(y, a3);
+    y = simde_mm_mul_ps(y, t);
+    y = simde_mm_add_ps(y, a2);
+    y = simde_mm_mul_ps(y, t);
+    y = simde_mm_add_ps(y, a1);
+    y = simde_mm_mul_ps(y, t);
+    y = simde_mm_mul_ps(y, simde_mm_exp_ps(simde_mm_mul_ps(x, simde_x_mm_negate_ps(x))));
+    y = simde_mm_sub_ps(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm_mul_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(0.5)), simde_mm_add_ps(one, simde_x_mm_xorsign_ps(y, a)));
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_cdfnormf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cdfnorm_ps
+  #define _mm_cdfnorm_ps(a) simde_mm_cdfnorm_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cdfnorm_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cdfnorm_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m128d a1 = simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.254829592));
+    const simde__m128d a2 = simde_mm_set1_pd(SIMDE_FLOAT64_C(-0.284496736));
+    const simde__m128d a3 = simde_mm_set1_pd(SIMDE_FLOAT64_C(1.421413741));
+    const simde__m128d a4 = simde_mm_set1_pd(SIMDE_FLOAT64_C(-1.453152027));
+    const simde__m128d a5 = simde_mm_set1_pd(SIMDE_FLOAT64_C(1.061405429));
+    const simde__m128d p = simde_mm_set1_pd(SIMDE_FLOAT64_C(0.6475911));
+    const simde__m128d one = simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0));
+
+    /* simde_math_fabs(x) / sqrt(2.0) */
+    const simde__m128d x = simde_mm_div_pd(simde_x_mm_abs_pd(a), simde_mm_sqrt_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m128d t = simde_mm_div_pd(one, simde_mm_add_pd(one, simde_mm_mul_pd(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m128d y = simde_mm_mul_pd(a5, t);
+    y = simde_mm_add_pd(y, a4);
+    y = simde_mm_mul_pd(y, t);
+    y = simde_mm_add_pd(y, a3);
+    y = simde_mm_mul_pd(y, t);
+    y = simde_mm_add_pd(y, a2);
+    y = simde_mm_mul_pd(y, t);
+    y = simde_mm_add_pd(y, a1);
+    y = simde_mm_mul_pd(y, t);
+    y = simde_mm_mul_pd(y, simde_mm_exp_pd(simde_mm_mul_pd(x, simde_x_mm_negate_pd(x))));
+    y = simde_mm_sub_pd(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm_mul_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(0.5)), simde_mm_add_pd(one, simde_x_mm_xorsign_pd(y, a)));
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cdfnorm(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cdfnorm_pd
+  #define _mm_cdfnorm_pd(a) simde_mm_cdfnorm_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cdfnorm_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cdfnorm_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m256 a1 = simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.254829592));
+    const simde__m256 a2 = simde_mm256_set1_ps(SIMDE_FLOAT32_C(-0.284496736));
+    const simde__m256 a3 = simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.421413741));
+    const simde__m256 a4 = simde_mm256_set1_ps(SIMDE_FLOAT32_C(-1.453152027));
+    const simde__m256 a5 = simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.061405429));
+    const simde__m256 p = simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.3275911));
+    const simde__m256 one = simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0));
+
+    /* simde_math_fabsf(x) / sqrtf(2.0) */
+    const simde__m256 x = simde_mm256_div_ps(simde_x_mm256_abs_ps(a), simde_mm256_sqrt_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m256 t = simde_mm256_div_ps(one, simde_mm256_add_ps(one, simde_mm256_mul_ps(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m256 y = simde_mm256_mul_ps(a5, t);
+    y = simde_mm256_add_ps(y, a4);
+    y = simde_mm256_mul_ps(y, t);
+    y = simde_mm256_add_ps(y, a3);
+    y = simde_mm256_mul_ps(y, t);
+    y = simde_mm256_add_ps(y, a2);
+    y = simde_mm256_mul_ps(y, t);
+    y = simde_mm256_add_ps(y, a1);
+    y = simde_mm256_mul_ps(y, t);
+    y = simde_mm256_mul_ps(y, simde_mm256_exp_ps(simde_mm256_mul_ps(x, simde_x_mm256_negate_ps(x))));
+    y = simde_mm256_sub_ps(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm256_mul_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.5)), simde_mm256_add_ps(one, simde_x_mm256_xorsign_ps(y, a)));
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cdfnorm_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cdfnormf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cdfnorm_ps
+  #define _mm256_cdfnorm_ps(a) simde_mm256_cdfnorm_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cdfnorm_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cdfnorm_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m256d a1 = simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.254829592));
+    const simde__m256d a2 = simde_mm256_set1_pd(SIMDE_FLOAT64_C(-0.284496736));
+    const simde__m256d a3 = simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.421413741));
+    const simde__m256d a4 = simde_mm256_set1_pd(SIMDE_FLOAT64_C(-1.453152027));
+    const simde__m256d a5 = simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.061405429));
+    const simde__m256d p = simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.6475911));
+    const simde__m256d one = simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0));
+
+    /* simde_math_fabs(x) / sqrt(2.0) */
+    const simde__m256d x = simde_mm256_div_pd(simde_x_mm256_abs_pd(a), simde_mm256_sqrt_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m256d t = simde_mm256_div_pd(one, simde_mm256_add_pd(one, simde_mm256_mul_pd(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m256d y = simde_mm256_mul_pd(a5, t);
+    y = simde_mm256_add_pd(y, a4);
+    y = simde_mm256_mul_pd(y, t);
+    y = simde_mm256_add_pd(y, a3);
+    y = simde_mm256_mul_pd(y, t);
+    y = simde_mm256_add_pd(y, a2);
+    y = simde_mm256_mul_pd(y, t);
+    y = simde_mm256_add_pd(y, a1);
+    y = simde_mm256_mul_pd(y, t);
+    y = simde_mm256_mul_pd(y, simde_mm256_exp_pd(simde_mm256_mul_pd(x, simde_x_mm256_negate_pd(x))));
+    y = simde_mm256_sub_pd(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm256_mul_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.5)), simde_mm256_add_pd(one, simde_x_mm256_xorsign_pd(y, a)));
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cdfnorm_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cdfnorm(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cdfnorm_pd
+  #define _mm256_cdfnorm_pd(a) simde_mm256_cdfnorm_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cdfnorm_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cdfnorm_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m512 a1 = simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.254829592));
+    const simde__m512 a2 = simde_mm512_set1_ps(SIMDE_FLOAT32_C(-0.284496736));
+    const simde__m512 a3 = simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.421413741));
+    const simde__m512 a4 = simde_mm512_set1_ps(SIMDE_FLOAT32_C(-1.453152027));
+    const simde__m512 a5 = simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.061405429));
+    const simde__m512 p = simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.3275911));
+    const simde__m512 one = simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0));
+
+    /* simde_math_fabsf(x) / sqrtf(2.0) */
+    const simde__m512 x = simde_mm512_div_ps(simde_mm512_abs_ps(a), simde_mm512_sqrt_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m512 t = simde_mm512_div_ps(one, simde_mm512_add_ps(one, simde_mm512_mul_ps(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m512 y = simde_mm512_mul_ps(a5, t);
+    y = simde_mm512_add_ps(y, a4);
+    y = simde_mm512_mul_ps(y, t);
+    y = simde_mm512_add_ps(y, a3);
+    y = simde_mm512_mul_ps(y, t);
+    y = simde_mm512_add_ps(y, a2);
+    y = simde_mm512_mul_ps(y, t);
+    y = simde_mm512_add_ps(y, a1);
+    y = simde_mm512_mul_ps(y, t);
+    y = simde_mm512_mul_ps(y, simde_mm512_exp_ps(simde_mm512_mul_ps(x, simde_x_mm512_negate_ps(x))));
+    y = simde_mm512_sub_ps(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm512_mul_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.5)), simde_mm512_add_ps(one, simde_x_mm512_xorsign_ps(y, a)));
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_cdfnorm_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cdfnormf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cdfnorm_ps
+  #define _mm512_cdfnorm_ps(a) simde_mm512_cdfnorm_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cdfnorm_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cdfnorm_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://www.johndcook.com/blog/cpp_phi/ */
+    const simde__m512d a1 = simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.254829592));
+    const simde__m512d a2 = simde_mm512_set1_pd(SIMDE_FLOAT64_C(-0.284496736));
+    const simde__m512d a3 = simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.421413741));
+    const simde__m512d a4 = simde_mm512_set1_pd(SIMDE_FLOAT64_C(-1.453152027));
+    const simde__m512d a5 = simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.061405429));
+    const simde__m512d p = simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.6475911));
+    const simde__m512d one = simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0));
+
+    /* simde_math_fabs(x) / sqrt(2.0) */
+    const simde__m512d x = simde_mm512_div_pd(simde_mm512_abs_pd(a), simde_mm512_sqrt_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(2.0))));
+
+    /* 1.0 / (1.0 + p * x) */
+    const simde__m512d t = simde_mm512_div_pd(one, simde_mm512_add_pd(one, simde_mm512_mul_pd(p, x)));
+
+    /* 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * exp(-x * x) */
+    simde__m512d y = simde_mm512_mul_pd(a5, t);
+    y = simde_mm512_add_pd(y, a4);
+    y = simde_mm512_mul_pd(y, t);
+    y = simde_mm512_add_pd(y, a3);
+    y = simde_mm512_mul_pd(y, t);
+    y = simde_mm512_add_pd(y, a2);
+    y = simde_mm512_mul_pd(y, t);
+    y = simde_mm512_add_pd(y, a1);
+    y = simde_mm512_mul_pd(y, t);
+    y = simde_mm512_mul_pd(y, simde_mm512_exp_pd(simde_mm512_mul_pd(x, simde_x_mm512_negate_pd(x))));
+    y = simde_mm512_sub_pd(one, y);
+
+    /* 0.5 * (1.0 + ((a < 0.0) ? -y : y)) */
+    return simde_mm512_mul_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.5)), simde_mm512_add_pd(one, simde_x_mm512_xorsign_pd(y, a)));
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_cdfnorm_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cdfnorm(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cdfnorm_pd
+  #define _mm512_cdfnorm_pd(a) simde_mm512_cdfnorm_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cdfnorm_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cdfnorm_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cdfnorm_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cdfnorm_ps
+  #define _mm512_mask_cdfnorm_ps(src, k, a) simde_mm512_mask_cdfnorm_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cdfnorm_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cdfnorm_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cdfnorm_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cdfnorm_pd
+  #define _mm512_mask_cdfnorm_pd(src, k, a) simde_mm512_mask_cdfnorm_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_idivrem_epi32 (simde__m128i* mem_addr, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_idivrem_epi32(HEDLEY_REINTERPRET_CAST(__m128i*, mem_addr), a, b);
+  #else
+    simde__m128i r;
+
+    r = simde_mm_div_epi32(a, b);
+    *mem_addr = simde_mm_sub_epi32(a, simde_mm_mullo_epi32(r, b));
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_idivrem_epi32
+  #define _mm_idivrem_epi32(mem_addr, a, b) simde_mm_idivrem_epi32((mem_addr),(a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_idivrem_epi32 (simde__m256i* mem_addr, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_idivrem_epi32(HEDLEY_REINTERPRET_CAST(__m256i*, mem_addr), a, b);
+  #else
+    simde__m256i r;
+
+    r = simde_mm256_div_epi32(a, b);
+    *mem_addr = simde_mm256_sub_epi32(a, simde_mm256_mullo_epi32(r, b));
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_idivrem_epi32
+  #define _mm256_idivrem_epi32(mem_addr, a, b) simde_mm256_idivrem_epi32((mem_addr),(a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_hypot_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_hypot_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotf4_u05(a, b);
+    #else
+      return Sleef_hypotf4_u35(a, b);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_hypotf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_hypot_ps
+  #define _mm_hypot_ps(a, b) simde_mm_hypot_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_hypot_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_hypot_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotd2_u05(a, b);
+    #else
+      return Sleef_hypotd2_u35(a, b);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_hypot(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_hypot_pd
+  #define _mm_hypot_pd(a, b) simde_mm_hypot_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_hypot_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hypot_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotf8_u05(a, b);
+    #else
+      return Sleef_hypotf8_u35(a, b);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_hypotf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hypot_ps
+  #define _mm256_hypot_ps(a, b) simde_mm256_hypot_ps(a, b)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_hypot_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_hypot_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotd4_u05(a, b);
+    #else
+      return Sleef_hypotd4_u35(a, b);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_hypot(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_hypot_pd
+  #define _mm256_hypot_pd(a, b) simde_mm256_hypot_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_hypot_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_hypot_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotf16_u05(a, b);
+    #else
+      return Sleef_hypotf16_u35(a, b);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_hypotf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_hypot_ps
+  #define _mm512_hypot_ps(a, b) simde_mm512_hypot_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_hypot_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_hypot_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_hypotd8_u05(a, b);
+    #else
+      return Sleef_hypotd8_u35(a, b);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_hypot(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_hypot_pd
+  #define _mm512_hypot_pd(a, b) simde_mm512_hypot_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_hypot_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_hypot_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_hypot_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_hypot_ps
+  #define _mm512_mask_hypot_ps(src, k, a, b) simde_mm512_mask_hypot_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_hypot_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_hypot_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_hypot_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_hypot_pd
+  #define _mm512_mask_hypot_pd(src, k, a, b) simde_mm512_mask_hypot_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_invcbrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_invcbrt_ps(a);
+  #else
+    return simde_mm_rcp_ps(simde_mm_cbrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_invcbrt_ps
+  #define _mm_invcbrt_ps(a) simde_mm_invcbrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_invcbrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_invcbrt_pd(a);
+  #else
+    return simde_mm_div_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)), simde_mm_cbrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_invcbrt_pd
+  #define _mm_invcbrt_pd(a) simde_mm_invcbrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_invcbrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_invcbrt_ps(a);
+  #else
+    return simde_mm256_rcp_ps(simde_mm256_cbrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_invcbrt_ps
+  #define _mm256_invcbrt_ps(a) simde_mm256_invcbrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_invcbrt_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_invcbrt_pd(a);
+  #else
+    return simde_mm256_div_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), simde_mm256_cbrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_invcbrt_pd
+  #define _mm256_invcbrt_pd(a) simde_mm256_invcbrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_invsqrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_invsqrt_ps(a);
+  #else
+    return simde_mm_rcp_ps(simde_mm_sqrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_invsqrt_ps
+  #define _mm_invsqrt_ps(a) simde_mm_invsqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_invsqrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_invsqrt_pd(a);
+  #else
+    return simde_mm_div_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)), simde_mm_sqrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_invsqrt_pd
+  #define _mm_invsqrt_pd(a) simde_mm_invsqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_invsqrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_invsqrt_ps(a);
+  #else
+    return simde_mm256_rcp_ps(simde_mm256_sqrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_invsqrt_ps
+  #define _mm256_invsqrt_ps(a) simde_mm256_invsqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_invsqrt_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_invsqrt_pd(a);
+  #else
+    return simde_mm256_div_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), simde_mm256_sqrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_invsqrt_pd
+  #define _mm256_invsqrt_pd(a) simde_mm256_invsqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_invsqrt_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_invsqrt_ps(a);
+  #else
+    return simde_mm512_div_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), simde_mm512_sqrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_invsqrt_ps
+  #define _mm512_invsqrt_ps(a) simde_mm512_invsqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_invsqrt_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_invsqrt_pd(a);
+  #else
+    return simde_mm512_div_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), simde_mm512_sqrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_invsqrt_pd
+  #define _mm512_invsqrt_pd(a) simde_mm512_invsqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_invsqrt_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_invsqrt_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_invsqrt_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_invsqrt_ps
+  #define _mm512_mask_invsqrt_ps(src, k, a) simde_mm512_mask_invsqrt_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_invsqrt_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_invsqrt_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_invsqrt_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_invsqrt_pd
+  #define _mm512_mask_invsqrt_pd(src, k, a) simde_mm512_mask_invsqrt_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_log_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log_ps(a);
+  #elif defined(SIMDE_POWER_ALTIVEC_P7_NATIVE) && 0
+    return vec_loge(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logf4_u10(a);
+    #else
+      return Sleef_logf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_logf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log_ps
+  #define _mm_log_ps(a) simde_mm_log_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_log_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logd2_u10(a);
+    #else
+      return Sleef_logd2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_log(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log_pd
+  #define _mm_log_pd(a) simde_mm_log_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_log_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logf8_u10(a);
+    #else
+      return Sleef_logf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_log_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_logf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log_ps
+  #define _mm256_log_ps(a) simde_mm256_log_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_log_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logd4_u10(a);
+    #else
+      return Sleef_logd4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_log_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log_pd
+  #define _mm256_log_pd(a) simde_mm256_log_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_log_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logf16_u10(a);
+    #else
+      return Sleef_logf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_log_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_logf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log_ps
+  #define _mm512_log_ps(a) simde_mm512_log_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_log_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_logd8_u10(a);
+    #else
+      return Sleef_logd8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_log_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log_pd
+  #define _mm512_log_pd(a) simde_mm512_log_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_log_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_log_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log_ps
+  #define _mm512_mask_log_ps(src, k, a) simde_mm512_mask_log_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_log_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_log_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log_pd
+  #define _mm512_mask_log_pd(src, k, a) simde_mm512_mask_log_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_cdfnorminv_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cdfnorminv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    simde__m128 matched, retval = simde_mm_setzero_ps();
+
+    { /* if (a < 0 || a > 1) */
+      matched = simde_mm_or_ps(simde_mm_cmplt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0))), simde_mm_cmpgt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0))));
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__m128 mask = simde_mm_cmpeq_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0)));
+      mask = simde_mm_andnot_ps(matched, mask);
+      matched = simde_mm_or_ps(matched, mask);
+
+      simde__m128 res = simde_mm_set1_ps(-SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+    }
+
+    { /* else if (a == 1) */
+      simde__m128 mask = simde_mm_cmpeq_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0)));
+      mask = simde_mm_andnot_ps(matched, mask);
+      matched = simde_mm_or_ps(matched, mask);
+
+      simde__m128 res = simde_mm_set1_ps(SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+    }
+
+    { /* Remaining conditions.
+       *
+       * Including the else case in this complicates things a lot, but
+       * we're using cheap operations to get rid of expensive multiply
+       * and add functions.  This should be a small improvement on SSE
+       * prior to 4.1.  On SSE 4.1 we can use _mm_blendv_ps which is
+       * very fast and this becomes a huge win.  NEON, AltiVec, and
+       * WASM also have blend operations, so this should be a big win
+       * there, too. */
+
+      /* else if (a < 0.02425) */
+      simde__m128 mask_lo = simde_mm_cmplt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.02425)));
+      /* else if (a > 0.97575) */
+      simde__m128 mask_hi = simde_mm_cmpgt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.97575)));
+
+      simde__m128 mask = simde_mm_or_ps(mask_lo, mask_hi);
+      matched = simde_mm_or_ps(matched, mask);
+
+      /* else */
+      simde__m128 mask_el = simde_x_mm_not_ps(matched);
+      mask = simde_mm_or_ps(mask, mask_el);
+
+      /* r = a - 0.5f */
+      simde__m128 r = simde_mm_sub_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m128 q = simde_mm_and_ps(mask_lo, a);
+      q = simde_mm_or_ps(q, simde_mm_and_ps(mask_hi, simde_mm_sub_ps(simde_mm_set1_ps(1.0f), a)));
+
+      /* q = simde_math_sqrtf(-2.0f * simde_math_logf(q)) */
+      q = simde_mm_log_ps(q);
+      q = simde_mm_mul_ps(q, simde_mm_set1_ps(SIMDE_FLOAT32_C(-2.0)));
+      q = simde_mm_sqrt_ps(q);
+
+      /* el: q = r * r */
+      q = simde_x_mm_select_ps(q, simde_mm_mul_ps(r, r), mask_el);
+
+      /* lo: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0f); */
+      /* hi: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0f); */
+      /* el: float numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m128 numerator = simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(-7.784894002430293e-03)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-3.969683028665376e+01)), mask_el);
+      numerator = simde_mm_fmadd_ps(numerator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(-3.223964580411365e-01)), simde_mm_set1_ps(SIMDE_FLOAT32_C( 2.209460984245205e+02)), mask_el));
+      numerator = simde_mm_fmadd_ps(numerator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(-2.400758277161838e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-2.759285104469687e+02)), mask_el));
+      numerator = simde_mm_fmadd_ps(numerator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(-2.549732539343734e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.383577518672690e+02)), mask_el));
+      numerator = simde_mm_fmadd_ps(numerator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 4.374664141464968e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-3.066479806614716e+01)), mask_el));
+      numerator = simde_mm_fmadd_ps(numerator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 2.938163982698783e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C( 2.506628277459239e+00)), mask_el));
+      {
+        simde__m128 multiplier;
+        multiplier =                            simde_mm_and_ps(mask_lo, simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.0)));
+        multiplier = simde_mm_or_ps(multiplier, simde_mm_and_ps(mask_hi, simde_mm_set1_ps(SIMDE_FLOAT32_C(-1.0))));
+        multiplier = simde_mm_or_ps(multiplier, simde_mm_and_ps(mask_el, r));
+        numerator = simde_mm_mul_ps(numerator, multiplier);
+      }
+
+      /* lo/hi: float denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: float denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m128 denominator = simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 7.784695709041462e-03)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-5.447609879822406e+01)), mask_el);
+      denominator = simde_mm_fmadd_ps(denominator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 3.224671290700398e-01)), simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.615858368580409e+02)), mask_el));
+      denominator = simde_mm_fmadd_ps(denominator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 2.445134137142996e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-1.556989798598866e+02)), mask_el));
+      denominator = simde_mm_fmadd_ps(denominator, q, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 3.754408661907416e+00)), simde_mm_set1_ps(SIMDE_FLOAT32_C( 6.680131188771972e+01)), mask_el));
+      denominator = simde_mm_fmadd_ps(denominator, simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.0)), q, mask_el),
+                                                   simde_x_mm_select_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.0)), simde_mm_set1_ps(SIMDE_FLOAT32_C(-1.328068155288572e+01)), mask_el));
+      denominator = simde_mm_fmadd_ps(denominator, q, simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0)));
+
+      /* res = numerator / denominator; */
+      simde__m128 res = simde_mm_div_ps(numerator, denominator);
+
+      retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+    }
+
+    return retval;
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_cdfnorminvf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cdfnorminv_ps
+  #define _mm_cdfnorminv_ps(a) simde_mm_cdfnorminv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_cdfnorminv_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_cdfnorminv_pd(a);
+   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    simde__m128d matched, retval = simde_mm_setzero_pd();
+
+    { /* if (a < 0 || a > 1) */
+      matched = simde_mm_or_pd(simde_mm_cmplt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0))), simde_mm_cmpgt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0))));
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__m128d mask = simde_mm_cmpeq_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0)));
+      mask = simde_mm_andnot_pd(matched, mask);
+      matched = simde_mm_or_pd(matched, mask);
+
+      simde__m128d res = simde_mm_set1_pd(-SIMDE_MATH_INFINITY);
+
+      retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+    }
+
+    { /* else if (a == 1) */
+      simde__m128d mask = simde_mm_cmpeq_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)));
+      mask = simde_mm_andnot_pd(matched, mask);
+      matched = simde_mm_or_pd(matched, mask);
+
+      simde__m128d res = simde_mm_set1_pd(SIMDE_MATH_INFINITY);
+
+      retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+    }
+
+    { /* Remaining conditions.
+       *
+       * Including the else case in this complicates things a lot, but
+       * we're using cheap operations to get rid of expensive multiply
+       * and add functions.  This should be a small improvement on SSE
+       * prior to 4.1.  On SSE 4.1 we can use _mm_blendv_pd which is
+       * very fast and this becomes a huge win.  NEON, AltiVec, and
+       * WASM also have blend operations, so this should be a big win
+       * there, too. */
+
+      /* else if (a < 0.02425) */
+      simde__m128d mask_lo = simde_mm_cmplt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.02425)));
+      /* else if (a > 0.97575) */
+      simde__m128d mask_hi = simde_mm_cmpgt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.97575)));
+
+      simde__m128d mask = simde_mm_or_pd(mask_lo, mask_hi);
+      matched = simde_mm_or_pd(matched, mask);
+
+      /* else */
+      simde__m128d mask_el = simde_x_mm_not_pd(matched);
+      mask = simde_mm_or_pd(mask, mask_el);
+
+      /* r = a - 0.5 */
+      simde__m128d r = simde_mm_sub_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m128d q = simde_mm_and_pd(mask_lo, a);
+      q = simde_mm_or_pd(q, simde_mm_and_pd(mask_hi, simde_mm_sub_pd(simde_mm_set1_pd(1.0), a)));
+
+      /* q = simde_math_sqrt(-2.0 * simde_math_log(q)) */
+      q = simde_mm_log_pd(q);
+      q = simde_mm_mul_pd(q, simde_mm_set1_pd(SIMDE_FLOAT64_C(-2.0)));
+      q = simde_mm_sqrt_pd(q);
+
+      /* el: q = r * r */
+      q = simde_x_mm_select_pd(q, simde_mm_mul_pd(r, r), mask_el);
+
+      /* lo: double numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0); */
+      /* hi: double numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0); */
+      /* el: double numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m128d numerator = simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(-7.784894002430293e-03)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-3.969683028665376e+01)), mask_el);
+      numerator = simde_mm_fmadd_pd(numerator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(-3.223964580411365e-01)), simde_mm_set1_pd(SIMDE_FLOAT64_C( 2.209460984245205e+02)), mask_el));
+      numerator = simde_mm_fmadd_pd(numerator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(-2.400758277161838e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-2.759285104469687e+02)), mask_el));
+      numerator = simde_mm_fmadd_pd(numerator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(-2.549732539343734e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.383577518672690e+02)), mask_el));
+      numerator = simde_mm_fmadd_pd(numerator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 4.374664141464968e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-3.066479806614716e+01)), mask_el));
+      numerator = simde_mm_fmadd_pd(numerator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 2.938163982698783e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C( 2.506628277459239e+00)), mask_el));
+      {
+        simde__m128d multiplier;
+        multiplier =                            simde_mm_and_pd(mask_lo, simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.0)));
+        multiplier = simde_mm_or_pd(multiplier, simde_mm_and_pd(mask_hi, simde_mm_set1_pd(SIMDE_FLOAT64_C(-1.0))));
+        multiplier = simde_mm_or_pd(multiplier, simde_mm_and_pd(mask_el, r));
+        numerator = simde_mm_mul_pd(numerator, multiplier);
+      }
+
+      /* lo/hi: double denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: double denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m128d denominator = simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 7.784695709041462e-03)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-5.447609879822406e+01)), mask_el);
+      denominator = simde_mm_fmadd_pd(denominator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 3.224671290700398e-01)), simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.615858368580409e+02)), mask_el));
+      denominator = simde_mm_fmadd_pd(denominator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 2.445134137142996e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-1.556989798598866e+02)), mask_el));
+      denominator = simde_mm_fmadd_pd(denominator, q, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 3.754408661907416e+00)), simde_mm_set1_pd(SIMDE_FLOAT64_C( 6.680131188771972e+01)), mask_el));
+      denominator = simde_mm_fmadd_pd(denominator, simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.0)), q, mask_el),
+                                                   simde_x_mm_select_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.0)), simde_mm_set1_pd(SIMDE_FLOAT64_C(-1.328068155288572e+01)), mask_el));
+      denominator = simde_mm_fmadd_pd(denominator, q, simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)));
+
+      /* res = numerator / denominator; */
+      simde__m128d res = simde_mm_div_pd(numerator, denominator);
+
+      retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+    }
+
+    return retval;
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_cdfnorminv(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_cdfnorminv_pd
+  #define _mm_cdfnorminv_pd(a) simde_mm_cdfnorminv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_cdfnorminv_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cdfnorminv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    simde__m256 matched, retval = simde_mm256_setzero_ps();
+
+    { /* if (a < 0 || a > 1) */
+      matched = simde_mm256_or_ps(simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_LT_OQ), simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)), SIMDE_CMP_GT_OQ));
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__m256 mask = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_ps(matched, mask);
+      matched = simde_mm256_or_ps(matched, mask);
+
+      simde__m256 res = simde_mm256_set1_ps(-SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+    }
+
+    { /* else if (a == 1) */
+      simde__m256 mask = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_ps(matched, mask);
+      matched = simde_mm256_or_ps(matched, mask);
+
+      simde__m256 res = simde_mm256_set1_ps(SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+    }
+
+    { /* Remaining conditions.
+       *
+       * Including the else case in this complicates things a lot, but
+       * we're using cheap operations to get rid of expensive multiply
+       * and add functions.  This should be a small improvement on SSE
+       * prior to 4.1.  On SSE 4.1 we can use _mm256_blendv_ps which is
+       * very fast and this becomes a huge win.  NEON, AltiVec, and
+       * WASM also have blend operations, so this should be a big win
+       * there, too. */
+
+      /* else if (a < 0.02425) */
+      simde__m256 mask_lo = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.02425)), SIMDE_CMP_LT_OQ);
+      /* else if (a > 0.97575) */
+      simde__m256 mask_hi = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.97575)), SIMDE_CMP_GT_OQ);
+
+      simde__m256 mask = simde_mm256_or_ps(mask_lo, mask_hi);
+      matched = simde_mm256_or_ps(matched, mask);
+
+      /* else */
+      simde__m256 mask_el = simde_x_mm256_not_ps(matched);
+      mask = simde_mm256_or_ps(mask, mask_el);
+
+      /* r = a - 0.5f */
+      simde__m256 r = simde_mm256_sub_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m256 q = simde_mm256_and_ps(mask_lo, a);
+      q = simde_mm256_or_ps(q, simde_mm256_and_ps(mask_hi, simde_mm256_sub_ps(simde_mm256_set1_ps(1.0f), a)));
+
+      /* q = simde_math_sqrtf(-2.0f * simde_math_logf(q)) */
+      q = simde_mm256_log_ps(q);
+      q = simde_mm256_mul_ps(q, simde_mm256_set1_ps(SIMDE_FLOAT32_C(-2.0)));
+      q = simde_mm256_sqrt_ps(q);
+
+      /* el: q = r * r */
+      q = simde_x_mm256_select_ps(q, simde_mm256_mul_ps(r, r), mask_el);
+
+      /* lo: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0f); */
+      /* hi: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0f); */
+      /* el: float numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m256 numerator = simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(-7.784894002430293e-03)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-3.969683028665376e+01)), mask_el);
+      numerator = simde_mm256_fmadd_ps(numerator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(-3.223964580411365e-01)), simde_mm256_set1_ps(SIMDE_FLOAT32_C( 2.209460984245205e+02)), mask_el));
+      numerator = simde_mm256_fmadd_ps(numerator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(-2.400758277161838e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-2.759285104469687e+02)), mask_el));
+      numerator = simde_mm256_fmadd_ps(numerator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(-2.549732539343734e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.383577518672690e+02)), mask_el));
+      numerator = simde_mm256_fmadd_ps(numerator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 4.374664141464968e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-3.066479806614716e+01)), mask_el));
+      numerator = simde_mm256_fmadd_ps(numerator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 2.938163982698783e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C( 2.506628277459239e+00)), mask_el));
+      {
+        simde__m256 multiplier;
+        multiplier =                            simde_mm256_and_ps(mask_lo, simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.0)));
+        multiplier = simde_mm256_or_ps(multiplier, simde_mm256_and_ps(mask_hi, simde_mm256_set1_ps(SIMDE_FLOAT32_C(-1.0))));
+        multiplier = simde_mm256_or_ps(multiplier, simde_mm256_and_ps(mask_el, r));
+        numerator = simde_mm256_mul_ps(numerator, multiplier);
+      }
+
+      /* lo/hi: float denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: float denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m256 denominator = simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 7.784695709041462e-03)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-5.447609879822406e+01)), mask_el);
+      denominator = simde_mm256_fmadd_ps(denominator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 3.224671290700398e-01)), simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.615858368580409e+02)), mask_el));
+      denominator = simde_mm256_fmadd_ps(denominator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 2.445134137142996e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-1.556989798598866e+02)), mask_el));
+      denominator = simde_mm256_fmadd_ps(denominator, q, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 3.754408661907416e+00)), simde_mm256_set1_ps(SIMDE_FLOAT32_C( 6.680131188771972e+01)), mask_el));
+      denominator = simde_mm256_fmadd_ps(denominator, simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.0)), q, mask_el),
+                                                   simde_x_mm256_select_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.0)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(-1.328068155288572e+01)), mask_el));
+      denominator = simde_mm256_fmadd_ps(denominator, q, simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)));
+
+      /* res = numerator / denominator; */
+      simde__m256 res = simde_mm256_div_ps(numerator, denominator);
+
+      retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+    }
+
+    return retval;
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_cdfnorminv_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_cdfnorminvf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cdfnorminv_ps
+  #define _mm256_cdfnorminv_ps(a) simde_mm256_cdfnorminv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_cdfnorminv_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_cdfnorminv_pd(a);
+   #elif SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    simde__m256d matched, retval = simde_mm256_setzero_pd();
+
+    { /* if (a < 0 || a > 1) */
+      matched = simde_mm256_or_pd(simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_LT_OQ), simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), SIMDE_CMP_GT_OQ));
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__m256d mask = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_pd(matched, mask);
+      matched = simde_mm256_or_pd(matched, mask);
+
+      simde__m256d res = simde_mm256_set1_pd(-SIMDE_MATH_INFINITY);
+
+      retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+    }
+
+    { /* else if (a == 1) */
+      simde__m256d mask = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_pd(matched, mask);
+      matched = simde_mm256_or_pd(matched, mask);
+
+      simde__m256d res = simde_mm256_set1_pd(SIMDE_MATH_INFINITY);
+
+      retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+    }
+
+    { /* Remaining conditions.
+       *
+       * Including the else case in this complicates things a lot, but
+       * we're using cheap operations to get rid of expensive multiply
+       * and add functions.  This should be a small improvement on SSE
+       * prior to 4.1.  On SSE 4.1 we can use _mm256_blendv_pd which is
+       * very fast and this becomes a huge win.  NEON, AltiVec, and
+       * WASM also have blend operations, so this should be a big win
+       * there, too. */
+
+      /* else if (a < 0.02425) */
+      simde__m256d mask_lo = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.02425)), SIMDE_CMP_LT_OQ);
+      /* else if (a > 0.97575) */
+      simde__m256d mask_hi = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.97575)), SIMDE_CMP_GT_OQ);
+
+      simde__m256d mask = simde_mm256_or_pd(mask_lo, mask_hi);
+      matched = simde_mm256_or_pd(matched, mask);
+
+      /* else */
+      simde__m256d mask_el = simde_x_mm256_not_pd(matched);
+      mask = simde_mm256_or_pd(mask, mask_el);
+
+      /* r = a - 0.5 */
+      simde__m256d r = simde_mm256_sub_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m256d q = simde_mm256_and_pd(mask_lo, a);
+      q = simde_mm256_or_pd(q, simde_mm256_and_pd(mask_hi, simde_mm256_sub_pd(simde_mm256_set1_pd(1.0), a)));
+
+      /* q = simde_math_sqrt(-2.0 * simde_math_log(q)) */
+      q = simde_mm256_log_pd(q);
+      q = simde_mm256_mul_pd(q, simde_mm256_set1_pd(SIMDE_FLOAT64_C(-2.0)));
+      q = simde_mm256_sqrt_pd(q);
+
+      /* el: q = r * r */
+      q = simde_x_mm256_select_pd(q, simde_mm256_mul_pd(r, r), mask_el);
+
+      /* lo: double numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0); */
+      /* hi: double numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0); */
+      /* el: double numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m256d numerator = simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(-7.784894002430293e-03)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-3.969683028665376e+01)), mask_el);
+      numerator = simde_mm256_fmadd_pd(numerator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(-3.223964580411365e-01)), simde_mm256_set1_pd(SIMDE_FLOAT64_C( 2.209460984245205e+02)), mask_el));
+      numerator = simde_mm256_fmadd_pd(numerator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(-2.400758277161838e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-2.759285104469687e+02)), mask_el));
+      numerator = simde_mm256_fmadd_pd(numerator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(-2.549732539343734e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.383577518672690e+02)), mask_el));
+      numerator = simde_mm256_fmadd_pd(numerator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 4.374664141464968e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-3.066479806614716e+01)), mask_el));
+      numerator = simde_mm256_fmadd_pd(numerator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 2.938163982698783e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C( 2.506628277459239e+00)), mask_el));
+      {
+        simde__m256d multiplier;
+        multiplier =                            simde_mm256_and_pd(mask_lo, simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.0)));
+        multiplier = simde_mm256_or_pd(multiplier, simde_mm256_and_pd(mask_hi, simde_mm256_set1_pd(SIMDE_FLOAT64_C(-1.0))));
+        multiplier = simde_mm256_or_pd(multiplier, simde_mm256_and_pd(mask_el, r));
+        numerator = simde_mm256_mul_pd(numerator, multiplier);
+      }
+
+      /* lo/hi: double denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: double denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m256d denominator = simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 7.784695709041462e-03)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-5.447609879822406e+01)), mask_el);
+      denominator = simde_mm256_fmadd_pd(denominator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 3.224671290700398e-01)), simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.615858368580409e+02)), mask_el));
+      denominator = simde_mm256_fmadd_pd(denominator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 2.445134137142996e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-1.556989798598866e+02)), mask_el));
+      denominator = simde_mm256_fmadd_pd(denominator, q, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 3.754408661907416e+00)), simde_mm256_set1_pd(SIMDE_FLOAT64_C( 6.680131188771972e+01)), mask_el));
+      denominator = simde_mm256_fmadd_pd(denominator, simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.0)), q, mask_el),
+                                                   simde_x_mm256_select_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.0)), simde_mm256_set1_pd(SIMDE_FLOAT64_C(-1.328068155288572e+01)), mask_el));
+      denominator = simde_mm256_fmadd_pd(denominator, q, simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)));
+
+      /* res = numerator / denominator; */
+      simde__m256d res = simde_mm256_div_pd(numerator, denominator);
+
+      retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+    }
+
+    return retval;
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_cdfnorminv_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_cdfnorminv(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_cdfnorminv_pd
+  #define _mm256_cdfnorminv_pd(a) simde_mm256_cdfnorminv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_cdfnorminv_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cdfnorminv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+      r_.m256[i] = simde_mm256_cdfnorminv_ps(a_.m256[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #else
+
+    simde__m512 retval = simde_mm512_setzero_ps();
+    simde__mmask16 matched;
+
+    { /* if (a < 0 || a > 1) */
+      matched  = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_LT_OQ);
+      matched |= simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), SIMDE_CMP_GT_OQ);
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__mmask16 mask = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_EQ_OQ);
+      matched |= mask;
+
+      retval = simde_mm512_mask_mov_ps(retval, mask, simde_mm512_set1_ps(-SIMDE_MATH_INFINITYF));
+    }
+
+    { /* else if (a == 1) */
+      simde__mmask16 mask = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_EQ_OQ);
+      matched |= mask;
+
+      retval = simde_mm512_mask_mov_ps(retval, mask, simde_mm512_set1_ps(SIMDE_MATH_INFINITYF));
+    }
+
+    { /* else if (a < 0.02425) */
+      simde__mmask16 mask_lo = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.02425)), SIMDE_CMP_LT_OQ);
+      /* else if (a > 0.97575) */
+      simde__mmask16 mask_hi = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.97575)), SIMDE_CMP_GT_OQ);
+
+      simde__mmask16 mask = mask_lo | mask_hi;
+      matched = matched | mask;
+
+      /* else */
+      simde__mmask16 mask_el = ~matched;
+      mask = mask | mask_el;
+
+      /* r = a - 0.5f */
+      simde__m512 r = simde_mm512_sub_ps(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m512 q = simde_mm512_maskz_mov_ps(mask_lo, a);
+      q = simde_mm512_mask_sub_ps(q, mask_hi, simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), a);
+
+      /* q = simde_math_sqrtf(-2.0f * simde_math_logf(q)) */
+      q = simde_mm512_log_ps(q);
+      q = simde_mm512_mul_ps(q, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-2.0)));
+      q = simde_mm512_sqrt_ps(q);
+
+      /* el: q = r * r */
+      q = simde_mm512_mask_mul_ps(q, mask_el, r, r);
+
+      /* lo: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0f); */
+      /* hi: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0f); */
+      /* el: float numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m512 numerator = simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(-7.784894002430293e-03)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-3.969683028665376e+01)));
+      numerator = simde_mm512_fmadd_ps(numerator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(-3.223964580411365e-01)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C( 2.209460984245205e+02))));
+      numerator = simde_mm512_fmadd_ps(numerator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(-2.400758277161838e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-2.759285104469687e+02))));
+      numerator = simde_mm512_fmadd_ps(numerator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(-2.549732539343734e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.383577518672690e+02))));
+      numerator = simde_mm512_fmadd_ps(numerator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 4.374664141464968e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-3.066479806614716e+01))));
+      numerator = simde_mm512_fmadd_ps(numerator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 2.938163982698783e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C( 2.506628277459239e+00))));
+      {
+        simde__m512 multiplier;
+        multiplier =                                              simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.0));
+        multiplier = simde_mm512_mask_mov_ps(multiplier, mask_hi, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-1.0)));
+        multiplier = simde_mm512_mask_mov_ps(multiplier, mask_el, r);
+        numerator = simde_mm512_mul_ps(numerator, multiplier);
+      }
+
+      /* lo/hi: float denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: float denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m512 denominator = simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 7.784695709041462e-03)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-5.447609879822406e+01)));
+      denominator = simde_mm512_fmadd_ps(denominator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 3.224671290700398e-01)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.615858368580409e+02))));
+      denominator = simde_mm512_fmadd_ps(denominator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 2.445134137142996e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-1.556989798598866e+02))));
+      denominator = simde_mm512_fmadd_ps(denominator, q, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 3.754408661907416e+00)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C( 6.680131188771972e+01))));
+      denominator = simde_mm512_fmadd_ps(denominator, simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.0)), mask_el, q),
+                                                      simde_mm512_mask_mov_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.0)), mask_el, simde_mm512_set1_ps(SIMDE_FLOAT32_C(-1.328068155288572e+01))));
+      denominator = simde_mm512_fmadd_ps(denominator, q, simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)));
+
+      /* res = numerator / denominator; */
+      retval = simde_mm512_mask_div_ps(retval, mask_lo | mask_hi | mask_el, numerator, denominator);
+    }
+
+    return retval;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cdfnorminv_ps
+  #define _mm512_cdfnorminv_ps(a) simde_mm512_cdfnorminv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_cdfnorminv_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_cdfnorminv_pd(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+      r_.m256d[i] = simde_mm256_cdfnorminv_pd(a_.m256d[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #else
+
+    simde__m512d retval = simde_mm512_setzero_pd();
+    simde__mmask8 matched;
+
+    { /* if (a < 0 || a > 1) */
+      matched  = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_LT_OQ);
+      matched |= simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), SIMDE_CMP_GT_OQ);
+
+      /* We don't actually need to do anything here since we initialize
+       * retval to 0.0. */
+    }
+
+    { /* else if (a == 0) */
+      simde__mmask8 mask = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_EQ_OQ);
+      matched |= mask;
+
+      retval = simde_mm512_mask_mov_pd(retval, mask, simde_mm512_set1_pd(-SIMDE_MATH_INFINITY));
+    }
+
+    { /* else if (a == 1) */
+      simde__mmask8 mask = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_EQ_OQ);
+      matched |= mask;
+
+      retval = simde_mm512_mask_mov_pd(retval, mask, simde_mm512_set1_pd(SIMDE_MATH_INFINITY));
+    }
+
+    { /* else if (a < 0.02425) */
+      simde__mmask8 mask_lo = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.02425)), SIMDE_CMP_LT_OQ);
+      /* else if (a > 0.97575) */
+      simde__mmask8 mask_hi = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.97575)), SIMDE_CMP_GT_OQ);
+
+      simde__mmask8 mask = mask_lo | mask_hi;
+      matched = matched | mask;
+
+      /* else */
+      simde__mmask8 mask_el = ~matched;
+      mask = mask | mask_el;
+
+      /* r = a - 0.5f */
+      simde__m512d r = simde_mm512_sub_pd(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.5)));
+
+      /* lo: q = a
+       * hi: q = (1.0 - a) */
+      simde__m512d q = a;
+      q = simde_mm512_mask_sub_pd(q, mask_hi, simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), a);
+
+      /* q = simde_math_sqrtf(-2.0f * simde_math_logf(q)) */
+      q = simde_mm512_log_pd(q);
+      q = simde_mm512_mul_pd(q, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-2.0)));
+      q = simde_mm512_sqrt_pd(q);
+
+      /* el: q = r * r */
+      q = simde_mm512_mask_mul_pd(q, mask_el, r, r);
+
+      /* lo: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) *  1.0f); */
+      /* hi: float numerator = ((((((c_c[0] * q + c_c[1]) * q + c_c[2]) * q + c_c[3]) * q + c_c[4]) * q + c_c[5]) * -1.0f); */
+      /* el: float numerator = ((((((c_a[0] * q + c_a[1]) * q + c_a[2]) * q + c_a[3]) * q + c_a[4]) * q + c_a[5]) *  r); */
+      simde__m512d numerator = simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(-7.784894002430293e-03)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-3.969683028665376e+01)));
+      numerator = simde_mm512_fmadd_pd(numerator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(-3.223964580411365e-01)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C( 2.209460984245205e+02))));
+      numerator = simde_mm512_fmadd_pd(numerator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(-2.400758277161838e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-2.759285104469687e+02))));
+      numerator = simde_mm512_fmadd_pd(numerator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(-2.549732539343734e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.383577518672690e+02))));
+      numerator = simde_mm512_fmadd_pd(numerator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 4.374664141464968e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-3.066479806614716e+01))));
+      numerator = simde_mm512_fmadd_pd(numerator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 2.938163982698783e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C( 2.506628277459239e+00))));
+      {
+        simde__m512d multiplier;
+        multiplier =                                              simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.0));
+        multiplier = simde_mm512_mask_mov_pd(multiplier, mask_hi, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-1.0)));
+        multiplier = simde_mm512_mask_mov_pd(multiplier, mask_el, r);
+        numerator = simde_mm512_mul_pd(numerator, multiplier);
+      }
+
+      /* lo/hi: float denominator = (((((c_d[0] * q + c_d[1]) * q + c_d[2]) * q + c_d[3]) * 1 +   0.0f) * q + 1); */
+      /*    el: float denominator = (((((c_b[0] * q + c_b[1]) * q + c_b[2]) * q + c_b[3]) * q + c_b[4]) * q + 1); */
+      simde__m512d denominator = simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 7.784695709041462e-03)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-5.447609879822406e+01)));
+      denominator = simde_mm512_fmadd_pd(denominator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 3.224671290700398e-01)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.615858368580409e+02))));
+      denominator = simde_mm512_fmadd_pd(denominator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 2.445134137142996e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-1.556989798598866e+02))));
+      denominator = simde_mm512_fmadd_pd(denominator, q, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 3.754408661907416e+00)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C( 6.680131188771972e+01))));
+      denominator = simde_mm512_fmadd_pd(denominator, simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.0)), mask_el, q),
+                                                      simde_mm512_mask_mov_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.0)), mask_el, simde_mm512_set1_pd(SIMDE_FLOAT64_C(-1.328068155288572e+01))));
+      denominator = simde_mm512_fmadd_pd(denominator, q, simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)));
+
+      /* res = numerator / denominator; */
+      retval = simde_mm512_mask_div_pd(retval, mask_lo | mask_hi | mask_el, numerator, denominator);
+    }
+
+    return retval;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_cdfnorminv_pd
+  #define _mm512_cdfnorminv_pd(a) simde_mm512_cdfnorminv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_cdfnorminv_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cdfnorminv_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_cdfnorminv_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cdfnorminv_ps
+  #define _mm512_mask_cdfnorminv_ps(src, k, a) simde_mm512_mask_cdfnorminv_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_cdfnorminv_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_cdfnorminv_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_cdfnorminv_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_cdfnorminv_pd
+  #define _mm512_mask_cdfnorminv_pd(src, k, a) simde_mm512_mask_cdfnorminv_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_erfinv_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfinv_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    /* https://stackoverflow.com/questions/27229371/inverse-error-function-in-c */
+    simde__m128 one = simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0));
+
+    simde__m128 lnx = simde_mm_log_ps(simde_mm_mul_ps(simde_mm_sub_ps(one, a), simde_mm_add_ps(one, a)));
+
+    simde__m128 tt1 = simde_mm_mul_ps(simde_mm_set1_ps(HEDLEY_STATIC_CAST(simde_float32, SIMDE_MATH_PI)), simde_mm_set1_ps(SIMDE_FLOAT32_C(0.147)));
+    tt1 = simde_mm_div_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(2.0)), tt1);
+    tt1 = simde_mm_add_ps(tt1, simde_mm_mul_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(0.5)), lnx));
+
+    simde__m128 tt2 = simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0) / SIMDE_FLOAT32_C(0.147));
+    tt2 = simde_mm_mul_ps(tt2, lnx);
+
+    simde__m128 r = simde_mm_mul_ps(tt1, tt1);
+    r = simde_mm_sub_ps(r, tt2);
+    r = simde_mm_sqrt_ps(r);
+    r = simde_mm_add_ps(simde_x_mm_negate_ps(tt1), r);
+    r = simde_mm_sqrt_ps(r);
+
+    return simde_x_mm_xorsign_ps(r, a);
+  #else
+    simde__m128_private
+      a_ = simde__m128_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erfinvf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfinv_ps
+  #define _mm_erfinv_ps(a) simde_mm_erfinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_erfinv_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfinv_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m128d one = simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0));
+
+    simde__m128d lnx = simde_mm_log_pd(simde_mm_mul_pd(simde_mm_sub_pd(one, a), simde_mm_add_pd(one, a)));
+
+    simde__m128d tt1 = simde_mm_mul_pd(simde_mm_set1_pd(SIMDE_MATH_PI), simde_mm_set1_pd(SIMDE_FLOAT64_C(0.147)));
+    tt1 = simde_mm_div_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(2.0)), tt1);
+    tt1 = simde_mm_add_pd(tt1, simde_mm_mul_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(0.5)), lnx));
+
+    simde__m128d tt2 = simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0) / SIMDE_FLOAT64_C(0.147));
+    tt2 = simde_mm_mul_pd(tt2, lnx);
+
+    simde__m128d r = simde_mm_mul_pd(tt1, tt1);
+    r = simde_mm_sub_pd(r, tt2);
+    r = simde_mm_sqrt_pd(r);
+    r = simde_mm_add_pd(simde_x_mm_negate_pd(tt1), r);
+    r = simde_mm_sqrt_pd(r);
+
+    return simde_x_mm_xorsign_pd(r, a);
+  #else
+    simde__m128d_private
+      a_ = simde__m128d_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erfinv(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfinv_pd
+  #define _mm_erfinv_pd(a) simde_mm_erfinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_erfinv_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfinv_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m256 one = simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0));
+    simde__m256 sgn = simde_x_mm256_copysign_ps(one, a);
+
+    a = simde_mm256_mul_ps(simde_mm256_sub_ps(one, a), simde_mm256_add_ps(one, a));
+    simde__m256 lnx = simde_mm256_log_ps(a);
+
+    simde__m256 tt1 = simde_mm256_mul_ps(simde_mm256_set1_ps(HEDLEY_STATIC_CAST(simde_float32, SIMDE_MATH_PI)), simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.147)));
+    tt1 = simde_mm256_div_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(2.0)), tt1);
+    tt1 = simde_mm256_add_ps(tt1, simde_mm256_mul_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.5)), lnx));
+
+    simde__m256 tt2 = simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0) / SIMDE_FLOAT32_C(0.147));
+    tt2 = simde_mm256_mul_ps(tt2, lnx);
+
+    simde__m256 r = simde_mm256_mul_ps(tt1, tt1);
+    r = simde_mm256_sub_ps(r, tt2);
+    r = simde_mm256_sqrt_ps(r);
+    r = simde_mm256_add_ps(simde_x_mm256_negate_ps(tt1), r);
+    r = simde_mm256_sqrt_ps(r);
+
+    return simde_mm256_mul_ps(sgn, r);
+  #else
+    simde__m256_private
+      a_ = simde__m256_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erfinvf(a_.f32[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfinv_ps
+  #define _mm256_erfinv_ps(a) simde_mm256_erfinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_erfinv_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfinv_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m256d one = simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0));
+    simde__m256d sgn = simde_x_mm256_copysign_pd(one, a);
+
+    a = simde_mm256_mul_pd(simde_mm256_sub_pd(one, a), simde_mm256_add_pd(one, a));
+    simde__m256d lnx = simde_mm256_log_pd(a);
+
+    simde__m256d tt1 = simde_mm256_mul_pd(simde_mm256_set1_pd(SIMDE_MATH_PI), simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.147)));
+    tt1 = simde_mm256_div_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(2.0)), tt1);
+    tt1 = simde_mm256_add_pd(tt1, simde_mm256_mul_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.5)), lnx));
+
+    simde__m256d tt2 = simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0) / SIMDE_FLOAT64_C(0.147));
+    tt2 = simde_mm256_mul_pd(tt2, lnx);
+
+    simde__m256d r = simde_mm256_mul_pd(tt1, tt1);
+    r = simde_mm256_sub_pd(r, tt2);
+    r = simde_mm256_sqrt_pd(r);
+    r = simde_mm256_add_pd(simde_x_mm256_negate_pd(tt1), r);
+    r = simde_mm256_sqrt_pd(r);
+
+    return simde_mm256_mul_pd(sgn, r);
+  #else
+    simde__m256d_private
+      a_ = simde__m256d_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erfinv(a_.f64[i]);
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfinv_pd
+  #define _mm256_erfinv_pd(a) simde_mm256_erfinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_erfinv_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfinv_ps(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m512 one = simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0));
+    simde__m512 sgn = simde_x_mm512_copysign_ps(one, a);
+
+    a = simde_mm512_mul_ps(simde_mm512_sub_ps(one, a), simde_mm512_add_ps(one, a));
+    simde__m512 lnx = simde_mm512_log_ps(a);
+
+    simde__m512 tt1 = simde_mm512_mul_ps(simde_mm512_set1_ps(HEDLEY_STATIC_CAST(simde_float32, SIMDE_MATH_PI)), simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.147)));
+    tt1 = simde_mm512_div_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(2.0)), tt1);
+    tt1 = simde_mm512_add_ps(tt1, simde_mm512_mul_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.5)), lnx));
+
+    simde__m512 tt2 = simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0) / SIMDE_FLOAT32_C(0.147));
+    tt2 = simde_mm512_mul_ps(tt2, lnx);
+
+    simde__m512 r = simde_mm512_mul_ps(tt1, tt1);
+    r = simde_mm512_sub_ps(r, tt2);
+    r = simde_mm512_sqrt_ps(r);
+    r = simde_mm512_add_ps(simde_x_mm512_negate_ps(tt1), r);
+    r = simde_mm512_sqrt_ps(r);
+
+    return simde_mm512_mul_ps(sgn, r);
+  #else
+    simde__m512_private
+      a_ = simde__m512_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erfinvf(a_.f32[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfinv_ps
+  #define _mm512_erfinv_ps(a) simde_mm512_erfinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_erfinv_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfinv_pd(a);
+  #elif (SIMDE_NATURAL_VECTOR_SIZE > 0)
+    simde__m512d one = simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0));
+    simde__m512d sgn = simde_x_mm512_copysign_pd(one, a);
+
+    a = simde_mm512_mul_pd(simde_mm512_sub_pd(one, a), simde_mm512_add_pd(one, a));
+    simde__m512d lnx = simde_mm512_log_pd(a);
+
+    simde__m512d tt1 = simde_mm512_mul_pd(simde_mm512_set1_pd(SIMDE_MATH_PI), simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.147)));
+    tt1 = simde_mm512_div_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(2.0)), tt1);
+    tt1 = simde_mm512_add_pd(tt1, simde_mm512_mul_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.5)), lnx));
+
+    simde__m512d tt2 = simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0) / SIMDE_FLOAT64_C(0.147));
+    tt2 = simde_mm512_mul_pd(tt2, lnx);
+
+    simde__m512d r = simde_mm512_mul_pd(tt1, tt1);
+    r = simde_mm512_sub_pd(r, tt2);
+    r = simde_mm512_sqrt_pd(r);
+    r = simde_mm512_add_pd(simde_x_mm512_negate_pd(tt1), r);
+    r = simde_mm512_sqrt_pd(r);
+
+    return simde_mm512_mul_pd(sgn, r);
+  #else
+    simde__m512d_private
+      a_ = simde__m512d_to_private(a),
+      r_;
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erfinv(a_.f64[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfinv_pd
+  #define _mm512_erfinv_pd(a) simde_mm512_erfinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_erfinv_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfinv_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_erfinv_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfinv_ps
+  #define _mm512_mask_erfinv_ps(src, k, a) simde_mm512_mask_erfinv_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_erfinv_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfinv_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_erfinv_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfinv_pd
+  #define _mm512_mask_erfinv_pd(src, k, a) simde_mm512_mask_erfinv_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_erfcinv_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfcinv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    simde__m128 matched, retval = simde_mm_setzero_ps();
+
+    { /* if (a < 2.0f && a > 0.0625f) */
+      matched = simde_mm_cmplt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(2.0)));
+      matched = simde_mm_and_ps(matched, simde_mm_cmpgt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0625))));
+
+      if (!simde_mm_test_all_zeros(simde_mm_castps_si128(matched), simde_x_mm_setone_si128())) {
+        retval = simde_mm_erfinv_ps(simde_mm_sub_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0)), a));
+      }
+
+      if (simde_mm_test_all_ones(simde_mm_castps_si128(matched))) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625f && a > 0.0f) */
+      simde__m128 mask = simde_mm_cmplt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0625)));
+      mask = simde_mm_and_ps(mask, simde_mm_cmpgt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0))));
+      mask = simde_mm_andnot_ps(matched, mask);
+
+      if (!simde_mm_test_all_zeros(simde_mm_castps_si128(mask), simde_x_mm_setone_si128())) {
+        matched = simde_mm_or_ps(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m128 t = simde_x_mm_negate_ps(simde_mm_log_ps(a));
+        t = simde_mm_sqrt_ps(t);
+        t = simde_mm_div_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m128 p[] = {
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.1550470003116)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.382719649631)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.690969348887)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C(-1.128081391617)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.680544246825)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C(-0.164441567910))
+        };
+
+        const simde__m128 q[] = {
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.155024849822)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.385228141995)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m128 numerator = simde_mm_fmadd_ps(p[5], t, p[4]);
+        numerator = simde_mm_fmadd_ps(numerator, t, p[3]);
+        numerator = simde_mm_fmadd_ps(numerator, t, p[2]);
+        numerator = simde_mm_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm_add_ps(numerator, simde_mm_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m128 denominator = simde_mm_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm_fmadd_ps(denominator, t, q[0]);
+
+        simde__m128 res = simde_mm_div_ps(numerator, denominator);
+
+        retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0f) */
+      simde__m128 mask = simde_mm_cmplt_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0)));
+      mask = simde_mm_andnot_ps(matched, mask);
+
+      if (!simde_mm_test_all_zeros(simde_mm_castps_si128(mask), simde_x_mm_setone_si128())) {
+        matched = simde_mm_or_ps(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m128 t = simde_x_mm_negate_ps(simde_mm_log_ps(a));
+        t = simde_mm_sqrt_ps(t);
+        t = simde_mm_div_ps(simde_mm_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m128 p[] = {
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.00980456202915)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.36366788917100)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.97302949837000)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( -0.5374947401000))
+        };
+
+        const simde__m128 q[] = {
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.00980451277802)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 0.36369997154400)),
+          simde_mm_set1_ps(SIMDE_FLOAT32_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m128 numerator = simde_mm_fmadd_ps(p[3], t, p[2]);
+        numerator = simde_mm_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm_add_ps(numerator, simde_mm_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m128 denominator = simde_mm_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm_fmadd_ps(denominator, t, q[0]);
+
+        simde__m128 res = simde_mm_div_ps(numerator, denominator);
+
+        retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+
+        if (simde_mm_test_all_ones(simde_mm_castps_si128(matched))) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0f) */
+      simde__m128 mask = simde_mm_cmpeq_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(0.0)));
+      mask = simde_mm_andnot_ps(matched, mask);
+      matched = simde_mm_or_ps(matched, mask);
+
+      simde__m128 res = simde_mm_set1_ps(SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm_or_ps(retval, simde_mm_and_ps(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0f) */
+      retval = simde_mm_or_ps(retval, simde_mm_andnot_ps(matched, simde_mm_set1_ps(-SIMDE_MATH_INFINITYF)));
+    }
+
+    return retval;
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_erfcinvf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfcinv_ps
+  #define _mm_erfcinv_ps(a) simde_mm_erfcinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_erfcinv_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_erfcinv_pd(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(128)
+    simde__m128d matched, retval = simde_mm_setzero_pd();
+
+    { /* if (a < 2.0 && a > 0.0625) */
+      matched = simde_mm_cmplt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(2.0)));
+      matched = simde_mm_and_pd(matched, simde_mm_cmpgt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0625))));
+
+      if (!simde_mm_test_all_zeros(simde_mm_castpd_si128(matched), simde_x_mm_setone_si128())) {
+        retval = simde_mm_erfinv_pd(simde_mm_sub_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)), a));
+      }
+
+      if (simde_mm_test_all_ones(simde_mm_castpd_si128(matched))) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625 && a > 0.0) */
+      simde__m128d mask = simde_mm_cmplt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0625)));
+      mask = simde_mm_and_pd(mask, simde_mm_cmpgt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0))));
+      mask = simde_mm_andnot_pd(matched, mask);
+
+      if (!simde_mm_test_all_zeros(simde_mm_castpd_si128(mask), simde_x_mm_setone_si128())) {
+        matched = simde_mm_or_pd(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m128d t = simde_x_mm_negate_pd(simde_mm_log_pd(a));
+        t = simde_mm_sqrt_pd(t);
+        t = simde_mm_div_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m128d p[] = {
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.1550470003116)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.382719649631)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.690969348887)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C(-1.128081391617)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.680544246825)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C(-0.164441567910))
+        };
+
+        const simde__m128d q[] = {
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.155024849822)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.385228141995)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m128d numerator = simde_mm_fmadd_pd(p[5], t, p[4]);
+        numerator = simde_mm_fmadd_pd(numerator, t, p[3]);
+        numerator = simde_mm_fmadd_pd(numerator, t, p[2]);
+        numerator = simde_mm_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm_add_pd(numerator, simde_mm_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m128d denominator = simde_mm_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm_fmadd_pd(denominator, t, q[0]);
+
+        simde__m128d res = simde_mm_div_pd(numerator, denominator);
+
+        retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0) */
+      simde__m128d mask = simde_mm_cmplt_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0)));
+      mask = simde_mm_andnot_pd(matched, mask);
+
+      if (!simde_mm_test_all_zeros(simde_mm_castpd_si128(mask), simde_x_mm_setone_si128())) {
+        matched = simde_mm_or_pd(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m128d t = simde_x_mm_negate_pd(simde_mm_log_pd(a));
+        t = simde_mm_sqrt_pd(t);
+        t = simde_mm_div_pd(simde_mm_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m128d p[] = {
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.00980456202915)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.36366788917100)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.97302949837000)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( -0.5374947401000))
+        };
+
+        const simde__m128d q[] = {
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.00980451277802)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 0.36369997154400)),
+          simde_mm_set1_pd(SIMDE_FLOAT64_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m128d numerator = simde_mm_fmadd_pd(p[3], t, p[2]);
+        numerator = simde_mm_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm_add_pd(numerator, simde_mm_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m128d denominator = simde_mm_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm_fmadd_pd(denominator, t, q[0]);
+
+        simde__m128d res = simde_mm_div_pd(numerator, denominator);
+
+        retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+
+        if (simde_mm_test_all_ones(simde_mm_castpd_si128(matched))) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0) */
+      simde__m128d mask = simde_mm_cmpeq_pd(a, simde_mm_set1_pd(SIMDE_FLOAT64_C(0.0)));
+      mask = simde_mm_andnot_pd(matched, mask);
+      matched = simde_mm_or_pd(matched, mask);
+
+      simde__m128d res = simde_mm_set1_pd(SIMDE_MATH_INFINITY);
+
+      retval = simde_mm_or_pd(retval, simde_mm_and_pd(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0) */
+      retval = simde_mm_or_pd(retval, simde_mm_andnot_pd(matched, simde_mm_set1_pd(-SIMDE_MATH_INFINITY)));
+    }
+
+    return retval;
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_erfcinv(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_erfcinv_pd
+  #define _mm_erfcinv_pd(a) simde_mm_erfcinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_erfcinv_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfcinv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    simde__m256 matched, retval = simde_mm256_setzero_ps();
+
+    { /* if (a < 2.0f && a > 0.0625f) */
+      matched = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(2.0)), SIMDE_CMP_LT_OQ);
+      matched = simde_mm256_and_ps(matched, simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0625)), SIMDE_CMP_GT_OQ));
+
+      if (!simde_mm256_testz_ps(matched, matched)) {
+        retval = simde_mm256_erfinv_ps(simde_mm256_sub_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)), a));
+      }
+
+      if (simde_x_mm256_test_all_ones(simde_mm256_castps_si256(matched))) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625f && a > 0.0f) */
+      simde__m256 mask = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0625)), SIMDE_CMP_LT_OQ);
+      mask = simde_mm256_and_ps(mask, simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_GT_OQ));
+      mask = simde_mm256_andnot_ps(matched, mask);
+
+      if (!simde_mm256_testz_ps(mask, mask)) {
+        matched = simde_mm256_or_ps(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m256 t = simde_x_mm256_negate_ps(simde_mm256_log_ps(a));
+        t = simde_mm256_sqrt_ps(t);
+        t = simde_mm256_div_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m256 p[] = {
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.1550470003116)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.382719649631)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.690969348887)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C(-1.128081391617)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.680544246825)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C(-0.16444156791))
+        };
+
+        const simde__m256 q[] = {
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.155024849822)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.385228141995)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m256 numerator = simde_mm256_fmadd_ps(p[5], t, p[4]);
+        numerator = simde_mm256_fmadd_ps(numerator, t, p[3]);
+        numerator = simde_mm256_fmadd_ps(numerator, t, p[2]);
+        numerator = simde_mm256_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm256_add_ps(numerator, simde_mm256_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m256 denominator = simde_mm256_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm256_fmadd_ps(denominator, t, q[0]);
+
+        simde__m256 res = simde_mm256_div_ps(numerator, denominator);
+
+        retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0f) */
+      simde__m256 mask = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_LT_OQ);
+      mask = simde_mm256_andnot_ps(matched, mask);
+
+      if (!simde_mm256_testz_ps(mask, mask)) {
+        matched = simde_mm256_or_ps(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m256 t = simde_x_mm256_negate_ps(simde_mm256_log_ps(a));
+        t = simde_mm256_sqrt_ps(t);
+        t = simde_mm256_div_ps(simde_mm256_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m256 p[] = {
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.00980456202915)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.36366788917100)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.97302949837000)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C(-0.5374947401000))
+        };
+
+        const simde__m256 q[] = {
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.00980451277802)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 0.36369997154400)),
+          simde_mm256_set1_ps(SIMDE_FLOAT32_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m256 numerator = simde_mm256_fmadd_ps(p[3], t, p[2]);
+        numerator = simde_mm256_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm256_add_ps(numerator, simde_mm256_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m256 denominator = simde_mm256_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm256_fmadd_ps(denominator, t, q[0]);
+
+        simde__m256 res = simde_mm256_div_ps(numerator, denominator);
+
+        retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+
+        if (simde_x_mm256_test_all_ones(simde_mm256_castps_si256(matched))) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0f) */
+      simde__m256 mask = simde_mm256_cmp_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_ps(matched, mask);
+      matched = simde_mm256_or_ps(matched, mask);
+
+      simde__m256 res = simde_mm256_set1_ps(SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm256_or_ps(retval, simde_mm256_and_ps(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0f) */
+      retval = simde_mm256_or_ps(retval, simde_mm256_andnot_ps(matched, simde_mm256_set1_ps(-SIMDE_MATH_INFINITYF)));
+    }
+
+    return retval;
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_erfcinv_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_erfcinvf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfcinv_ps
+  #define _mm256_erfcinv_ps(a) simde_mm256_erfcinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_erfcinv_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_erfcinv_pd(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_GE(256)
+    simde__m256d matched, retval = simde_mm256_setzero_pd();
+
+    { /* if (a < 2.0 && a > 0.0625) */
+      matched = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(2.0)), SIMDE_CMP_LT_OQ);
+      matched = simde_mm256_and_pd(matched, simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0625)), SIMDE_CMP_GT_OQ));
+
+      if (!simde_mm256_testz_pd(matched, matched)) {
+        retval = simde_mm256_erfinv_pd(simde_mm256_sub_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), a));
+      }
+
+      if (simde_x_mm256_test_all_ones(simde_mm256_castpd_si256(matched))) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625 && a > 0.0) */
+      simde__m256d mask = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0625)), SIMDE_CMP_LT_OQ);
+      mask = simde_mm256_and_pd(mask, simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_GT_OQ));
+      mask = simde_mm256_andnot_pd(matched, mask);
+
+      if (!simde_mm256_testz_pd(mask, mask)) {
+        matched = simde_mm256_or_pd(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m256d t = simde_x_mm256_negate_pd(simde_mm256_log_pd(a));
+        t = simde_mm256_sqrt_pd(t);
+        t = simde_mm256_div_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m256d p[] = {
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.1550470003116)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.382719649631)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.690969348887)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C(-1.128081391617)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.680544246825)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C(-0.16444156791))
+        };
+
+        const simde__m256d q[] = {
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.155024849822)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.385228141995)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m256d numerator = simde_mm256_fmadd_pd(p[5], t, p[4]);
+        numerator = simde_mm256_fmadd_pd(numerator, t, p[3]);
+        numerator = simde_mm256_fmadd_pd(numerator, t, p[2]);
+        numerator = simde_mm256_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm256_add_pd(numerator, simde_mm256_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m256d denominator = simde_mm256_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm256_fmadd_pd(denominator, t, q[0]);
+
+        simde__m256d res = simde_mm256_div_pd(numerator, denominator);
+
+        retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0) */
+      simde__m256d mask = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_LT_OQ);
+      mask = simde_mm256_andnot_pd(matched, mask);
+
+      if (!simde_mm256_testz_pd(mask, mask)) {
+        matched = simde_mm256_or_pd(matched, mask);
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m256d t = simde_x_mm256_negate_pd(simde_mm256_log_pd(a));
+        t = simde_mm256_sqrt_pd(t);
+        t = simde_mm256_div_pd(simde_mm256_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m256d p[] = {
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.00980456202915)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.36366788917100)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.97302949837000)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C(-0.5374947401000))
+        };
+
+        const simde__m256d q[] = {
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.00980451277802)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 0.36369997154400)),
+          simde_mm256_set1_pd(SIMDE_FLOAT64_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m256d numerator = simde_mm256_fmadd_pd(p[3], t, p[2]);
+        numerator = simde_mm256_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm256_add_pd(numerator, simde_mm256_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m256d denominator = simde_mm256_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm256_fmadd_pd(denominator, t, q[0]);
+
+        simde__m256d res = simde_mm256_div_pd(numerator, denominator);
+
+        retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+
+        if (simde_x_mm256_test_all_ones(simde_mm256_castpd_si256(matched))) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0) */
+      simde__m256d mask = simde_mm256_cmp_pd(a, simde_mm256_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = simde_mm256_andnot_pd(matched, mask);
+      matched = simde_mm256_or_pd(matched, mask);
+
+      simde__m256d res = simde_mm256_set1_pd(SIMDE_MATH_INFINITY);
+
+      retval = simde_mm256_or_pd(retval, simde_mm256_and_pd(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0) */
+      retval = simde_mm256_or_pd(retval, simde_mm256_andnot_pd(matched, simde_mm256_set1_pd(-SIMDE_MATH_INFINITY)));
+    }
+
+    return retval;
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_erfcinv_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_erfcinv(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_erfcinv_pd
+  #define _mm256_erfcinv_pd(a) simde_mm256_erfcinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_erfcinv_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfcinv_ps(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256) && (!defined(SIMDE_ARCH_ARM) || defined(SIMDE_ARCH_AARCH64))
+    /* The results on Arm are *slightly* off, which causes problems for
+     * the edge cases; for example, if you pass 2.0 sqrt will be called
+     * with a value of -0.0 instead of 0.0, resulting in a NaN. */
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+      r_.m256[i] = simde_mm256_erfcinv_ps(a_.m256[i]);
+    }
+    return simde__m512_from_private(r_);
+  #else
+    simde__m512 retval = simde_mm512_setzero_ps();
+    simde__mmask16 matched;
+
+    { /* if (a < 2.0f && a > 0.0625f) */
+      matched =  simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(2.0)), SIMDE_CMP_LT_OQ);
+      matched &= simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0625)), SIMDE_CMP_GT_OQ);
+
+      if (matched != 0) {
+        retval = simde_mm512_erfinv_ps(simde_mm512_sub_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), a));
+      }
+
+      if (matched == 1) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625f && a > 0.0f) */
+      simde__mmask16 mask = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0625)), SIMDE_CMP_LT_OQ);
+      mask &= simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_GT_OQ);
+      mask = ~matched & mask;
+
+      if (mask != 0) {
+        matched = matched | mask;
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m512 t = simde_x_mm512_negate_ps(simde_mm512_log_ps(a));
+        t = simde_mm512_sqrt_ps(t);
+        t = simde_mm512_div_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m512 p[] = {
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.1550470003116)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.382719649631)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.690969348887)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C(-1.128081391617)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.680544246825)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C(-0.16444156791))
+        };
+
+        const simde__m512 q[] = {
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.155024849822)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.385228141995)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m512 numerator = simde_mm512_fmadd_ps(p[5], t, p[4]);
+        numerator = simde_mm512_fmadd_ps(numerator, t, p[3]);
+        numerator = simde_mm512_fmadd_ps(numerator, t, p[2]);
+        numerator = simde_mm512_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm512_add_ps(numerator, simde_mm512_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m512 denominator = simde_mm512_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm512_fmadd_ps(denominator, t, q[0]);
+
+        simde__m512 res = simde_mm512_div_ps(numerator, denominator);
+
+        retval = simde_mm512_or_ps(retval, simde_mm512_maskz_mov_ps(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0f) */
+      simde__mmask16 mask = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_LT_OQ);
+      mask = ~matched & mask;
+
+      if (mask != 0) {
+        matched = matched | mask;
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m512 t = simde_x_mm512_negate_ps(simde_mm512_log_ps(a));
+        t = simde_mm512_sqrt_ps(t);
+        t = simde_mm512_div_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), t);
+
+        const simde__m512 p[] = {
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.00980456202915)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.36366788917100)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.97302949837000)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( -0.5374947401000))
+        };
+
+        const simde__m512 q[] = {
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.00980451277802)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 0.36369997154400)),
+          simde_mm512_set1_ps(SIMDE_FLOAT32_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m512 numerator = simde_mm512_fmadd_ps(p[3], t, p[2]);
+        numerator = simde_mm512_fmadd_ps(numerator, t, p[1]);
+        numerator = simde_mm512_add_ps(numerator, simde_mm512_div_ps(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m512 denominator = simde_mm512_fmadd_ps(q[2], t, q[1]);
+        denominator = simde_mm512_fmadd_ps(denominator, t, q[0]);
+
+        simde__m512 res = simde_mm512_div_ps(numerator, denominator);
+
+        retval = simde_mm512_or_ps(retval, simde_mm512_maskz_mov_ps(mask, res));
+
+        if (matched == 1) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0f) */
+      simde__mmask16 mask = simde_mm512_cmp_ps_mask(a, simde_mm512_set1_ps(SIMDE_FLOAT32_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = ~matched & mask;
+      matched = matched | mask;
+
+      simde__m512 res = simde_mm512_set1_ps(SIMDE_MATH_INFINITYF);
+
+      retval = simde_mm512_or_ps(retval, simde_mm512_maskz_mov_ps(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0f) */
+      retval = simde_mm512_or_ps(retval, simde_mm512_maskz_mov_ps(~matched, simde_mm512_set1_ps(-SIMDE_MATH_INFINITYF)));
+    }
+
+    return retval;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfcinv_ps
+  #define _mm512_erfcinv_ps(a) simde_mm512_erfcinv_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_erfcinv_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_erfcinv_pd(a);
+  #elif SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+      r_.m256d[i] = simde_mm256_erfcinv_pd(a_.m256d[i]);
+    }
+    return simde__m512d_from_private(r_);
+  #else
+    simde__m512d retval = simde_mm512_setzero_pd();
+    simde__mmask8 matched;
+
+    { /* if (a < 2.0f && a > 0.0625f) */
+      matched =  simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(2.0)), SIMDE_CMP_LT_OQ);
+      matched &= simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0625)), SIMDE_CMP_GT_OQ);
+
+      if (matched != 0) {
+        retval = simde_mm512_erfinv_pd(simde_mm512_sub_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), a));
+      }
+
+      if (matched == 1) {
+        return retval;
+      }
+    }
+
+    { /* else if (a < 0.0625f && a > 0.0f) */
+      simde__mmask8 mask = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0625)), SIMDE_CMP_LT_OQ);
+      mask &= simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_GT_OQ);
+      mask = ~matched & mask;
+
+      if (mask != 0) {
+        matched = matched | mask;
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m512d t = simde_x_mm512_negate_pd(simde_mm512_log_pd(a));
+        t = simde_mm512_sqrt_pd(t);
+        t = simde_mm512_div_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m512d p[] = {
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.1550470003116)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.382719649631)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.690969348887)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C(-1.128081391617)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.680544246825)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C(-0.16444156791))
+        };
+
+        const simde__m512d q[] = {
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.155024849822)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.385228141995)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.000000000000))
+        };
+
+        /* float numerator = p[0] / t + p[1] + t * (p[2] + t * (p[3] + t * (p[4] + t * p[5])))) */
+        simde__m512d numerator = simde_mm512_fmadd_pd(p[5], t, p[4]);
+        numerator = simde_mm512_fmadd_pd(numerator, t, p[3]);
+        numerator = simde_mm512_fmadd_pd(numerator, t, p[2]);
+        numerator = simde_mm512_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm512_add_pd(numerator, simde_mm512_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m512d denominator = simde_mm512_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm512_fmadd_pd(denominator, t, q[0]);
+
+        simde__m512d res = simde_mm512_div_pd(numerator, denominator);
+
+        retval = simde_mm512_or_pd(retval, simde_mm512_maskz_mov_pd(mask, res));
+      }
+    }
+
+    { /* else if (a < 0.0f) */
+      simde__mmask8 mask = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_LT_OQ);
+      mask = ~matched & mask;
+
+      if (mask != 0) {
+        matched = matched | mask;
+
+        /* t =  1/(sqrt(-log(a))) */
+        simde__m512d t = simde_x_mm512_negate_pd(simde_mm512_log_pd(a));
+        t = simde_mm512_sqrt_pd(t);
+        t = simde_mm512_div_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), t);
+
+        const simde__m512d p[] = {
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.00980456202915)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.36366788917100)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.97302949837000)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( -0.5374947401000))
+        };
+
+        const simde__m512d q[] = {
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.00980451277802)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 0.36369997154400)),
+          simde_mm512_set1_pd(SIMDE_FLOAT64_C( 1.00000000000000))
+        };
+
+        /* float numerator = (p[0] / t + p[1] + t * (p[2] + t * p[3])) */
+        simde__m512d numerator = simde_mm512_fmadd_pd(p[3], t, p[2]);
+        numerator = simde_mm512_fmadd_pd(numerator, t, p[1]);
+        numerator = simde_mm512_add_pd(numerator, simde_mm512_div_pd(p[0], t));
+
+        /* float denominator = (q[0] + t * (q[1] + t * (q[2]))) */
+        simde__m512d denominator = simde_mm512_fmadd_pd(q[2], t, q[1]);
+        denominator = simde_mm512_fmadd_pd(denominator, t, q[0]);
+
+        simde__m512d res = simde_mm512_div_pd(numerator, denominator);
+
+        retval = simde_mm512_or_pd(retval, simde_mm512_maskz_mov_pd(mask, res));
+
+        if (matched == 1) {
+          return retval;
+        }
+      }
+    }
+
+    { /* else if (a == 0.0f) */
+      simde__mmask8 mask = simde_mm512_cmp_pd_mask(a, simde_mm512_set1_pd(SIMDE_FLOAT64_C(0.0)), SIMDE_CMP_EQ_OQ);
+      mask = ~matched & mask;
+      matched = matched | mask;
+
+      simde__m512d res = simde_mm512_set1_pd(SIMDE_MATH_INFINITY);
+
+      retval = simde_mm512_or_pd(retval, simde_mm512_maskz_mov_pd(mask, res));
+    }
+
+    { /* else */
+      /* (a >= 2.0f) */
+      retval = simde_mm512_or_pd(retval, simde_mm512_maskz_mov_pd(~matched, simde_mm512_set1_pd(-SIMDE_MATH_INFINITY)));
+    }
+
+    return retval;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_erfcinv_pd
+  #define _mm512_erfcinv_pd(a) simde_mm512_erfcinv_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_erfcinv_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfcinv_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_erfcinv_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfcinv_ps
+  #define _mm512_mask_erfcinv_ps(src, k, a) simde_mm512_mask_erfcinv_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_erfcinv_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_erfcinv_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_erfcinv_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_erfcinv_pd
+  #define _mm512_mask_erfcinv_pd(src, k, a) simde_mm512_mask_erfcinv_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_logb_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_logb_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_logbf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_logb_ps
+  #define _mm_logb_ps(a) simde_mm_logb_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_logb_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_logb_pd(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_logb(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_logb_pd
+  #define _mm_logb_pd(a) simde_mm_logb_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_logb_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_logb_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_logb_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_logbf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_logb_ps
+  #define _mm256_logb_ps(a) simde_mm256_logb_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_logb_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_logb_pd(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_logb_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_logb(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_logb_pd
+  #define _mm256_logb_pd(a) simde_mm256_logb_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_logb_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_logb_ps(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_logb_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_logbf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_logb_ps
+  #define _mm512_logb_ps(a) simde_mm512_logb_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_logb_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_logb_pd(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_logb_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_logb(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_logb_pd
+  #define _mm512_logb_pd(a) simde_mm512_logb_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_logb_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_logb_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_logb_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_logb_ps
+  #define _mm512_mask_logb_ps(src, k, a) simde_mm512_mask_logb_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_logb_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_logb_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_logb_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_logb_pd
+  #define _mm512_mask_logb_pd(src, k, a) simde_mm512_mask_logb_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_log2_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2f4_u35(a);
+    #else
+      return Sleef_log2f4_u10(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_log2f(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log2_ps
+  #define _mm_log2_ps(a) simde_mm_log2_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_log2_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2d2_u35(a);
+    #else
+      return Sleef_log2d2_u10(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_log2(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log2_pd
+  #define _mm_log2_pd(a) simde_mm_log2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_log2_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2f8_u35(a);
+    #else
+      return Sleef_log2f8_u10(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_log2_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log2f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log2_ps
+  #define _mm256_log2_ps(a) simde_mm256_log2_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_log2_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2d4_u35(a);
+    #else
+      return Sleef_log2d4_u10(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_log2_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log2(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log2_pd
+  #define _mm256_log2_pd(a) simde_mm256_log2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_log2_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log2_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2f16_u35(a);
+    #else
+      return Sleef_log2f16_u10(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_log2_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log2f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log2_ps
+  #define _mm512_log2_ps(a) simde_mm512_log2_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_log2_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log2_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_MATH_SLEEF_VERSION_CHECK(3,4,0) && (SIMDE_ACCURACY_PREFERENCE <= 1)
+      return Sleef_log2d8_u35(a);
+    #else
+      return Sleef_log2d8_u10(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_log2_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log2(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log2_pd
+  #define _mm512_log2_pd(a) simde_mm512_log2_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_log2_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log2_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_log2_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log2_ps
+  #define _mm512_mask_log2_ps(src, k, a) simde_mm512_mask_log2_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_log2_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log2_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_log2_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log2_pd
+  #define _mm512_mask_log2_pd(src, k, a) simde_mm512_mask_log2_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_log1p_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log1p_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_log1pf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_log1pf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log1p_ps
+  #define _mm_log1p_ps(a) simde_mm_log1p_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_log1p_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log1p_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_log1pd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_log1p(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log1p_pd
+  #define _mm_log1p_pd(a) simde_mm_log1p_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_log1p_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log1p_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_log1pf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_log1p_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log1pf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log1p_ps
+  #define _mm256_log1p_ps(a) simde_mm256_log1p_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_log1p_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log1p_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_log1pd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_log1p_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log1p(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log1p_pd
+  #define _mm256_log1p_pd(a) simde_mm256_log1p_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_log1p_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log1p_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_log1pf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_log1p_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log1pf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log1p_ps
+  #define _mm512_log1p_ps(a) simde_mm512_log1p_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_log1p_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log1p_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_log1pd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_log1p_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log1p(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log1p_pd
+  #define _mm512_log1p_pd(a) simde_mm512_log1p_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_log1p_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log1p_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_log1p_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log1p_ps
+  #define _mm512_mask_log1p_ps(src, k, a) simde_mm512_mask_log1p_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_log1p_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log1p_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_log1p_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log1p_pd
+  #define _mm512_mask_log1p_pd(src, k, a) simde_mm512_mask_log1p_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_log10_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_log10f4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_log10f(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log10_ps
+  #define _mm_log10_ps(a) simde_mm_log10_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_log10_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_log10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_log10d2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_log10(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_log10_pd
+  #define _mm_log10_pd(a) simde_mm_log10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_log10_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_log10f8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_log10_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log10f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log10_ps
+  #define _mm256_log10_ps(a) simde_mm256_log10_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_log10_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_log10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_log10d4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_log10_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log10(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_log10_pd
+  #define _mm256_log10_pd(a) simde_mm256_log10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_log10_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log10_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_log10f16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_log10_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_log10f(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log10_ps
+  #define _mm512_log10_ps(a) simde_mm512_log10_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_log10_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_log10_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_log10d8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_log10_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_log10(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_log10_pd
+  #define _mm512_log10_pd(a) simde_mm512_log10_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_log10_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log10_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_log10_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log10_ps
+  #define _mm512_mask_log10_ps(src, k, a) simde_mm512_mask_log10_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_log10_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_log10_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_log10_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_log10_pd
+  #define _mm512_mask_log10_pd(src, k, a) simde_mm512_mask_log10_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_nearbyint_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_nearbyint_ps(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_nearbyintf(a_.f32[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_nearbyint_ps
+  #define _mm512_nearbyint_ps(a) simde_mm512_nearbyint_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_nearbyint_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_nearbyint_pd(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_nearbyint(a_.f64[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_nearbyint_pd
+  #define _mm512_nearbyint_pd(a) simde_mm512_nearbyint_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_nearbyint_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_nearbyint_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_nearbyint_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_nearbyint_ps
+  #define _mm512_mask_nearbyint_ps(src, k, a) simde_mm512_mask_nearbyint_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_nearbyint_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_nearbyint_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_nearbyint_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_nearbyint_pd
+  #define _mm512_mask_nearbyint_pd(src, k, a) simde_mm512_mask_nearbyint_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_pow_ps (simde__m128 a, simde__m128 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_pow_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_powf4_u10(a, b);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a),
+      b_ = simde__m128_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_powf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_pow_ps
+  #define _mm_pow_ps(a, b) simde_mm_pow_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_pow_pd (simde__m128d a, simde__m128d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_pow_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_powd2_u10(a, b);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a),
+      b_ = simde__m128d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_pow(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_pow_pd
+  #define _mm_pow_pd(a, b) simde_mm_pow_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_pow_ps (simde__m256 a, simde__m256 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_pow_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_powf8_u10(a, b);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a),
+      b_ = simde__m256_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_powf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_pow_ps
+  #define _mm256_pow_ps(a, b) simde_mm256_pow_ps(a, b)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_pow_pd (simde__m256d a, simde__m256d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_pow_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_powd4_u10(a, b);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a),
+      b_ = simde__m256d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_pow(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_pow_pd
+  #define _mm256_pow_pd(a, b) simde_mm256_pow_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_pow_ps (simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_pow_ps(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_powf16_u10(a, b);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a),
+      b_ = simde__m512_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_powf(a_.f32[i], b_.f32[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_pow_ps
+  #define _mm512_pow_ps(a, b) simde_mm512_pow_ps(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_pow_pd (simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_pow_pd(a, b);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_powd8_u10(a, b);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a),
+      b_ = simde__m512d_to_private(b);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_pow(a_.f64[i], b_.f64[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_pow_pd
+  #define _mm512_pow_pd(a, b) simde_mm512_pow_pd(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_pow_ps(simde__m512 src, simde__mmask16 k, simde__m512 a, simde__m512 b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_pow_ps(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_pow_ps(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_pow_ps
+  #define _mm512_mask_pow_ps(src, k, a, b) simde_mm512_mask_pow_ps(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_pow_pd(simde__m512d src, simde__mmask8 k, simde__m512d a, simde__m512d b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_pow_pd(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_pow_pd(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_pow_pd
+  #define _mm512_mask_pow_pd(src, k, a, b) simde_mm512_mask_pow_pd(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_clog_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_clog_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    simde__m128_private pow_res_ = simde__m128_to_private(simde_mm_pow_ps(a, simde_mm_set1_ps(SIMDE_FLOAT32_C(2.0))));
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+      r_.f32[  i  ] = simde_math_logf(simde_math_sqrtf(pow_res_.f32[i] + pow_res_.f32[i+1]));
+      r_.f32[i + 1] = simde_math_atan2f(a_.f32[i + 1], a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_clog_ps
+  #define _mm_clog_ps(a) simde_mm_clog_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_clog_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm256_clog_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    simde__m256_private pow_res_ = simde__m256_to_private(simde_mm256_pow_ps(a, simde_mm256_set1_ps(SIMDE_FLOAT32_C(2.0))));
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i += 2) {
+      r_.f32[  i  ] = simde_math_logf(simde_math_sqrtf(pow_res_.f32[i] + pow_res_.f32[i + 1]));
+      r_.f32[i + 1] = simde_math_atan2f(a_.f32[i + 1], a_.f32[i]);
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_clog_ps
+  #define _mm256_clog_ps(a) simde_mm256_clog_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_csqrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_csqrt_ps(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    simde__m128 pow_res= simde_mm_pow_ps(a,simde_mm_set1_ps(SIMDE_FLOAT32_C(2.0)));
+    simde__m128_private pow_res_=simde__m128_to_private(pow_res);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=2) {
+      simde_float32 sign = simde_math_copysignf(SIMDE_FLOAT32_C(1.0), a_.f32[i + 1]);
+      simde_float32 temp = simde_math_sqrtf(pow_res_.f32[i] + pow_res_.f32[i+1]);
+
+      r_.f32[  i  ] =       simde_math_sqrtf(( a_.f32[i] + temp) / SIMDE_FLOAT32_C(2.0));
+      r_.f32[i + 1] = sign * simde_math_sqrtf((-a_.f32[i] + temp) / SIMDE_FLOAT32_C(2.0));
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_csqrt_ps
+  #define _mm_csqrt_ps(a) simde_mm_csqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_csqrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm256_csqrt_ps(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    simde__m256 pow_res= simde_mm256_pow_ps(a,simde_mm256_set1_ps(SIMDE_FLOAT32_C(2.0)));
+    simde__m256_private pow_res_=simde__m256_to_private(pow_res);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i+=2) {
+      simde_float32 sign = simde_math_copysignf(SIMDE_FLOAT32_C(1.0), a_.f32[i + 1]);
+      simde_float32 temp = simde_math_sqrtf(pow_res_.f32[i] + pow_res_.f32[i+1]);
+
+      r_.f32[  i  ] =       simde_math_sqrtf(( a_.f32[i] + temp) / SIMDE_FLOAT32_C(2.0));
+      r_.f32[i + 1] = sign * simde_math_sqrtf((-a_.f32[i] + temp) / SIMDE_FLOAT32_C(2.0));
+    }
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_csqrt_ps
+  #define _mm256_csqrt_ps(a) simde_mm256_csqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epi8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epi8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 % b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] % b_.i8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epi8
+  #define _mm_rem_epi8(a, b) simde_mm_rem_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epi16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epi16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 % b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] % b_.i16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epi16
+  #define _mm_rem_epi16(a, b) simde_mm_rem_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epi32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epi32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 % b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] % b_.i32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_irem_epi32(a, b) simde_mm_rem_epi32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epi32
+  #define _mm_rem_epi32(a, b) simde_mm_rem_epi32(a, b)
+  #undef _mm_irem_epi32
+  #define _mm_irem_epi32(a, b) simde_mm_rem_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epi64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epi64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 % b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] % b_.i64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epi64
+  #define _mm_rem_epi64(a, b) simde_mm_rem_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epu8 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epu8(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 % b_.u8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] % b_.u8[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epu8
+  #define _mm_rem_epu8(a, b) simde_mm_rem_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epu16 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epu16(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 % b_.u16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] % b_.u16[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epu16
+  #define _mm_rem_epu16(a, b) simde_mm_rem_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epu32 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epu32(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 % b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] % b_.u32[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#define simde_mm_urem_epi32(a, b) simde_mm_rem_epu32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epu32
+  #define _mm_rem_epu32(a, b) simde_mm_rem_epu32(a, b)
+  #undef _mm_urem_epi32
+  #define _mm_urem_epi32(a, b) simde_mm_rem_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_rem_epu64 (simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_rem_epu64(a, b);
+  #else
+    simde__m128i_private
+      r_,
+      a_ = simde__m128i_to_private(a),
+      b_ = simde__m128i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 % b_.u64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] % b_.u64[i];
+      }
+    #endif
+
+    return simde__m128i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_rem_epu64
+  #define _mm_rem_epu64(a, b) simde_mm_rem_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epi8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epi8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 % b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] % b_.i8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epi8
+  #define _mm256_rem_epi8(a, b) simde_mm256_rem_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epi16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epi16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 % b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] % b_.i16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epi16
+  #define _mm256_rem_epi16(a, b) simde_mm256_rem_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epi32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epi32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 % b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] % b_.i32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#define simde_mm256_irem_epi32(a, b) simde_mm256_rem_epi32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epi32
+  #define _mm256_rem_epi32(a, b) simde_mm256_rem_epi32(a, b)
+  #undef _mm256_irem_epi32
+  #define _mm256_irem_epi32(a, b) simde_mm256_rem_epi32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epi64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epi64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 % b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] % b_.i64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epi64
+  #define _mm256_rem_epi64(a, b) simde_mm256_rem_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epu8 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epu8(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 % b_.u8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] % b_.u8[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epu8
+  #define _mm256_rem_epu8(a, b) simde_mm256_rem_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epu16 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epu16(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 % b_.u16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] % b_.u16[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epu16
+  #define _mm256_rem_epu16(a, b) simde_mm256_rem_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epu32 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epu32(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 % b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] % b_.u32[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#define simde_mm256_urem_epi32(a, b) simde_mm256_rem_epu32(a, b)
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epu32
+  #define _mm256_rem_epu32(a, b) simde_mm256_rem_epu32(a, b)
+  #undef _mm256_urem_epi32
+  #define _mm256_urem_epi32(a, b) simde_mm256_rem_epu32(a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_rem_epu64 (simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_rem_epu64(a, b);
+  #else
+    simde__m256i_private
+      r_,
+      a_ = simde__m256i_to_private(a),
+      b_ = simde__m256i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 % b_.u64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] % b_.u64[i];
+      }
+    #endif
+
+    return simde__m256i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_rem_epu64
+  #define _mm256_rem_epu64(a, b) simde_mm256_rem_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epi8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epi8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i8 = a_.i8 % b_.i8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i8) / sizeof(r_.i8[0])) ; i++) {
+        r_.i8[i] = a_.i8[i] % b_.i8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epi8
+  #define _mm512_rem_epi8(a, b) simde_mm512_rem_epi8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epi16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epi16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i16 = a_.i16 % b_.i16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i16) / sizeof(r_.i16[0])) ; i++) {
+        r_.i16[i] = a_.i16[i] % b_.i16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epi16
+  #define _mm512_rem_epi16(a, b) simde_mm512_rem_epi16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epi32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epi32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i32 = a_.i32 % b_.i32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i32) / sizeof(r_.i32[0])) ; i++) {
+        r_.i32[i] = a_.i32[i] % b_.i32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epi32
+  #define _mm512_rem_epi32(a, b) simde_mm512_rem_epi32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_rem_epi32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_rem_epi32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_rem_epi32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_rem_epi32
+  #define _mm512_mask_rem_epi32(src, k, a, b) simde_mm512_mask_rem_epi32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epi64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epi64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.i64 = a_.i64 % b_.i64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.i64) / sizeof(r_.i64[0])) ; i++) {
+        r_.i64[i] = a_.i64[i] % b_.i64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epi64
+  #define _mm512_rem_epi64(a, b) simde_mm512_rem_epi64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epu8 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epu8(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u8 = a_.u8 % b_.u8;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u8) / sizeof(r_.u8[0])) ; i++) {
+        r_.u8[i] = a_.u8[i] % b_.u8[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epu8
+  #define _mm512_rem_epu8(a, b) simde_mm512_rem_epu8((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epu16 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epu16(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u16 = a_.u16 % b_.u16;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u16) / sizeof(r_.u16[0])) ; i++) {
+        r_.u16[i] = a_.u16[i] % b_.u16[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epu16
+  #define _mm512_rem_epu16(a, b) simde_mm512_rem_epu16((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epu32 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epu32(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u32 = a_.u32 % b_.u32;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u32) / sizeof(r_.u32[0])) ; i++) {
+        r_.u32[i] = a_.u32[i] % b_.u32[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epu32
+  #define _mm512_rem_epu32(a, b) simde_mm512_rem_epu32((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_mask_rem_epu32(simde__m512i src, simde__mmask16 k, simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_rem_epu32(src, k, a, b);
+  #else
+    return simde_mm512_mask_mov_epi32(src, k, simde_mm512_rem_epu32(a, b));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_rem_epu32
+  #define _mm512_mask_rem_epu32(src, k, a, b) simde_mm512_mask_rem_epu32(src, k, a, b)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512i
+simde_mm512_rem_epu64 (simde__m512i a, simde__m512i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rem_epu64(a, b);
+  #else
+    simde__m512i_private
+      r_,
+      a_ = simde__m512i_to_private(a),
+      b_ = simde__m512i_to_private(b);
+
+    #if defined(SIMDE_VECTOR_SUBSCRIPT_OPS)
+      r_.u64 = a_.u64 % b_.u64;
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.u64) / sizeof(r_.u64[0])) ; i++) {
+        r_.u64[i] = a_.u64[i] % b_.u64[i];
+      }
+    #endif
+
+    return simde__m512i_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rem_epu64
+  #define _mm512_rem_epu64(a, b) simde_mm512_rem_epu64((a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_recip_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_recip_ps(a);
+  #else
+    return simde_mm512_div_ps(simde_mm512_set1_ps(SIMDE_FLOAT32_C(1.0)), a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_recip_ps
+  #define _mm512_recip_ps(a) simde_mm512_recip_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_recip_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_recip_pd(a);
+  #else
+    return simde_mm512_div_pd(simde_mm512_set1_pd(SIMDE_FLOAT64_C(1.0)), a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_recip_pd
+  #define _mm512_recip_pd(a) simde_mm512_recip_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_recip_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_recip_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_recip_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_recip_ps
+  #define _mm512_mask_recip_ps(src, k, a) simde_mm512_mask_recip_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_recip_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_recip_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_recip_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_recip_pd
+  #define _mm512_mask_recip_pd(src, k, a) simde_mm512_mask_recip_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_rint_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rint_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_rintf16(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_rintf(a_.f32[i]);
+    }
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rint_ps
+  #define _mm512_rint_ps(a) simde_mm512_rint_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_rint_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_rint_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_rintd8(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_rint(a_.f64[i]);
+    }
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_rint_pd
+  #define _mm512_rint_pd(a) simde_mm512_rint_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_rint_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_rint_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_rint_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_rint_ps
+  #define _mm512_mask_rint_ps(src, k, a) simde_mm512_mask_rint_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_rint_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_rint_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_rint_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_rint_pd
+  #define _mm512_mask_rint_pd(src, k, a) simde_mm512_mask_rint_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sin_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf4_u10(a);
+    #else
+      return Sleef_sinf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_sinf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sin_ps
+  #define _mm_sin_ps(a) simde_mm_sin_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sin_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind2_u10(a);
+    #else
+      return Sleef_sind2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_sin(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sin_pd
+  #define _mm_sin_pd(a) simde_mm_sin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sin_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf8_u10(a);
+    #else
+      return Sleef_sinf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_sin_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sin_ps
+  #define _mm256_sin_ps(a) simde_mm256_sin_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sin_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind4_u10(a);
+    #else
+      return Sleef_sind4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_sin_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sin(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sin_pd
+  #define _mm256_sin_pd(a) simde_mm256_sin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sin_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sin_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf16_u10(a);
+    #else
+      return Sleef_sinf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_sin_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sin_ps
+  #define _mm512_sin_ps(a) simde_mm512_sin_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sin_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sin_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind8_u10(a);
+    #else
+      return Sleef_sind8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_sin_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sin(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sin_pd
+  #define _mm512_sin_pd(a) simde_mm512_sin_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sin_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sin_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_sin_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sin_ps
+  #define _mm512_mask_sin_ps(src, k, a) simde_mm512_mask_sin_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sin_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sin_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_sin_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sin_pd
+  #define _mm512_mask_sin_pd(src, k, a) simde_mm512_mask_sin_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sincos_ps (simde__m128* mem_addr, simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sincos_ps(HEDLEY_REINTERPRET_CAST(__m128*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    Sleef___m128_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosf4_u10(a);
+    #else
+      temp = Sleef_sincosf4_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m128 r;
+
+    r = simde_mm_sin_ps(a);
+    *mem_addr = simde_mm_cos_ps(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sincos_ps
+  #define _mm_sincos_ps(mem_addr, a) simde_mm_sincos_ps((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sincos_pd (simde__m128d* mem_addr, simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sincos_pd(HEDLEY_REINTERPRET_CAST(__m128d*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    Sleef___m128d_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosd2_u10(a);
+    #else
+      temp = Sleef_sincosd2_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m128d r;
+
+    r = simde_mm_sin_pd(a);
+    *mem_addr = simde_mm_cos_pd(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sincos_pd
+  #define _mm_sincos_pd(mem_addr, a) simde_mm_sincos_pd((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sincos_ps (simde__m256* mem_addr, simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sincos_ps(HEDLEY_REINTERPRET_CAST(__m256*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    Sleef___m256_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosf8_u10(a);
+    #else
+      temp = Sleef_sincosf8_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m256 r;
+
+    r = simde_mm256_sin_ps(a);
+    *mem_addr = simde_mm256_cos_ps(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sincos_ps
+  #define _mm256_sincos_ps(mem_addr, a) simde_mm256_sincos_ps((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sincos_pd (simde__m256d* mem_addr, simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sincos_pd(HEDLEY_REINTERPRET_CAST(__m256d*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    Sleef___m256d_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosd4_u10(a);
+    #else
+      temp = Sleef_sincosd4_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m256d r;
+
+    r = simde_mm256_sin_pd(a);
+    *mem_addr = simde_mm256_cos_pd(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sincos_pd
+  #define _mm256_sincos_pd(mem_addr, a) simde_mm256_sincos_pd((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sincos_ps (simde__m512* mem_addr, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sincos_ps(HEDLEY_REINTERPRET_CAST(__m512*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    Sleef___m512_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosf16_u10(a);
+    #else
+      temp = Sleef_sincosf16_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m512 r;
+
+    r = simde_mm512_sin_ps(a);
+    *mem_addr = simde_mm512_cos_ps(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sincos_ps
+  #define _mm512_sincos_ps(mem_addr, a) simde_mm512_sincos_ps((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sincos_pd (simde__m512d* mem_addr, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sincos_pd(HEDLEY_REINTERPRET_CAST(__m512d*, mem_addr), a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    Sleef___m512d_2 temp;
+
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      temp = Sleef_sincosd8_u10(a);
+    #else
+      temp = Sleef_sincosd8_u35(a);
+    #endif
+
+    *mem_addr = temp.y;
+    return temp.x;
+  #else
+    simde__m512d r;
+
+    r = simde_mm512_sin_pd(a);
+    *mem_addr = simde_mm512_cos_pd(a);
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sincos_pd
+  #define _mm512_sincos_pd(mem_addr, a) simde_mm512_sincos_pd((mem_addr),(a))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sincos_ps(simde__m512* mem_addr, simde__m512 sin_src, simde__m512 cos_src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sincos_ps(mem_addr, sin_src, cos_src, k, a);
+  #else
+    simde__m512 cos_res, sin_res;
+    sin_res = simde_mm512_sincos_ps(&cos_res, a);
+    *mem_addr = simde_mm512_mask_mov_ps(cos_src, k, cos_res);
+    return simde_mm512_mask_mov_ps(sin_src, k, sin_res);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sincos_ps
+  #define _mm512_mask_sincos_ps(mem_addr, sin_src, cos_src, k, a) simde_mm512_mask_sincos_ps(mem_addr, sin_src, cos_src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sincos_pd(simde__m512d* mem_addr, simde__m512d sin_src, simde__m512d cos_src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sincos_pd(mem_addr, sin_src, cos_src, k, a);
+  #else
+    simde__m512d cos_res, sin_res;
+    sin_res = simde_mm512_sincos_pd(&cos_res, a);
+    *mem_addr = simde_mm512_mask_mov_pd(cos_src, k, cos_res);
+    return simde_mm512_mask_mov_pd(sin_src, k, sin_res);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sincos_pd
+  #define _mm512_mask_sincos_pd(mem_addr, sin_src, cos_src, k, a) simde_mm512_mask_sincos_pd(mem_addr, sin_src, cos_src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sind_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sind_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf4_u10(simde_x_mm_deg2rad_ps(a));
+    #else
+      return Sleef_sinf4_u35(simde_x_mm_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_sinf(simde_math_deg2radf(a_.f32[i]));
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sind_ps
+  #define _mm_sind_ps(a) simde_mm_sind_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sind_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sind_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind2_u10(simde_x_mm_deg2rad_pd(a));
+    #else
+      return Sleef_sind2_u35(simde_x_mm_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_sin(simde_math_deg2rad(a_.f64[i]));
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sind_pd
+  #define _mm_sind_pd(a) simde_mm_sind_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sind_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sind_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf8_u10(simde_x_mm256_deg2rad_ps(a));
+    #else
+      return Sleef_sinf8_u35(simde_x_mm256_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_sind_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sind_ps
+  #define _mm256_sind_ps(a) simde_mm256_sind_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sind_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sind_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind4_u10(simde_x_mm256_deg2rad_pd(a));
+    #else
+      return Sleef_sind4_u35(simde_x_mm256_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_sind_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sin(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sind_pd
+  #define _mm256_sind_pd(a) simde_mm256_sind_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sind_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sind_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sinf16_u10(simde_x_mm512_deg2rad_ps(a));
+    #else
+      return Sleef_sinf16_u35(simde_x_mm512_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_sind_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sind_ps
+  #define _mm512_sind_ps(a) simde_mm512_sind_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sind_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sind_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_sind8_u10(simde_x_mm512_deg2rad_pd(a));
+    #else
+      return Sleef_sind8_u35(simde_x_mm512_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_sind_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sin(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sind_pd
+  #define _mm512_sind_pd(a) simde_mm512_sind_pd(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sind_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sind_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_sind_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sind_ps
+  #define _mm512_mask_sind_ps(src, k, a) simde_mm512_mask_sind_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sind_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sind_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_sind_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sind_pd
+  #define _mm512_mask_sind_pd(src, k, a) simde_mm512_mask_sind_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_sinh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_sinhf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_sinhf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sinh_ps
+  #define _mm_sinh_ps(a) simde_mm_sinh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_sinh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_sinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_sinhd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_sinh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_sinh_pd
+  #define _mm_sinh_pd(a) simde_mm_sinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_sinh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_sinhf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_sinh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sinh_ps
+  #define _mm256_sinh_ps(a) simde_mm256_sinh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_sinh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_sinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_sinhd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_sinh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sinh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_sinh_pd
+  #define _mm256_sinh_pd(a) simde_mm256_sinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_sinh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sinh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_sinhf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_sinh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_sinhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sinh_ps
+  #define _mm512_sinh_ps(a) simde_mm512_sinh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_sinh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_sinh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_sinhd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_sinh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_sinh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_sinh_pd
+  #define _mm512_sinh_pd(a) simde_mm512_sinh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_sinh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sinh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_sinh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sinh_ps
+  #define _mm512_mask_sinh_ps(src, k, a) simde_mm512_mask_sinh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_sinh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_sinh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_sinh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_sinh_pd
+  #define _mm512_mask_sinh_pd(src, k, a) simde_mm512_mask_sinh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_svml_ceil_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_ceil_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_ceilf4(a);
+  #else
+    return simde_mm_round_ps(a, SIMDE_MM_FROUND_TO_POS_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_ceil_ps
+  #define _mm_svml_ceil_ps(a) simde_mm_svml_ceil_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_svml_ceil_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_ceil_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_ceild2(a);
+  #else
+    return simde_mm_round_pd(a, SIMDE_MM_FROUND_TO_POS_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_ceil_pd
+  #define _mm_svml_ceil_pd(a) simde_mm_svml_ceil_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_svml_ceil_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_ceil_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_ceilf8(a);
+  #else
+    return simde_mm256_round_ps(a, SIMDE_MM_FROUND_TO_POS_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_ceil_ps
+  #define _mm256_svml_ceil_ps(a) simde_mm256_svml_ceil_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_svml_ceil_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_ceil_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_ceild4(a);
+  #else
+    return simde_mm256_round_pd(a, SIMDE_MM_FROUND_TO_POS_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_ceil_pd
+  #define _mm256_svml_ceil_pd(a) simde_mm256_svml_ceil_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_ceil_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_ceil_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_ceilf16(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_ceil_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_ceilf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_ceil_ps
+  #define _mm512_ceil_ps(a) simde_mm512_ceil_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_ceil_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_ceil_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_ceild8(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_ceil_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_ceil(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_ceil_pd
+  #define _mm512_ceil_pd(a) simde_mm512_ceil_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_ceil_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_ceil_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_ceil_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_ceil_ps
+  #define _mm512_mask_ceil_ps(src, k, a) simde_mm512_mask_ceil_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_ceil_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_ceil_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_ceil_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_ceil_pd
+  #define _mm512_mask_ceil_pd(src, k, a) simde_mm512_mask_ceil_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_svml_floor_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_floor_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_floorf4(a);
+  #else
+    return simde_mm_round_ps(a, SIMDE_MM_FROUND_TO_NEG_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_floor_ps
+  #define _mm_svml_floor_ps(a) simde_mm_svml_floor_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_svml_floor_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_floor_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_floord2(a);
+  #else
+    return simde_mm_round_pd(a, SIMDE_MM_FROUND_TO_NEG_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_floor_pd
+  #define _mm_svml_floor_pd(a) simde_mm_svml_floor_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_svml_floor_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_floor_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_floorf8(a);
+  #else
+    return simde_mm256_round_ps(a, SIMDE_MM_FROUND_TO_NEG_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_floor_ps
+  #define _mm256_svml_floor_ps(a) simde_mm256_svml_floor_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_svml_floor_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_floor_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_floord4(a);
+  #else
+    return simde_mm256_round_pd(a, SIMDE_MM_FROUND_TO_NEG_INF);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_floor_pd
+  #define _mm256_svml_floor_pd(a) simde_mm256_svml_floor_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_floor_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_floor_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_floorf16(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_floor_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_floorf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_floor_ps
+  #define _mm512_floor_ps(a) simde_mm512_floor_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_floor_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_floor_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_floord8(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_floor_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_floor(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_floor_pd
+  #define _mm512_floor_pd(a) simde_mm512_floor_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_floor_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_floor_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_floor_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_floor_ps
+  #define _mm512_mask_floor_ps(src, k, a) simde_mm512_mask_floor_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_floor_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_floor_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_floor_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_floor_pd
+  #define _mm512_mask_floor_pd(src, k, a) simde_mm512_mask_floor_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_svml_round_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_round_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_roundf4(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_roundf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_round_ps
+  #define _mm_svml_round_ps(a) simde_mm_svml_round_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_svml_round_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_round_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_roundd2(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_round(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_round_pd
+  #define _mm_svml_round_pd(a) simde_mm_svml_round_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_svml_round_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_round_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_roundf8(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_svml_round_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_roundf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_round_ps
+  #define _mm256_svml_round_ps(a) simde_mm256_svml_round_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_svml_round_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_round_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_roundd4(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_svml_round_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_round(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_round_pd
+  #define _mm256_svml_round_pd(a) simde_mm256_svml_round_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_svml_round_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_svml_round_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_roundd8(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_svml_round_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_round(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_svml_round_pd
+  #define _mm512_svml_round_pd(a) simde_mm512_svml_round_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_svml_round_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_svml_round_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_svml_round_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_svml_round_pd
+  #define _mm512_mask_svml_round_pd(src, k, a) simde_mm512_mask_svml_round_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_svml_sqrt_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_sqrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_sqrtf4(a);
+  #else
+    return simde_mm_sqrt_ps(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_sqrt_ps
+  #define _mm_svml_sqrt_ps(a) simde_mm_svml_sqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_svml_sqrt_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_svml_sqrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_sqrtd2(a);
+  #else
+    return simde_mm_sqrt_pd(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_svml_sqrt_pd
+  #define _mm_svml_sqrt_pd(a) simde_mm_svml_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_svml_sqrt_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_sqrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_sqrtf8(a);
+  #else
+    return simde_mm256_sqrt_ps(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_sqrt_ps
+  #define _mm256_svml_sqrt_ps(a) simde_mm256_svml_sqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_svml_sqrt_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_svml_sqrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_sqrtd4(a);
+  #else
+    return simde_mm256_sqrt_pd(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_svml_sqrt_pd
+  #define _mm256_svml_sqrt_pd(a) simde_mm256_svml_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_svml_sqrt_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_svml_sqrt_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_sqrtf16(a);
+  #else
+    return simde_mm512_sqrt_ps(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_svml_sqrt_ps
+  #define _mm512_svml_sqrt_ps(a) simde_mm512_svml_sqrt_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_svml_sqrt_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_svml_sqrt_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_sqrtd8(a);
+  #else
+    return simde_mm512_sqrt_pd(a);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_svml_sqrt_pd
+  #define _mm512_svml_sqrt_pd(a) simde_mm512_svml_sqrt_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_tan_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf4_u10(a);
+    #else
+      return Sleef_tanf4_u35(a);
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_tanf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tan_ps
+  #define _mm_tan_ps(a) simde_mm_tan_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_tan_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand2_u10(a);
+    #else
+      return Sleef_tand2_u35(a);
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_tan(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tan_pd
+  #define _mm_tan_pd(a) simde_mm_tan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_tan_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf8_u10(a);
+    #else
+      return Sleef_tanf8_u35(a);
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_tan_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tan_ps
+  #define _mm256_tan_ps(a) simde_mm256_tan_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_tan_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand4_u10(a);
+    #else
+      return Sleef_tand4_u35(a);
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_tan_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tan(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tan_pd
+  #define _mm256_tan_pd(a) simde_mm256_tan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_tan_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tan_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf16_u10(a);
+    #else
+      return Sleef_tanf16_u35(a);
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_tan_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tan_ps
+  #define _mm512_tan_ps(a) simde_mm512_tan_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_tan_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tan_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand8_u10(a);
+    #else
+      return Sleef_tand8_u35(a);
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_tan_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tan(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tan_pd
+  #define _mm512_tan_pd(a) simde_mm512_tan_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_tan_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tan_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_tan_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tan_ps
+  #define _mm512_mask_tan_ps(src, k, a) simde_mm512_mask_tan_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_tan_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tan_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_tan_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tan_pd
+  #define _mm512_mask_tan_pd(src, k, a) simde_mm512_mask_tan_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_tand_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tand_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf4_u10(simde_x_mm_deg2rad_ps(a));
+    #else
+      return Sleef_tanf4_u35(simde_x_mm_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_tanf(simde_math_deg2radf(a_.f32[i]));
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tand_ps
+  #define _mm_tand_ps(a) simde_mm_tand_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_tand_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tand_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand2_u10(simde_x_mm_deg2rad_pd(a));
+    #else
+      return Sleef_tand2_u35(simde_x_mm_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_tan(simde_math_deg2rad(a_.f64[i]));
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tand_pd
+  #define _mm_tand_pd(a) simde_mm_tand_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_tand_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tand_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf8_u10(simde_x_mm256_deg2rad_ps(a));
+    #else
+      return Sleef_tanf8_u35(simde_x_mm256_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_tand_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tand_ps
+  #define _mm256_tand_ps(a) simde_mm256_tand_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_tand_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tand_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand4_u10(simde_x_mm256_deg2rad_pd(a));
+    #else
+      return Sleef_tand4_u35(simde_x_mm256_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_tand_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tan(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tand_pd
+  #define _mm256_tand_pd(a) simde_mm256_tand_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_tand_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tand_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tanf16_u10(simde_x_mm512_deg2rad_ps(a));
+    #else
+      return Sleef_tanf16_u35(simde_x_mm512_deg2rad_ps(a));
+    #endif
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_tand_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanf(simde_math_deg2radf(a_.f32[i]));
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tand_ps
+  #define _mm512_tand_ps(a) simde_mm512_tand_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_tand_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tand_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    #if SIMDE_ACCURACY_PREFERENCE > 1
+      return Sleef_tand8_u10(simde_x_mm512_deg2rad_pd(a));
+    #else
+      return Sleef_tand8_u35(simde_x_mm512_deg2rad_pd(a));
+    #endif
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+  #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_tand_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tan(simde_math_deg2rad(a_.f64[i]));
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tand_pd
+  #define _mm512_tand_pd(a) simde_mm512_tand_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_tand_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tand_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_tand_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tand_ps
+  #define _mm512_mask_tand_ps(src, k, a) simde_mm512_mask_tand_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_tand_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tand_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_tand_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tand_pd
+  #define _mm512_mask_tand_pd(src, k, a) simde_mm512_mask_tand_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_tanh_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_tanhf4_u10(a);
+  #else
+    simde__m128_private
+      r_,
+      a_ = simde__m128_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+      r_.f32[i] = simde_math_tanhf(a_.f32[i]);
+    }
+
+    return simde__m128_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tanh_ps
+  #define _mm_tanh_ps(a) simde_mm_tanh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_tanh_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_tanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_tanhd2_u10(a);
+  #else
+    simde__m128d_private
+      r_,
+      a_ = simde__m128d_to_private(a);
+
+    SIMDE_VECTORIZE
+    for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+      r_.f64[i] = simde_math_tanh(a_.f64[i]);
+    }
+
+    return simde__m128d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_tanh_pd
+  #define _mm_tanh_pd(a) simde_mm_tanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_tanh_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_tanhf8_u10(a);
+  #else
+    simde__m256_private
+      r_,
+      a_ = simde__m256_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128) / sizeof(r_.m128[0])) ; i++) {
+        r_.m128[i] = simde_mm_tanh_ps(a_.m128[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m256_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tanh_ps
+  #define _mm256_tanh_ps(a) simde_mm256_tanh_ps(a)
+#endif
+
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_tanh_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_tanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_tanhd4_u10(a);
+  #else
+    simde__m256d_private
+      r_,
+      a_ = simde__m256d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(128)
+      for (size_t i = 0 ; i < (sizeof(r_.m128d) / sizeof(r_.m128d[0])) ; i++) {
+        r_.m128d[i] = simde_mm_tanh_pd(a_.m128d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tanh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m256d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_tanh_pd
+  #define _mm256_tanh_pd(a) simde_mm256_tanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_tanh_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tanh_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_tanhf16_u10(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_tanh_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_tanhf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tanh_ps
+  #define _mm512_tanh_ps(a) simde_mm512_tanh_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_tanh_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_tanh_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+      return Sleef_tanhd8_u10(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_tanh_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_tanh(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_tanh_pd
+  #define _mm512_tanh_pd(a) simde_mm512_tanh_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_tanh_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tanh_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_tanh_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tanh_ps
+  #define _mm512_mask_tanh_ps(src, k, a) simde_mm512_mask_tanh_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_tanh_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_tanh_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_tanh_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_tanh_pd
+  #define _mm512_mask_tanh_pd(src, k, a) simde_mm512_mask_tanh_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128
+simde_mm_trunc_ps (simde__m128 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_trunc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_truncf4(a);
+  #else
+    return simde_mm_round_ps(a, SIMDE_MM_FROUND_TO_ZERO);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_trunc_ps
+  #define _mm_trunc_ps(a) simde_mm_trunc_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128d
+simde_mm_trunc_pd (simde__m128d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE_NATIVE)
+    return _mm_trunc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_SSE_NATIVE)
+      return Sleef_truncd2(a);
+  #else
+    return simde_mm_round_pd(a, SIMDE_MM_FROUND_TO_ZERO);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_trunc_pd
+  #define _mm_trunc_pd(a) simde_mm_trunc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256
+simde_mm256_trunc_ps (simde__m256 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_trunc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_truncf8(a);
+  #else
+    return simde_mm256_round_ps(a, SIMDE_MM_FROUND_TO_ZERO);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_trunc_ps
+  #define _mm256_trunc_ps(a) simde_mm256_trunc_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256d
+simde_mm256_trunc_pd (simde__m256d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_trunc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX_NATIVE)
+      return Sleef_truncd4(a);
+  #else
+    return simde_mm256_round_pd(a, SIMDE_MM_FROUND_TO_ZERO);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_trunc_pd
+  #define _mm256_trunc_pd(a) simde_mm256_trunc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_trunc_ps (simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_trunc_ps(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return Sleef_truncf16(a);
+  #else
+    simde__m512_private
+      r_,
+      a_ = simde__m512_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256) / sizeof(r_.m256[0])) ; i++) {
+        r_.m256[i] = simde_mm256_trunc_ps(a_.m256[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f32) / sizeof(r_.f32[0])) ; i++) {
+        r_.f32[i] = simde_math_truncf(a_.f32[i]);
+      }
+    #endif
+
+    return simde__m512_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_trunc_ps
+  #define _mm512_trunc_ps(a) simde_mm512_trunc_ps(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_trunc_pd (simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_trunc_pd(a);
+  #elif defined(SIMDE_MATH_SLEEF_ENABLE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return Sleef_truncd8(a);
+  #else
+    simde__m512d_private
+      r_,
+      a_ = simde__m512d_to_private(a);
+
+    #if SIMDE_NATURAL_VECTOR_SIZE_LE(256)
+      for (size_t i = 0 ; i < (sizeof(r_.m256d) / sizeof(r_.m256d[0])) ; i++) {
+        r_.m256d[i] = simde_mm256_trunc_pd(a_.m256d[i]);
+      }
+    #else
+      SIMDE_VECTORIZE
+      for (size_t i = 0 ; i < (sizeof(r_.f64) / sizeof(r_.f64[0])) ; i++) {
+        r_.f64[i] = simde_math_trunc(a_.f64[i]);
+      }
+    #endif
+
+    return simde__m512d_from_private(r_);
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_trunc_pd
+  #define _mm512_trunc_pd(a) simde_mm512_trunc_pd(a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512
+simde_mm512_mask_trunc_ps(simde__m512 src, simde__mmask16 k, simde__m512 a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_trunc_ps(src, k, a);
+  #else
+    return simde_mm512_mask_mov_ps(src, k, simde_mm512_trunc_ps(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_trunc_ps
+  #define _mm512_mask_trunc_ps(src, k, a) simde_mm512_mask_trunc_ps(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m512d
+simde_mm512_mask_trunc_pd(simde__m512d src, simde__mmask8 k, simde__m512d a) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX512F_NATIVE)
+    return _mm512_mask_trunc_pd(src, k, a);
+  #else
+    return simde_mm512_mask_mov_pd(src, k, simde_mm512_trunc_pd(a));
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm512_mask_trunc_pd
+  #define _mm512_mask_trunc_pd(src, k, a) simde_mm512_mask_trunc_pd(src, k, a)
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m128i
+simde_mm_udivrem_epi32 (simde__m128i * mem_addr, simde__m128i a, simde__m128i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_SSE2_NATIVE)
+    return _mm_udivrem_epi32(mem_addr, a, b);
+  #else
+    simde__m128i r;
+
+    r = simde_mm_div_epu32(a, b);
+    *mem_addr = simde_x_mm_sub_epu32(a, simde_x_mm_mullo_epu32(r, b));
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm_udivrem_epi32
+  #define _mm_udivrem_epi32(mem_addr, a, b) simde_mm_udivrem_epi32((mem_addr),(a), (b))
+#endif
+
+SIMDE_FUNCTION_ATTRIBUTES
+simde__m256i
+simde_mm256_udivrem_epi32 (simde__m256i* mem_addr, simde__m256i a, simde__m256i b) {
+  #if defined(SIMDE_X86_SVML_NATIVE) && defined(SIMDE_X86_AVX_NATIVE)
+    return _mm256_udivrem_epi32(HEDLEY_REINTERPRET_CAST(__m256i*, mem_addr), a, b);
+  #else
+    simde__m256i r;
+
+    r = simde_mm256_div_epu32(a, b);
+    *mem_addr = simde_x_mm256_sub_epu32(a, simde_x_mm256_mullo_epu32(r, b));
+
+    return r;
+  #endif
+}
+#if defined(SIMDE_X86_SVML_ENABLE_NATIVE_ALIASES)
+  #undef _mm256_udivrem_epi32
+  #define _mm256_udivrem_epi32(mem_addr, a, b) simde_mm256_udivrem_epi32((mem_addr),(a), (b))
+#endif
+
+SIMDE_END_DECLS_
+
+HEDLEY_DIAGNOSTIC_POP
+
+#endif /* !defined(SIMDE_X86_SVML_H) */


### PR DESCRIPTION
We have made some changes to adapt plink to the arm64 platform :
1. Add [simde architecture](https://github.com/simd-everywhere/simde) and modify related code and building scripts.
2. Replace the static link of  ```zstd``` with dynamic link.